### PR TITLE
Let CircleCI workflows trigger on cron without needing a pipeline param.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,6 @@ workflows:
   # Automation for deploy to CD environment and create a branch with Mayflower and Mass develop branch by using mayflower_develop_branch.
   # This will only happens on Sunday night 11 p.m. ETS to allow us to review Mayflower in Drupal on Mondays.
   mayflower_dev_branch:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - mayflower_develop_branch:
@@ -504,7 +503,6 @@ workflows:
   # This is to automate the creation of the release branch for Wednesday at 1 p.m. ET.
   # The cron time needs to be updated every Fall/Spring for daylight saving time.
   release_branch:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - cut_release_branch:
@@ -770,7 +768,6 @@ workflows:
 
   # Daily run of test suite using super sanitized DB
   build_test_super:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - test:
@@ -784,12 +781,11 @@ workflows:
             branches:
               only:
                 - develop
-                - night-super-sanitized3
+                - fix-triggers
 
   # Daily rebuild of our sanitized and super-sanitized mysql data images.
   # The cron time needs to be updated every Fall/Spring for daylight saving time.
   mysql_rebuild:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - populate:
@@ -812,7 +808,6 @@ workflows:
 
   # Daily deploy to the CD environment, runs at 11:00PM EST. Except for Sunday night the deploy_mayflower_cd uses the CD environment instead.
   deploy_cd:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - deploy:
@@ -835,10 +830,10 @@ workflows:
             branches:
               only:
                 - develop
+                - fix-triggers
 
   # Nightly pm:security, runs at 2:00AM EST.
   nightly_pending_security:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build
       - pending_security:
@@ -850,3 +845,4 @@ workflows:
               branches:
                   only:
                       - develop
+                      - fix-triggers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,11 +509,12 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "00 18 * * 3"
+          cron: "00 18 * * 4"
           filters:
             branches:
               only:
                 - develop
+                - fix-triggers
 
   # This is to automate the release branch only.
   release:
@@ -805,6 +806,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix-triggers
 
   # Daily deploy to the CD environment, runs at 11:00PM EST. Except for Sunday night the deploy_mayflower_cd uses the CD environment instead.
   deploy_cd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,6 @@ workflows:
 
   # Automation for deploy to CD environment and create a branch with Mayflower and Mass develop branch by using mayflower_dev branch only.
   deploy_mayflower_cd:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:
@@ -518,7 +517,6 @@ workflows:
 
   # This is to automate the release branch only.
   release:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:
@@ -568,7 +566,6 @@ workflows:
 
   # This is to automate the hotfix branch only.
   hotfix:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:
@@ -617,7 +614,6 @@ workflows:
 
   # This is to automate the mayflower branch only.
   mayflower:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:
@@ -667,7 +663,6 @@ workflows:
 
   # This is to tag the release in the GitHub repository
   build_github_tag:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:
@@ -705,7 +700,6 @@ workflows:
   # This is to tag the release in the Acquia repository.
   # This will deploy the newly created tag to stage environment and production environment with hold/approval for each job.
   build_tag:
-    when: << pipeline.parameters.post-trigger >>
     jobs:
       - build:
           filters:

--- a/changelogs/DP-17313.yml
+++ b/changelogs/DP-17313.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Fixed:
+  - description: Restore triggerred workflows at CircleCI
+    issue: DP-17313


### PR DESCRIPTION
**Description:**
Restores cutting of release branch, and other automated jobs.


**Jira:**
DP-17313


**To Test:**
- [ ] Review Circle logs and see if workflow `nightly_pending_security` ran last night. If yes its good.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
