### PR TITLE
DP-17047 modify mg_type metatag to support multiple values

### DIFF
--- a/changelogs/DP-17047.yml
+++ b/changelogs/DP-17047.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: Modify the mg_type metatag to support multiple values.
+    issue: DP-17047

--- a/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
+++ b/docroot/modules/custom/mass_site_map/src/Plugin/simple_sitemap/UrlGenerator/DocumentPagesUrlGenerator.php
@@ -92,11 +92,15 @@ class DocumentPagesUrlGenerator extends UrlGeneratorBase {
 
     if (isset($entity->field_document_type)) {
       /** @var \Drupal\taxonomy\Entity\Term $type_term */
-      $type_term = $entity->field_document_type->entity;
-      if (!empty($type_term)) {
+      $type_terms = $entity->field_document_type->referencedEntities();
+      $term_slugs = [];
+      foreach ($type_terms as $term) {
+        $term_slugs[] = $utility_service->slugify($term->getName());
+      }
+      if (!empty($term_slugs)) {
         $data['pagemap']['metatags'][] = [
           'name' => 'mg_type',
-          'value' => $utility_service->slugify($type_term->getName()),
+          'value' => implode(',', $term_slugs),
         ];
       }
     }


### PR DESCRIPTION
**Description:**
Modifies the mg_type metatag to support multiple values.


**Jira:**
https://jira.mass.gov/browse/DP-17047


**To Test:**

NOTE: I couldn't find an existing media entity where the `field_document_type` field had more than one value (I queried against the `media__field_document_type` table and there were no duplicate entries for the `entity_id` column or entries with a delta > 0).
- [ ] Chose an entity to test; for instance the first media entity listed with the `mg_type` attribute on the first page of the sitemap (for convenience sake/ease of finding later)
- [ ] Edit the media entity
- [ ] In the "Type" field select 2 or more types to be attributed to the entity
- [ ] Save the entity
- [ ] Regenerate the sitemap using `drush ss:generate`
- [ ] Find the media entity in the sitemap and verify the `mg_type` attribute lists all the "Types" you've selected, comma separated and slugified.


**Screenshots/GIFs:**
![2020-02-04_820x420](https://user-images.githubusercontent.com/4932789/73773110-8b1acf80-474f-11ea-8cdc-c8ec5b950ed3.png)

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
