### PR TITLE
Resolve PHP notice in EntitySorter when title is an exact match and content type != person

### DIFF
--- a/changelogs/DP-16524.yml
+++ b/changelogs/DP-16524.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+  - description: Resolved a test failure due to PHP notices in entity comparisons that was uncovered by an upstream content change.
+    issue: DP-16524

--- a/docroot/modules/custom/mass_content/src/EntitySorter.php
+++ b/docroot/modules/custom/mass_content/src/EntitySorter.php
@@ -191,20 +191,26 @@ class EntitySorter {
     return strnatcmp($a_title, $b_title);
   }
 
-  function getComparisonTitle(EntityInterface $entity) {
+  /**
+   * Determine the title of an entity to use as the basis for comparison.
+   */
+  private function getComparisonTitle(EntityInterface $entity) {
+    // Derive the title from `field_title` on media entities.
     if ($entity instanceof Media) {
       return Helper::fieldValue($entity, 'field_title');
     }
-    if($entity instanceof Node) {
-      switch($entity->bundle()) {
+    // For specific content types, we derive the title special ways.
+    if ($entity instanceof Node) {
+      switch ($entity->bundle()) {
         case 'person':
           return Helper::fieldValue($entity, 'field_last_name') . ' ' . Helper::fieldValue($entity, 'field_first_name');
+
         case 'contact_information':
           return Helper::fieldValue($entity, 'field_display_title');
-        default:
-          return $entity->label();
       }
     }
+
+    // Fallback to entity label if we can't figure out a more specific one.
     return $entity->label();
   }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This is an attempt to resolve a test failure that happens only when using the `EntitySorter` to sort a list containing two entities alphabetically that have exactly the same title, but aren't a `person` node.  In this PR, we extract the logic of determining the title to a new method.  This simplifies the comparison logic and helps make it clearer how we determine the title for sorting. 


**Jira:**
https://jira.mass.gov/browse/DP-16524


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
