### PR TITLE
DP-16695 Fix the error with curated list page

### DIFF
--- a/changelogs/DP-16695.yml
+++ b/changelogs/DP-16695.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Type: Fixed
+  - description: Resolve the error with curated list pages by correcting the field names in /modules/custom/mass_content/src/EntitySorter.php.
+    issue: DP-16695

--- a/changelogs/DP-16695.yml
+++ b/changelogs/DP-16695.yml
@@ -28,6 +28,6 @@
   #    issue: DP-19875
   #  - description: Third change item that needs a description along with an issue.
   #    issue: DP-19843
-Type: Fixed
+Fixed:
   - description: Resolve the error with curated list pages by correcting the field names in /modules/custom/mass_content/src/EntitySorter.php.
     issue: DP-16695

--- a/docroot/modules/custom/mass_content/src/EntitySorter.php
+++ b/docroot/modules/custom/mass_content/src/EntitySorter.php
@@ -203,7 +203,7 @@ class EntitySorter {
     if ($entity instanceof Node) {
       switch ($entity->bundle()) {
         case 'person':
-          return Helper::fieldValue($entity, 'field_last_name') . ' ' . Helper::fieldValue($entity, 'field_first_name');
+          return Helper::fieldValue($entity, 'field_person_last_name') . ' ' . Helper::fieldValue($entity, 'field_person_first_name');
 
         case 'contact_information':
           return Helper::fieldValue($entity, 'field_display_title');


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Fixed the error by correcting the field name:
InvalidArgumentException: Field field_last_name is unknown. in Drupal\Core\Entity\ContentEntityBase->getTranslatedField() (line 587 of /mnt/www/html/massgov/docroot/core/lib/Drupal/Core/Entity/ContentEntityBase.php).

**Jira:**
https://jira.mass.gov/browse/DP-16695


**To Test:**
- [ ] Go to curated lists based on person content.
- [ ] Find the page is rendered without any errors.
        Sample page: http://mass.local/lists/department-of-correction-division-and-staff-directory


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
