### PR TITLE
Update release bits from mass to openmass

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@ Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to 
 
 ---
 
-[Peer Review Checklist](https://github.com/massgov/mass/blob/develop/docs/peer_review_checklist.md)
+[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)

--- a/changelogs/DP-15695.yml
+++ b/changelogs/DP-15695.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Changed:
+  - description: Update a few release bits from mass to openmass
+    issue: DP-15695

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -92,7 +92,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
       throw new \Exception('Missing CIRCLECI_PERSONAL_API_TOKEN. See .env.example for more details.');
     }
     $branch = $options['ci-branch'];
-    $uri = "https://circleci.com/api/v1.1/project/github/massgov/mass/tree/$branch?circle-token=" . $token;
+    $uri = "https://circleci.com/api/v1.1/project/github/massgov/openmass/tree/$branch?circle-token=" . $token;
     $response = $client->request('POST', $uri, [
       'headers' => ['Accept' => 'application/json'],
       'form_params' => [

--- a/scripts/build-changelog.php
+++ b/scripts/build-changelog.php
@@ -122,8 +122,8 @@ $data_string = json_encode($data);
 curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');
 curl_setopt($ch, CURLOPT_PASSWORD, $_ENV['GITHUB_MASSGOV_BOT_TOKEN']);
 curl_setopt($ch, CURLOPT_POST, '-X');
-curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/mass/');
-curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/mass/pulls');
+curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/openmass/');
+curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/openmass/pulls');
 curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/json', 'Content-Type: application/json'));
 curl_setopt($ch, CURLOPT_POSTFIELDS, $data_string);
 

--- a/scripts/tag-release-github
+++ b/scripts/tag-release-github
@@ -25,12 +25,12 @@ generate_post_data()
   cat <<EOF
 {
     "tag_name":"${TAG}",
-    "target_commitish": "master", 
-    "name": "${TAG}", 
+    "target_commitish": "master",
+    "name": "${TAG}",
     "body": "Please paste notes from changelog."
  }
 EOF
 }
 
 # Create a release on GitHub for the tag that was just created.
-curl --fail -u massgov-bot:${GITHUB_MASSGOV_BOT_TOKEN} -H "Content-Type:application/json" -X POST https://api.github.com/repos/massgov/mass/releases --data "$(generate_post_data)"
+curl --fail -u massgov-bot:${GITHUB_MASSGOV_BOT_TOKEN} -H "Content-Type:application/json" -X POST https://api.github.com/repos/massgov/openmass/releases --data "$(generate_post_data)"


### PR DESCRIPTION
Update a few parts of the release process so they know about new openmass repo.

**Jira:**
https://jira.mass.gov/browse/DP-15695


**To Test:**
- [ ] `drush ma:release` now works


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/mass/blob/develop/docs/peer_review_checklist.md)
