### PR TITLE
Dp 17004 limit button text length

### DIFF
--- a/changelogs/DP-17004.yml
+++ b/changelogs/DP-17004.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Limit characters for button text in key message on promo pages to 35 char
+    issue: DP-17004

--- a/conf/drupal/config/core.entity_form_display.paragraph.key_message.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.key_message.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field_group
     - focal_point
     - link
+    - mass_validation
     - maxlength
     - text
 third_party_settings:
@@ -112,7 +113,12 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 35
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      mass_validation:
+        internal_link_content_type_blacklist: {  }
     type: link_default
     region: content
   field_image:

--- a/conf/drupal/config/core.entity_form_display.paragraph.key_message_section.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.key_message_section.default.yml
@@ -18,6 +18,7 @@ dependencies:
     - conditional_fields
     - image
     - link
+    - mass_validation
     - maxlength
     - text
 id: paragraph.key_message_section.default
@@ -36,7 +37,12 @@ content:
     settings:
       placeholder_url: ''
       placeholder_title: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 35
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+      mass_validation:
+        internal_link_content_type_blacklist: {  }
     type: link_default
     region: content
   field_image:


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Configure the form display to limit data entry to 35 characters for button fields on the 2 key message paragraph types allowed on the Promotional page.


**Jira:**
https://jira.mass.gov/browse/DP-17004


**To Test:**
- [ ] Create or edit a promotional page
- [ ] Add a key message and confirm that the button text cannot exceed 35 characters.
- [ ] Add a key message section and confirm that the button text cannot exceed 35 characters.



**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
