### PR TITLE
[WIP] Use SSH to transfer database during ma:deploy

### DIFF
--- a/changelogs/DP-17286.yml
+++ b/changelogs/DP-17286.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Changed:
+  - description: Use SSH to transfer database during ma:deploy
+    issue: DP-17286

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -134,7 +134,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
       // Fetch backup.
       // Directory set by https://jira.mass.gov/browse/DP-12823.
-      $process = Drush::drush($targetRecord, 'ma:latest-backup-fetch', [Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz')], ['verbose' => NULL]);
+      $destination = Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz');
+      $process = Drush::drush($targetRecord, 'ma:latest-backup-fetch', [$destination], ['verbose' => NULL]);
       $process->mustRun($process->showRealtime());
       $this->logger()->success('Fetched backup.');
 
@@ -146,7 +147,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
       // Import the latest backup.
       // $bash = ['zgrep', '--line-buffered', '-v', '-e', '^INSERT INTO \`cache_', '-e', '^INSERT INTO \`migrate_map_', '-e', "^INSERT INTO \`config_log", '-e', "^INSERT INTO \`key_value_expire", '-e', "^INSERT INTO \`sessions", $tmp, Shell::op('|'), Path::join($targetRecord->root(), '../vendor/bin/drush'), '-r', $targetRecord->root(), '-v', 'sql:cli'];
       // $bash = '-e "^INSERT INTO \`migrate_map_" -e "^INSERT INTO \`config_log" -e "^INSERT INTO \`key_value_expire" -e "^INSERT INTO \`sessions" ' . $tmp . ' | drush -vvv sql:cli';
-      $bash = ['cd', $targetRecord->root(), Shell::op('&&'), '../scripts/ma-import-backup', $tmp];
+      $bash = ['cd', $targetRecord->root(), Shell::op('&&'), '../scripts/ma-import-backup', $destination];
       $process = Drush::siteProcess($targetRecord, $bash);
       $process->disableOutput();
       $process->mustRun();

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -154,10 +154,10 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
       $this->logger()->success('Database imported from backup.');
 
       // Delete tmp file.
-      $bash = ['test', '-f', $tmp, Shell::op('&&'), 'rm', $tmp];
+      $bash = ['test', '-f', $destination, Shell::op('&&'), 'rm', $destination];
       $process = Drush::siteProcess($targetRecord, $bash);
       $process->mustRun();
-      $this->logger()->success('Temporary file deleted. ' . $tmp);
+      $this->logger()->success('Temporary file deleted. ' . $destination);
     }
 
     if ($options['skip-maint'] == FALSE) {
@@ -322,7 +322,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
   /**
    * Loop and re-check until a given task is complete.
    *
-   * @param str $uuid
+   * @param string $uuid
    *   The Notification UUID.
    *
    * @throws \Exception

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -67,7 +67,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @throws \Exception
    */
   public function latestBackupFetch($destination) {
-    // Get filename of latest backup.
+    // Get filename of latest backup. See https://docs.acquia.com/acquia-cloud/manage/back-up/cli/
     // The head | tail comes fom https://stackoverflow.com/questions/13832866/unix-show-the-second-line-of-the-file.
     $path_backups = '/mnt/files/massgov.prod/backups';
     $bash = ['ls',

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -70,8 +70,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     // Get filename of latest backup. See https://docs.acquia.com/acquia-cloud/manage/back-up/cli/
     // The head | tail comes fom https://stackoverflow.com/questions/13832866/unix-show-the-second-line-of-the-file.
     $path_backups = '/mnt/files/massgov.prod/backups';
-    $bash = ['ls',
-      $path_backups, Shell::op('|'), 'head', '-2', Shell::op('|'), 'tail', '-n', '1'];
+    $bash = ['ls', '-Art', '--group-directories-first', $path_backups, Shell::op('|'), 'tail', '-n', '1'];
     $prodRecord = $this->siteAliasManager()->getAlias('@prod');
     $process = Drush::siteProcess($prodRecord, $bash);
     $process->mustRun();

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -68,7 +68,6 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    */
   public function latestBackupFetch($destination) {
     // Get filename of latest backup. See https://docs.acquia.com/acquia-cloud/manage/back-up/cli/
-    // The head | tail comes fom https://stackoverflow.com/questions/13832866/unix-show-the-second-line-of-the-file.
     $path_backups = '/mnt/files/massgov.prod/backups';
     $bash = ['ls', '-Art', '--group-directories-first', $path_backups, Shell::op('|'), 'tail', '-n', '1'];
     $prodRecord = $this->siteAliasManager()->getAlias('@prod');

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -134,7 +134,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
       // Fetch backup.
       // Directory set by https://jira.mass.gov/browse/DP-12823.
-      $process = Drush::drush($self, 'ma:latest-backup-fetch', [Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz')]);
+      $process = Drush::drush($targetRecord, 'ma:latest-backup-fetch', [Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz')]);
       $process->mustRun();
       $this->logger()->success('Fetched backup.');
 

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -81,7 +81,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     // Rsync the latest backup.
     $self = $this->siteAliasManager()->getSelf();
     $process = Drush::drush($self, 'core:rsync', ["@prod:$file", "@self:$destination"], ['verbose' => NULL]);
-    $process->mustRun();
+    $process->mustRun($process->showRealtime());
     $this->logger()->success('Database downloaded from backup.');
   }
 
@@ -134,8 +134,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
       // Fetch backup.
       // Directory set by https://jira.mass.gov/browse/DP-12823.
-      $process = Drush::drush($targetRecord, 'ma:latest-backup-fetch', [Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz')]);
-      $process->mustRun();
+      $process = Drush::drush($targetRecord, 'ma:latest-backup-fetch', [Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz')], ['verbose' => NULL]);
+      $process->mustRun($process->showRealtime());
       $this->logger()->success('Fetched backup.');
 
       // Drop all tables.

--- a/scripts/ma-refresh-local
+++ b/scripts/ma-refresh-local
@@ -147,7 +147,7 @@ function sql_create() {
     # Create a database.
     echo
     echo "${HEADING}[+] Drop old database and create new one ${TEXTRESET}" | tee -a $LOGFILE_NAME
-#    drush -y -vvv sql:create
+    drush -y sql:create
     nonzero_exit
 }
 

--- a/scripts/ma-refresh-local
+++ b/scripts/ma-refresh-local
@@ -128,11 +128,8 @@ function nonzero_exit() {
 function download_backup() {
     # Download backup using Acquia's Cloud API.
     echo "${HEADING}[+] Download latest database backup ${TEXTRESET}" | tee -a $LOGFILE_NAME
-    LATEST_BACKUP=`drush ma:latest-backup-url prod`
-    # Track download url in current log file.
-    echo $LATEST_BACKUP >> $LOGFILE_NAME
-    echo
-    wget -q --continue $LATEST_BACKUP --output-document=$HOME/db-backup.sql.gz
+    drush ma:latest-backup-fetch -vvv $HOME/db-backup.sql.gz
+    nonzero_exit
     echo
 }
 
@@ -150,7 +147,7 @@ function sql_create() {
     # Create a database.
     echo
     echo "${HEADING}[+] Drop old database and create new one ${TEXTRESET}" | tee -a $LOGFILE_NAME
-    drush -y sql:create
+#    drush -y -vvv sql:create
     nonzero_exit
 }
 
@@ -290,7 +287,7 @@ function main() {
     # Sanitize database.
     elif [[ "$1" = "-s" ]] || [[ "$1" = "--sanitize" ]]; then
         sanitize
-    
+
     # Super sanitize database.
     elif [[ "$1" = "-ss" ]] || [[ "$1" = "--super-sanitize" ]]; then
         super_sanitize


### PR DESCRIPTION
Avoids use of broken Acquia networking thats evident during http  transfer of backup file. This will fix our population of new database images, and fix the --refresh-db that we do during release workflow and ad hoc developer pushes.

**Jira:**
DP-17286


**To Test:**
- [ ] `dcexec scripts/ma-refresh-local -dpo --super`. This is what our DB populate workflow does at Circle.
- [ ] Run code below. This assures that developers and release workflow can ma:deploy successfully:
```
dcdrush ma:deploy cd ssh-deploy -vvv
dcdrush ma:deploy cd ssh-deploy -vvv  --refresh-db
```
The testing step above highlights an inconvenience that we have to deploy this code once in order for the --refresh-db to be functional. This would make our next release awkward. I think we should move the code deploy earlier in ma:deploy so that the refresh-db happens after code is deployed. The current order has been inconvenient in the past as well.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
