### PR TITLE
DP-11540: Remove the option to create an unlimited temporary unpublis…

### DIFF
--- a/changelogs/DP-11540.yml
+++ b/changelogs/DP-11540.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Remove the option to create an "unlimited" temporary unpublished access token from the node form.
+    issue: DP-11540

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -91,6 +91,14 @@ function mass_utility_form_node_form_alter(&$form, FormStateInterface $form_stat
     $form['access_unpublished_settings']['generate_token']['#value'] = t('Get link');
   }
 
+  // Remove 'Unlimited' option for Temporary Unpublished Access.
+  if (isset($form['access_unpublished_settings'])) {
+    $options = $form['access_unpublished_settings']['duration']['#options'];
+    // The array key for 'Unlimited' access is '-1'.
+    unset($options['-1']);
+    $form['access_unpublished_settings']['duration']['#options'] = $options;
+  }
+
   // Add help text link for Scheduling options.
   if (isset($form['publish_on']['widget'][0]['value']['#description'])) {
     $schedule_url = Url::fromUri('https://massgovdigital.gitbook.io/knowledge-base/authoring-and-editing-1/strategy/schedule-publishing-and-unpublishing');


### PR DESCRIPTION
DP-11540: Remove the option to create an unlimited temporary unpublished access token from the node form.

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This removes the option to create an "unlimited" temporary unpublished access token from the node form.

**Jira:**
https://jira.mass.gov/browse/DP-11540

**To Test:**
- [ ] In "All Content", locate a node item that is not Published. In the Edit screen, in the right sidebar, expand "Temporary unpublished access."
- [ ] Check the options under "LIfetime". The "Unlimited" option should not appear.
- [ ] Test creating access tokens for the item and confirm that the tokens work as expected.


---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
