### PR TITLE
Add severity name to syslog

### DIFF
--- a/changelogs/DP-16688.yml
+++ b/changelogs/DP-16688.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Added:
+  - description: Add severity name to syslog
+    issue: DP-16688

--- a/docroot/modules/custom/mass_utility/src/Logger/AcquiaSyslogHandler.php
+++ b/docroot/modules/custom/mass_utility/src/Logger/AcquiaSyslogHandler.php
@@ -15,7 +15,7 @@ use Monolog\Logger;
  */
 class AcquiaSyslogHandler extends SyslogHandler {
 
-  const FORMAT = '%extra.base_url%|%extra.timestamp%|%channel%|%extra.ip%|%extra.request_uri%|%extra.referer%|%extra.uid%|%context.link%|%message%';
+  const FORMAT = '%level_name%|%extra.base_url%|%extra.timestamp%|%channel%|%extra.ip%|%extra.request_uri%|%extra.referer%|%extra.uid%|%context.link%|%message%';
 
   /**
    * Constructor.

--- a/docroot/modules/custom/mass_utility/src/Logger/AcquiaSyslogHandler.php
+++ b/docroot/modules/custom/mass_utility/src/Logger/AcquiaSyslogHandler.php
@@ -15,7 +15,7 @@ use Monolog\Logger;
  */
 class AcquiaSyslogHandler extends SyslogHandler {
 
-  const FORMAT = '%level_name%|%extra.base_url%|%extra.timestamp%|%channel%|%extra.ip%|%extra.request_uri%|%extra.referer%|%extra.uid%|%context.link%|%message%';
+  const FORMAT = '%extra.base_url%|%extra.timestamp%|%channel%|%level_name%|%extra.ip%|%extra.request_uri%|%extra.referer%|%extra.uid%|%context.link%|%message%';
 
   /**
    * Constructor.


### PR DESCRIPTION
**Jira:**
https://jira.mass.gov/browse/DP-16688
The Drupal work is now complete in this PR. We need to time the deployment of this PR with the deployment of a change to ELK Stack. That work is coming soon.

**To Test:**
- [ ] Not easily testable. I ran `dcdrush php:eval "\Drupal::logger('bar')->log(3, 'foo');"` and put a breakpoint at \Monolog\Handler\SyslogHandler::write in order to verify that the word ERROR is in $record['formatted']



---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
