### PR TITLE
add promo page route iframe config

### DIFF
--- a/changelogs/DP-16657.yml
+++ b/changelogs/DP-16657.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Added:
+  - description: Added config for route iframe for promo page analytics dashboards
+    issue: DP-16657

--- a/conf/drupal/config/route_iframes.route_iframe_config_entity.promo_page_dashboards.yml
+++ b/conf/drupal/config/route_iframes.route_iframe_config_entity.promo_page_dashboards.yml
@@ -1,0 +1,12 @@
+uuid: f2830526-bf2d-4d73-bac8-bf0dc1fd4654
+langcode: en
+status: true
+dependencies: {  }
+id: promo_page_dashboards
+name: 'Promo page dashboards'
+tab: dashboards
+scope_type: bundle
+weight: null
+scope: campaign_landing
+config: '/superset/dashboard/promo-page/?preselect_filters=%7B"1436"%3A%7B"node_id"%3A%5B"[node:nid]"%5D%7D%7D'
+iframe_height: '2200'


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Add a route iframe for promo page dashboards.


**Jira:**
https://jira.mass.gov/browse/DP-16657


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
