### PR TITLE
DP-17333 Add use statement to mass_serializer

### DIFF
--- a/changelogs/DP-17333.yml
+++ b/changelogs/DP-17333.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+  Fixed:
+  - description: Add missing "Entity\Media" class to fix `mass_serializer` cron job error.
+    issue: DP-17333

--- a/docroot/modules/custom/mass_serializer/src/Normalizer/MediaEntityDocumentNormalizer.php
+++ b/docroot/modules/custom/mass_serializer/src/Normalizer/MediaEntityDocumentNormalizer.php
@@ -6,6 +6,7 @@ use Drupal\Core\Url;
 use Drupal\Component\Utility\Unicode;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\file\Entity\File;
+use Drupal\media\Entity\Media;
 use Drupal\media\MediaInterface;
 use Drupal\serialization\Normalizer\ContentEntityNormalizer;
 use Drupal\taxonomy\TermStorage;


### PR DESCRIPTION


**Description:**
Cron job was failing. Now it isn't.


**Jira:**
https://jira.mass.gov/browse/DP-17333


**To Test:**
- [ ] See the error below and agree this is right fix.

```
In Process.php line 239:

  [Symfony\Component\Process\Exception\ProcessFailedException]
  The command "/mnt/www/html/massgov/vendor/drush/drush/drush mserc documents_by_filter 3326 --uri=https://www.mass.gov --root=/mnt/www/html/massgov/docroot" failed.

  Exit Code: 1(General error)

  Working directory:

  Output:
  ================
  Error: Class &#039;Drupal\mass_serializer\Normalizer\Media&#039; not found in Drupal\mass_serializer\Normalizer\MediaEntityDocumentNormalizer->normalize() (line 31
  6 of /mnt/www/html/massgov/docroot/modules/custom/mass_serializer/src/Normalizer/MediaEntityDocumentNormalizer.php).


  Error Output:
  ================
   [success] Beginning processing for endpoint (this could take a while)
   [success] View with offset: 0
   [warning] Drush command terminated abnormally.
```



---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
