### PR TITLE
DP-16620 Added a deployment job for production release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
           command: "drush ma:deploy -y -v $DEPLOY_REFRESH_DB $DEPLOY_SKIP_MAINT $DEPLOY_CACHE_REBUILD $DEPLOY_TARGET $DEPLOY_GIT_REF"
           no_output_timeout: 60m
 
-  # Deploy a tag to the stage environment within the Acquia repository (Testing for production deployment)
+  # Deploy a tag to the stage environment within the Acquia repository
   deploy_tag_stage:
     <<: *container_config
     steps:
@@ -384,6 +384,25 @@ jobs:
       # Deploy specified ref to specified environment
       - run:
           command: "drush ma:deploy -v test tags/$CIRCLE_TAG"
+          no_output_timeout: 60m
+
+  # Deploy a tag to the production environment within the Acquia repository
+  deploy_tag_prod:
+    <<: *container_config
+    steps:
+      - checkout
+      - *restore_composer_cache
+      - run: {name: 'Composer install', command: 'composer install --no-interaction --optimize-autoloader'}
+      # Deliberately don't save_cache in this job.
+      - run:
+          name: Fetch Drush aliases
+          command: "curl -f -o /var/www/code/drush/sites/self.site.yml -L https://$GITHUB_DS_INFRASTRUCTURE_TOKEN@raw.githubusercontent.com/massgov/DS-Infrastructure/develop/docs/massgov/self.site.yml"
+      - run: echo 'export PATH=/var/www/code/vendor/bin:$PATH' >> $BASH_ENV
+      - *no_host_check
+      - *no_ssh_timeout
+      # Deploy specified ref to specified environment
+      - run:
+          command: "drush ma:deploy -v -y prod tags/$CIRCLE_TAG"
           no_output_timeout: 60m
 
   # Nightcrawler is only using 1500 samples size to crawl the dev environment.
@@ -885,6 +904,27 @@ workflows:
           requires:
             - build
             - tagging_acquia
+            - hold
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+      - hold:
+          type: approval
+          requires:
+            - build
+            - tagging_acquia
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+      - deploy_tag_prod:
+          requires:
+            - build
+            - tagging_acquia
+            - deploy_tag_stage
             - hold
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -875,7 +875,7 @@ workflows:
               only: master
 
   # This is to tag the release in the Acquia repository.
-  # Testing deploying the newly created tag to stage environment.
+  # This will deploy the newly created tag to stage environment and production environment with hold/approval for each job.
   build_tag:
     jobs:
       - build:

--- a/changelogs/DP-16620.yml
+++ b/changelogs/DP-16620.yml
@@ -1,0 +1,3 @@
+Added:
+  - description: Added a new job to deploy code to production from CircleCI. Also added the job to our current workflow for build_tag with hold button.
+    issue: DP-16620


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
To streamline the deployment a bit more we are adding a job in the CircleCI config to deploy the new tag to production now.


**Jira:**
https://jira.mass.gov/browse/DP-16620


**To Test:**
- [ ] We tested the new tag deployment to stage. When the next release comes around and new tag is created. This should create a hold to deploy tag to stage than wait until that finishes for a new hold to deploy to production.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
