### PR TITLE
Remove acquia sdk as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
       }
     ],
     "require": {
-        "acquia/acquia-sdk-php": "0.10.7",
         "blakestein/datalayer": "master",
         "christian-riesen/base32": "^1.3.1",
         "composer/installers": "^1.2",


### PR DESCRIPTION
This PR removes the composer package `acquia/acquia-sdk-php` as a dependency because it is host-specific and not needed.  Incidentally, it was also blocking our local build because of an issue with one of its pear package dependencies (see: https://github.com/acquia/acquia-sdk-php/issues/51)