### PR TITLE
DP-17289 Allow contact hours in 5 minute increments

### DIFF
--- a/changelogs/DP-17289.yml
+++ b/changelogs/DP-17289.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Authors can now enter hours for contacts in 5 minute increments.
+    issue: DP-17289

--- a/conf/drupal/config/field.storage.paragraph.field_hours_structured.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_hours_structured.yml
@@ -12,7 +12,7 @@ type: office_hours
 settings:
   cardinality_per_day: '2'
   time_format: g
-  increment: '15'
+  increment: '5'
   valhrs: 1
   limit_start: ''
   limit_end: ''


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Authors can now edit contact hours in 5 minute increments


**Jira:**
https://jira.mass.gov/browse/DP-17289


**To Test:**
- [ ] Edit this contact node to use 5 minute increments: http://mass.local/node/31276/edit
- [ ] Verify that hours appear on this page. http://mass.local/locations/mci-shirley


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
