### PR TITLE
DP-17036 Remove hyphens from mg-organization metadata

### DIFF
--- a/changelogs/DP-17036.yml
+++ b/changelogs/DP-17036.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Remove hyphens from the mg_organization metadata for media entities.
+    issue: DP-17036

--- a/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
+++ b/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
@@ -69,9 +69,6 @@ class DocumentPagesUrlGenerator extends UrlGeneratorBase {
           $org_nodes = $entity->field_organizations->referencedEntities();
           $org_slugs = [];
           foreach ($org_nodes as $org) {
-            // $org_slugs += $utility_service->getAllOrgsFromNode($org);
-            // $allOrgs = $utility_service->getAllOrgsFromNode($org);
-            // $org_slugs += str_replace("-", "", $allOrgs);
             $org_slugs += str_replace("-", "", $utility_service->getAllOrgsFromNode($org));
           }
           if (!empty($org_slugs)) {

--- a/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
+++ b/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
@@ -69,7 +69,10 @@ class DocumentPagesUrlGenerator extends UrlGeneratorBase {
           $org_nodes = $entity->field_organizations->referencedEntities();
           $org_slugs = [];
           foreach ($org_nodes as $org) {
-            $org_slugs += $utility_service->getAllOrgsFromNode($org);
+            // $org_slugs += $utility_service->getAllOrgsFromNode($org);
+            // $allOrgs = $utility_service->getAllOrgsFromNode($org);
+            // $org_slugs += str_replace("-", "", $allOrgs);
+            $org_slugs += str_replace("-", "", $utility_service->getAllOrgsFromNode($org));
           }
           if (!empty($org_slugs)) {
             $data['pagemap']['metatags'][] = [


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Removed hyphens from mg-organization metadata in sitemap.

**Jira:**
https://jira.mass.gov/browse/DP-17036


**To Test:**
- [ ] Generate a sitemap at http://mass.local/admin/config/search/simplesitemap.
- [ ] Go to one of the site map file: ex) http://mass.local/sitemaps/5/sitemap.xml.
- [ ] Find **\<Attribute name="mg_organization"\>** content has no hyphens.

**Screenshots/GIFs:**
Before:
<img width="650" alt="before" src="https://user-images.githubusercontent.com/9633303/72184431-6e90af00-33be-11ea-92ba-0ca8bec841c5.png">

After:
<img width="804" alt="after" src="https://user-images.githubusercontent.com/9633303/72184440-72bccc80-33be-11ea-9162-32677627dc4c.png">


---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
