### PR TITLE
DP-17286: Fix ma-refresh-local for Acquia V2 API

### DIFF
--- a/changelogs/DP-17286.yml
+++ b/changelogs/DP-17286.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+  - description: Resolves an issue where ma-refresh-local was unable to download the database over Acquia's V2 API.
+    issue: DP-17286

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -128,17 +128,12 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
       // This section resembles ma-refresh-local --db-prep-only. We don't call that
       // since we can't easily make Cloud API calls from Acquia servers, and we
       // don't need to sanitize here.
-      $process = Drush::drush($self, 'ma:latest-backup-url', ['prod']);
-      $process->mustRun();
-      $url = $process->getOutput();
-      $this->logger()->success('Backup URL retrieved.');
 
       // Download the latest backup.
       // Directory set by https://jira.mass.gov/browse/DP-12823.
       $tmp =  Path::join('/mnt/tmp', $_SERVER['REQUEST_TIME'] . '-db-backup.sql.gz');
-      $bash = ['wget', '-q', '--continue', trim($url), "--output-document=$tmp"];
-      $process = Drush::siteProcess($targetRecord, $bash);
-      $process->mustRun($process->showRealtime());
+      $process = Drush::drush($self, 'ma:latest-backup-download', ['prod', $tmp]);
+      $process->mustRun();
       $this->logger()->success('Database downloaded from backup.');
 
       // Drop all tables.

--- a/scripts/ma-refresh-local
+++ b/scripts/ma-refresh-local
@@ -128,11 +128,8 @@ function nonzero_exit() {
 function download_backup() {
     # Download backup using Acquia's Cloud API.
     echo "${HEADING}[+] Download latest database backup ${TEXTRESET}" | tee -a $LOGFILE_NAME
-    LATEST_BACKUP=`drush ma:latest-backup-url prod`
-    # Track download url in current log file.
-    echo $LATEST_BACKUP >> $LOGFILE_NAME
     echo
-    wget -q --continue $LATEST_BACKUP --output-document=$HOME/db-backup.sql.gz
+    drush ma:download-latest-backup prod $HOME/db-backup.sql.gz
     echo
 }
 
@@ -290,7 +287,7 @@ function main() {
     # Sanitize database.
     elif [[ "$1" = "-s" ]] || [[ "$1" = "--sanitize" ]]; then
         sanitize
-    
+
     # Super sanitize database.
     elif [[ "$1" = "-ss" ]] || [[ "$1" = "--super-sanitize" ]]; then
         super_sanitize


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR updates ma-refresh-local so that it downloads the database using PHP (over an authenticated connection).  Hopefully, this will be the last step toward finally resolving our broken backup situation. 


**Jira:**
https://jira.mass.gov/browse/DP-17286


**To Test:**
- [ ] Run `docker-compose exec drupal scripts/ma-refresh-local --db-prep-only`
- [ ] You should end up with a fresh copy of the production database imported into MySQL, and no errors should be thrown. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
