### PR TITLE
Add field_links to location CT linking page config

### DIFF
--- a/changelogs/DP-15833.yml
+++ b/changelogs/DP-15833.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+    - description: Added field_links to Location CT linking pages config.
+    issue: DP-15833

--- a/conf/drupal/config/node.type.location.yml
+++ b/conf/drupal/config/node.type.location.yml
@@ -29,6 +29,7 @@ third_party_settings:
       - field_location_activity_detail>field_ref_location_details_page
     linking_pages:
       - 'field_location_activity_detail>*'
+      - field_links
       - field_ref_contact_info
       - field_ref_contact_info_1
       - field_related_locations


### PR DESCRIPTION
**Description:**
Adds field_links to location linking page config.


**Jira:**
https://jira.mass.gov/browse/DP-15833


**To Test:**
- [ ] Edit an existing [location](http://mass.local/locations/berkshire-north-wic-program) page (or create a new one)
- [ ] Under the "Related" tab enter a link to an existing piece of content in the "Quick Actions" field
- [ ] Save the location.
- [ ] Run "drush cron" to trigger the mass_content_api queue
- [ ] Visit the "Page linking here" tab of the content you linked to and verify the location page appears in the list.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
