### PR TITLE
DP-17189: change sitewide alert notification function to use MassMode…

### DIFF
--- a/changelogs/DP-17189.yml
+++ b/changelogs/DP-17189.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+  - description: Fix sitewide alert notification function to use updated moderation states from mass_content_moderation.
+    issue: DP-17189

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\mass_content_moderation\MassModeration;
 
 /**
  * Implements hook_form_FORM_ID_alter() for the FORM_ID() form.
@@ -183,7 +184,7 @@ function mass_alerts_mail($key, &$message, $params) {
  */
 function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
   // Only send notifications after an alert has been published.
-  if ($node->bundle() === "alert" && $node->moderation_state->target_id === 'published') {
+  if ($node->bundle() === "alert" && !MassModeration::isPrepublish($node)) {
     // Only send notifications if the alert is site-wide.
     $alert_placement = $node->get("field_alert_display")->getValue();
     if (!empty($alert_placement) && $alert_placement[0]['value'] === 'site_wide') {


### PR DESCRIPTION
DP-17189: change sitewide alert notification function to use MassModeration.

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This fixes the sitewide alert notification function to use the updated moderation state from mass_content_moderation.

**Jira:**
https://jira.mass.gov/browse/DP-17189


**To Test:**
- [ ] To test locally, create and publish a new Alert set to "Sitewide on all pages" and confirm that email is sent to the alert watcher email recipients. Full instructions for local testing are in the jira ticket.


**Screenshots/GIFs:**


---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
