### PR TITLE
update label for promotional page publisher role (from campaign landing)

### DIFF
--- a/changelogs/DP-17301.yml
+++ b/changelogs/DP-17301.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Update label for Promotional page publisher role (was Campaign Landing page publisher)
+    issue: DP-17301

--- a/conf/drupal/config/user.role.campaign_landing_page_publisher.yml
+++ b/conf/drupal/config/user.role.campaign_landing_page_publisher.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: campaign_landing_page_publisher
-label: 'Campaign landing page publisher'
+label: 'Promotional page publisher'
 weight: 2
 is_admin: null
 permissions:


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
change label for promotional page publisher role (from campaign landing page publisher)

**Jira:**
https://jira.mass.gov/browse/DP-17301


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
