### PR TITLE
DP-16915: Hide the 'Temporary unpublished access' form on the edit pa…

### DIFF
--- a/changelogs/DP-16915.yml
+++ b/changelogs/DP-16915.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Hides the "Temporary unpublished access" form on the edit page for media items.
+    issue: DP-16915

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -255,6 +255,11 @@ function mass_utility_form_media_form_alter(&$form, FormStateInterface $form_sta
       }
     }
   }
+
+  // Hide the Temporary Unpublished Access form on the edit page for media items.
+  if (isset($form['access_unpublished_settings'])) {
+    $form['access_unpublished_settings']['#access'] = FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
…ge for media items.

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This hides the "Temporary unpublished access" form on the edit page for media items.

**Jira:**
https://jira.mass.gov/browse/DP-16915

**To Test:**
- [x] In "All documents", locate a document that is not published. Go to the edit screen, and confirm that "Temporary unpublished access" does not appear in the right sidebar.
- [ ] In "All content", find an unpublished node, and confirm that the "Temporary unpublished access" form does appear as expected.

