### PR TITLE
DP-16927 Add intended audience to Drupal API

### DIFF
--- a/changelogs/DP-16927.yml
+++ b/changelogs/DP-16927.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Changed:
+  - description: Add intended audience to Drupal API
+    issue: DP-16927

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -164,6 +164,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         'title' => $item->title->value,
         'date_created' => $item->created->value,
         'date_changed' => $item->changed->value,
+        'intended_audience' => $item->field_intended_audience->value,
         'content_type' => $item->getType(),
         'offered_by_organizations' => $offered_by_organizations,
         'published' => $item->status->value == 1,

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -164,7 +164,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         'title' => $item->title->value,
         'date_created' => $item->created->value,
         'date_changed' => $item->changed->value,
-        'intended_audience' => ($item->field_intended_audience ? $item->field_intended_audience->value : '_none'),
+        'intended_audience' => $item->field_intended_audience ?? '_none',
         'content_type' => $item->getType(),
         'offered_by_organizations' => $offered_by_organizations,
         'published' => $item->status->value == 1,

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -164,7 +164,7 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         'title' => $item->title->value,
         'date_created' => $item->created->value,
         'date_changed' => $item->changed->value,
-        'intended_audience' => $item->field_intended_audience->value,
+        'intended_audience' => ($item->field_intended_audience ? $item->field_intended_audience->value : '_none'),
         'content_type' => $item->getType(),
         'offered_by_organizations' => $offered_by_organizations,
         'published' => $item->status->value == 1,


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Added intended audience to Drupal API


**Jira:**
https://jira.mass.gov/browse/DP-16927


**To Test:**
- [ ] Go to this local URL: http://mass.local/api/v1/content-metadata?content_types=service_page
- [ ] Search the response for "intended_audience".  You will see the field included.  Many of them will have values of "_none" but you will find some with values.  Search for "intended_audience":"Personal", "intended_audience":"Professional (For their jobs)", "intended_audience":"Both equally"


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
