### PR TITLE
DP-17273 add content moderation indices patch

### DIFF
--- a/changelogs/DP-17273.yml
+++ b/changelogs/DP-17273.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+  - description: Update content moderation indeces patch.
+    issue: DP-17273

--- a/patches/content-moderation-add-views-filter-indices.patch
+++ b/patches/content-moderation-add-views-filter-indices.patch
@@ -1,8 +1,8 @@
-diff --git a/core/modules/content_moderation/src/Plugin/views/filter/ModerationStateFilter.php b/core/modules/content_moderation/src/Plugin/views/filter/ModerationStateFilter.php
-index c658ef8759..29ceb9eddb 100644
---- a/core/modules/content_moderation/src/Plugin/views/filter/ModerationStateFilter.php
-+++ b/core/modules/content_moderation/src/Plugin/views/filter/ModerationStateFilter.php
-@@ -133,6 +133,15 @@ public function ensureMyTable() {
+diff --git a/core/modules/content_moderation/src/Plugin/views/ModerationStateJoinViewsHandlerTrait.php b/core/modules/content_moderation/src/Plugin/views/ModerationStateJoinViewsHandlerTrait.php
+index 3affab6..ee28090 100644
+--- a/core/modules/content_moderation/src/Plugin/views/ModerationStateJoinViewsHandlerTrait.php
++++ b/core/modules/content_moderation/src/Plugin/views/ModerationStateJoinViewsHandlerTrait.php
+@@ -35,6 +35,15 @@ trait ModerationStateJoinViewsHandlerTrait {
              'field' => 'content_entity_type_id',
              'value' => $left_entity_type->id(),
            ],


### PR DESCRIPTION
**Description:**
Update the content moderation views indeces patch to move the "extra" indeces to the `ModerationStateJoinViewsHandlerTrait`


**Jira:**
https://jira.mass.gov/browse/DP-DP-17273


**To Test:**
- [ ] Since this branch is based off of the `d88` branch you should be able to pull it down and just run `composer install`
- [ ] Verify the new patch ("patches/content-moderation-add-views-filter-indices.patch") applies cleanly


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
