### PR TITLE
Dp 17287 data fields condition logic help text

### DIFF
--- a/changelogs/DP-17287.yml
+++ b/changelogs/DP-17287.yml
@@ -1,0 +1,34 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: For service details and info details, we changed conditional logic to show the data resource type field only if the data type field = "data resource"
+We add help text to the data type and data resource type fields on service details, info details and curated list to define the options.  
+    issue: DP-17287

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -153,8 +153,8 @@ content:
     settings: {  }
     third_party_settings:
       conditional_fields:
-        7882a891-c073-474e-9549-c9afc45c40fa:
-          dependee: field_data_flag
+        d6eed0b6-1eff-44f0-86a4-2c8fddd7e0f0:
+          dependee: field_details_data_type
           settings:
             state: visible
             condition: value
@@ -164,7 +164,7 @@ content:
             values: {  }
             value_form:
               -
-                value: data
+                target_id: '77936'
             effect: show
             effect_options: {  }
             selector: ''

--- a/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
@@ -114,8 +114,8 @@ content:
     settings: {  }
     third_party_settings:
       conditional_fields:
-        f147a980-e4fc-4be7-ac9e-1c1a35ab8e09:
-          dependee: field_data_flag
+        be8e7705-a2ca-49cb-a5f5-5844761ae370:
+          dependee: field_details_data_type
           settings:
             state: visible
             condition: value
@@ -125,7 +125,7 @@ content:
             values: {  }
             value_form:
               -
-                value: data
+                target_id: '77936'
             effect: show
             effect_options: {  }
             selector: ''

--- a/conf/drupal/config/field.field.node.curated_list.field_list_data_type.yml
+++ b/conf/drupal/config/field.field.node.curated_list.field_list_data_type.yml
@@ -11,7 +11,7 @@ field_name: field_list_data_type
 entity_type: node
 bundle: curated_list
 label: 'Data type'
-description: 'Choose the data type that applies to this page.'
+description: "Choose the data type that applies to this page.<br/><br/> \r\n<b>Dataset:</b> A body of structured information describing some topic(s) of interest. A dataset usually comprises a description of the data and one or multiple data resources, which can be in various formats.<br/> \r\n<b>Data catalog:</b> A collection of datasets that covers one or more topics. For example, an open data portal or a curated dataset listing across multiple topics. "
 required: false
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.node.info_details.field_data_resource_type.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_data_resource_type.yml
@@ -11,7 +11,7 @@ field_name: field_data_resource_type
 entity_type: node
 bundle: info_details
 label: 'Data resource type'
-description: 'Choose the data resource type(s) that apply to this page. In many cases, checking more than one is appropriate so read the definitions carefully.'
+description: "Choose the data resource type(s) that apply to this page. In many cases, checking more than one is appropriate so read the definitions carefully.<br/><br/>\r\n<b>Report:</b> An information summary and analysis of a dataset or a collection of datasets that provide insights into the raw data. This type includes data reports and data stories. <br/>\r\n<b>Data visualization: </b>Information presented in the form of a chart, diagram, picture, dashboard, map, etc. This type can also include landing pages for charts, diagrams, pictures, or dashboards, etc.<br/>\r\n<b>Map:</b> A visualization of a dataset with a geographic component(s)."
 required: false
 translatable: true
 default_value: {  }

--- a/conf/drupal/config/field.field.node.info_details.field_details_data_type.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_details_data_type.yml
@@ -11,7 +11,7 @@ field_name: field_details_data_type
 entity_type: node
 bundle: info_details
 label: 'Data type'
-description: 'Choose the data type that applies to this page.'
+description: "Choose the data type that applies to this page.<br/><br/> \r\n<b>Data resource:</b> A report, data visualization or map.<br/> \r\n<b>Dataset:</b> A body of structured information describing some topic(s) of interest. A dataset usually comprises a description of the data and one or multiple data resources, which can be in various formats.<br/> \r\n<b>Data catalog:</b> A collection of datasets that covers one or more topics. For example, an open data portal or a curated dataset listing across multiple topics. \r\n"
 required: false
 translatable: true
 default_value: {  }

--- a/conf/drupal/config/field.field.node.service_details.field_data_resource_type.yml
+++ b/conf/drupal/config/field.field.node.service_details.field_data_resource_type.yml
@@ -11,7 +11,7 @@ field_name: field_data_resource_type
 entity_type: node
 bundle: service_details
 label: 'Data resource type'
-description: 'Choose the data resource type(s) that apply to this page. In many cases, checking more than one is appropriate so read the definitions carefully.'
+description: "Choose the data resource type(s) that apply to this page. In many cases, checking more than one is appropriate so read the definitions carefully.<br/><br/>\r\n<b>Report:</b> An information summary and analysis of a dataset or a collection of datasets that provide insights into the raw data. This type includes data reports and data stories. <br/>\r\n<b>Data visualization: </b>Information presented in the form of a chart, diagram, picture, dashboard, map, etc. This type can also include landing pages for charts, diagrams, pictures, or dashboards, etc.<br/>\r\n<b>Map:</b> A visualization of a dataset with a geographic component(s)."
 required: false
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.node.service_details.field_details_data_type.yml
+++ b/conf/drupal/config/field.field.node.service_details.field_details_data_type.yml
@@ -11,7 +11,7 @@ field_name: field_details_data_type
 entity_type: node
 bundle: service_details
 label: 'Data type'
-description: 'Choose the data type that applies to this page.'
+description: "Choose the data type that applies to this page.<br/><br/> \r\n<b>Data resource:</b> A report, data visualization or map.<br/> \r\n<b>Dataset:</b> A body of structured information describing some topic(s) of interest. A dataset usually comprises a description of the data and one or multiple data resources, which can be in various formats.<br/> \r\n<b>Data catalog:</b> A collection of datasets that covers one or more topics. For example, an open data portal or a curated dataset listing across multiple topics. "
 required: false
 translatable: false
 default_value: {  }


### PR DESCRIPTION
**Description:**
For service details and info details, we change conditional logic to show the data resource type field only if the data type field = "data resource"
We add help text to the data type fields on service details, info details and curated list to define the options.  
We add help text to the data resource type fields on service details and info details to define the options.


**Jira:**
https://jira.mass.gov/browse/DP-17287


**To Test:**
- [ ] Push this branch to a feature environment. The conditional logic cannot be tested locally without an updated database that contains the production taxonomy terms.  Make sure the database no more than 4 days old.
- [ ] Edit a service details page.  Check off the data flag.  You should see the data type field but not the data resource type.  Choose data type = "data resource".  You should see the data type field with 3 options but you won't see the data resource type field.  Verify that you see help text for both the data type and data resource type fields that defines the options. 
- [ ] Edit a info details page.  Check off the data flag.  You should see the data type field with 3 options but you won't see the data resource type field.  Choose data type = "data resource".  You should now see the data resource type field. Verify that you see help text for both the data type and data resource type fields that defines the options. 
- [ ] Edit a curated list page.  Check off the data flag.  You should see the data type field with two options.  There is no data resource type field. Verify that you see help text for the data type field that defines the options. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
