### PR TITLE
KPI information added to api/v1/content-metadata REST endpoint

### DIFF
--- a/changelogs/DP-16429.yml
+++ b/changelogs/DP-16429.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Added:
+  - description: KPI information added to api/v1/content-metadata REST endpoint
+    issue: DP-16429

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -147,7 +147,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
           $is_ctr = strpos($name, '_ctr') !== FALSE;
           $value = $item->get($name)->value;
           if ($value && ($is_ctr || $is_pct)) {
-            $value = round($value / 100, 3);
+            $value = $value / 100;
           }
           $kpis[$name] = $value;
         }

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -147,7 +147,6 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         }
       }
 
-
       $roles = array_map($get_target_id, $node_owner->roles->getValue());
       $mod_state = $item->moderation_state->getValue();
       $path = $this->aliasManager->getAliasByPath('/node/' . $item->nid->value);

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -135,6 +135,19 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         }
       }
 
+      /*
+       * Get any field_kpi_ fields for this entity.
+       * See https://jira.mass.gov/browse/DP-16429.
+       */
+      $kpis = [];
+      $info = $item->getFieldDefinitions();
+      foreach ($info as $name => $field) {
+        if (strpos($name, 'field_kpi_') !== FALSE) {
+          $kpis[$name] = $item->get($name)->value;
+        }
+      }
+
+
       $roles = array_map($get_target_id, $node_owner->roles->getValue());
       $mod_state = $item->moderation_state->getValue();
       $path = $this->aliasManager->getAliasByPath('/node/' . $item->nid->value);
@@ -160,6 +173,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
           'is_intern' => $node_owner->field_user_intern->value == 1,
           'roles' => $roles,
         ],
+        'kpis' => $kpis,
       ];
 
       if ($flag_show_flat) {

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -111,7 +111,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
       if (!empty($org)) {
         $organization = [
           'name' => $org->name->value,
-          'uuid' => $org->uuid->value,
+          'uuid' => $org->uuid(),
           'id' => $org->tid->value,
         ];
       }
@@ -143,7 +143,13 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
       $info = $item->getFieldDefinitions();
       foreach ($info as $name => $field) {
         if (strpos($name, 'field_kpi_') !== FALSE) {
-          $kpis[$name] = $item->get($name)->value;
+          $is_pct = strpos($name, '_pct') !== FALSE;
+          $is_ctr = strpos($name, '_ctr') !== FALSE;
+          $value = $item->get($name)->value;
+          if ($value && ($is_ctr || $is_pct)) {
+            $value = round($value / 100, 2);
+          }
+          $kpis[$name] = $value;
         }
       }
 

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -147,7 +147,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
           $is_ctr = strpos($name, '_ctr') !== FALSE;
           $value = $item->get($name)->value;
           if ($value && ($is_ctr || $is_pct)) {
-            $value = round($value / 100, 2);
+            $value = round($value / 100, 3);
           }
           $kpis[$name] = $value;
         }


### PR DESCRIPTION
**Jira:**
https://jira.mass.gov/browse/DP-16429


**To Test:**
- [ ] [Populate a campaign landing page with values](http://mass.local/community-compact-connector-campaign/edit
)
- [ ] Browse to http://mass.local/api/v1/content-metadata?content_types=campaign_landing. Verify that the above node has values in its new `kpis` section. It should be the first item in the JSON.
- [ ] If the above is impractical to test, see blue bar the screenshot below

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/7740/70466812-fc147280-1a91-11ea-98a1-92f058c00c0c.png">

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
