### PR TITLE
DP-16628 Render temp. unpublished links in service page

### DIFF
--- a/changelogs/DP-16628.yml
+++ b/changelogs/DP-16628.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+  Changed:
+  - description: Render temp. unpublished links to "What you need to know" in service page.
+    issue: DP-16628

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
@@ -184,7 +184,7 @@
       {% for i in 0..lastIndex %}
         {% set keyInfoLink = content.field_service_key_info_links_6[i] %}
         {% set href = keyInfoLink['#url_title'] %}
-        {% if '/node/' in href or '---unpublished' in href %}
+        {% if '/node/' in href or href ends with '---unpublished' %}
           {# DO NOTHING if referenced item is NULL or unpublished state. #}
         {% else %}
           {% set publishedLinkCount = publishedLinkCount + 1 %}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Adjust the condition to screen deleted and unpublished links to exclude temp. unpub. ones for "What you need to know" section.


**Jira:**
https://jira.mass.gov/browse/DP-16628


**To Test:**
- [ ] Go to the edit page of a published service page.
- [ ] Add a _temp. unpublished page_ to the **Key information links** in the **What you need to know** under the **Task and Key Info** tab.
- [ ] Save the change.
- [ ] Find the added temp. unpublished page link is rendered in the What you need to know in the page.

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
