### PR TITLE
Bring back drush ma:release command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,22 @@ parameters:
     type: boolean
     default: false
 
+  # These params for currently used in drush ma:release
+  ma-release:
+    type: boolean
+    default: false
+  refresh-db:
+    type: string
+    default: ""
+  skip-maint:
+    type: string
+    default: ""
+  target:
+    type: string
+    default: ""
+  git-ref:
+    type: string
+    default: ""
 jobs:
   trigger_workflows:
     docker:
@@ -807,6 +823,18 @@ workflows:
             branches:
               only:
                 - develop
+
+  # Usually triggerred by drush ma:release.
+  deploy_ad_hoc:
+    when: << pipeline.parameters.ma-release >>
+    jobs:
+      - build
+      - deploy:
+          requires: [build]
+          target: << pipeline.parameters.target >>
+          gitRef: << pipeline.parameters.git-ref >>
+          skip-maint: << pipeline.parameters.skip-maint >>
+          refresh-db: << pipeline.parameters.refresh-db >>
 
   # Daily deploy to the CD environment, runs at 11:00PM EST. Except for Sunday night the deploy_mayflower_cd uses the CD environment instead.
   deploy_cd:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,7 @@ workflows:
 
   # Automation for deploy to CD environment and create a branch with Mayflower and Mass develop branch by using mayflower_dev branch only.
   deploy_mayflower_cd:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:
@@ -540,6 +541,7 @@ workflows:
 
   # This is to automate the release branch only.
   release:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:
@@ -589,6 +591,7 @@ workflows:
 
   # This is to automate the hotfix branch only.
   hotfix:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:
@@ -637,6 +640,7 @@ workflows:
 
   # This is to automate the mayflower branch only.
   mayflower:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:
@@ -686,6 +690,7 @@ workflows:
 
   # This is to tag the release in the GitHub repository
   build_github_tag:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:
@@ -723,6 +728,7 @@ workflows:
   # This is to tag the release in the Acquia repository.
   # This will deploy the newly created tag to stage environment and production environment with hold/approval for each job.
   build_tag:
+    when: << pipeline.parameters.webhook >>
     jobs:
       - build:
           filters:

--- a/changelogs/DP-17243.yml
+++ b/changelogs/DP-17243.yml
@@ -1,0 +1,33 @@
+# Write your changelog entry here.  Every PR must have a changelog.
+#
+# You can use the following types:
+#   Added: For new features.
+#   Changed: For changes to existing functionality.
+#   Deprecated: For soon-to-be removed features.
+#   Removed: For removed features.
+#   Fixed: For any bug fixes.
+#   Security: In case of vulnerabilities.
+#
+# The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+# * All 3 parts are required: you must include type, description, and issue.
+# * Type must be left aligned and followed by a colon.
+# * Description must be indented 2 spaces.
+# * Issue must be indented 4 spaces.
+# * Issue should include just the Jira ticket number, not a URL.
+# * No extra spaces, indents, or blank lines are allowed.
+#
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type. Use the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+Added:
+  - description: Bring back ma:release command.
+    issue: DP-17243

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -96,9 +96,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     }
     $uri = "https://circleci.com/api/v2/project/github/massgov/openmass/pipeline";
     $options = [
-      'headers' => ['Accept' => 'application/json'],
       'auth' => [$token],
-      'form_params' => [
+      'json' => [
         'branch' => $options['ci-branch'],
         'parameters' => [
           'post-trigger' => FALSE,
@@ -106,8 +105,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
           'ma-release' => TRUE,
           'target' => $target,
           'git-ref' => $git_ref,
-          'skip-maint' => $options['skip-maint'] ? '--refresh-db' : '',
-          'refresh-db' => $options['refresh-db'] ? '--skip-maint' : '',
+          'skip-maint' => $options['skip-maint'] ? '--skip-maint' : '',
+          'refresh-db' => $options['refresh-db'] ? '--refresh-db' : '',
         ],
       ],
     ];
@@ -118,8 +117,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     }
 
     $body = json_decode((string)$response->getBody(), TRUE);
-    $id = $body['id'];
-    return $id;
+    $this->logger()->success('Pipeline ' . $body['id'] . ' is viewable at https://circleci.com/gh/massgov/openmass.');
   }
 
   /**


### PR DESCRIPTION
An old favorite Drush command is back. 

**Jira:**
https://jira.mass.gov/browse/DP-17243


**To Test:**
- [ ] Deploy this branch, then review its corresponding workflow in Circle to assure it succeeds: `dcdrush ma:release feature5 ma-release --ci-branch=ma-release --skip-maint --refresh-db  -v`. Or just see a green run from when I did it https://circleci.com/gh/massgov/openmass/3523

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
