### PR TITLE
DP-16689 Stop sending Purge module errors to New Relic

### DIFF
--- a/changelogs/DP-16689.yml
+++ b/changelogs/DP-16689.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Exclude purges sent to New Relic.
+    issue: DP-16689

--- a/docroot/sites/default/services.acquia.yml
+++ b/docroot/sites/default/services.acquia.yml
@@ -9,3 +9,4 @@ parameters:
   monolog.channel_handlers:
     # Log to syslog and NewRelic
     default: ['acquia_syslog', 'acquia_newrelic']
+    purge: ['acquia_syslog']


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Add the config to exclude purges sent to New Relic in services.acquia.yml.

The change was reviewed and the test method was agreed on at the 12/17 standup.


**Jira:**
https://jira.mass.gov/browse/DP-16689


**To Test:**
- [ ] Merge to `develop`, and let run NightCrawler on CD through nightly deployment to see any errors since New Relic is not hooked up with non-prod environments.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
