### PR TITLE
Mayflower/DP-17239 mayflower version 9.39.2

### DIFF
--- a/changelogs/DP-17239.yml
+++ b/changelogs/DP-17239.yml
@@ -1,0 +1,35 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Changed:
+  - description: |-
+      Updated Mayflower version to 8.14.0.
+          - DP-16804: Change the state organizations menu from a button to a link directly to the page. (MF)
+    issue: DP-17239

--- a/composer.json
+++ b/composer.json
@@ -207,7 +207,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "guzzlehttp/guzzle": "^6.3",
-        "massgov/mayflower-artifacts": "9.36.0",
+        "massgov/mayflower-artifacts": "9.39.2",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "cb7ae9ef62e5dda620fdc406d3278901",
+    "content-hash": "5769e608b68b7ed3046fa24e126200f6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10387,16 +10387,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "9.36.0",
+            "version": "9.39.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "c99d3d7677865a96b440dd9f2fd8dadb70aa3964"
+                "reference": "0367add174d864b6bf744c3e8b2e385a2eb606a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/c99d3d7677865a96b440dd9f2fd8dadb70aa3964",
-                "reference": "c99d3d7677865a96b440dd9f2fd8dadb70aa3964",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/0367add174d864b6bf744c3e8b2e385a2eb606a0",
+                "reference": "0367add174d864b6bf744c3e8b2e385a2eb606a0",
                 "shasum": ""
             },
             "require": {
@@ -10414,7 +10414,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-01-07T18:50:30+00:00"
+            "time": "2020-02-04T18:39:10+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
## 9.39.2 (2/4/2020)
### Fixed
- (React, Patternlab) [Circle] Release tag error. (#922)

## 9.39.1 (2/4/2020)
### Fixed
- (React, Patternlab) [Circle] Hotfix release tag package install. (#922)
## 9.39.0 (2/4/2020)
### Changed
- (Patternlab) [UtilityNav] DP-16804: Change the state organizations menu from a button to a link directly to the page. (#882)
- (React) [Storybook] DP-17320: Config storybook to add Mayflower theme. (#915)
- (React) [Storybook] DP-17338: Render welcome page to Mayflower-react. (#916)
- (React) [Storybook] DP-17338: Display `Color` in category "Brand". (#916)
- (React) [Storybook] DP-17372: Organize all form components from atoms, molecules and organisms into a forms category. (#919) \n- Import paths from mayflower-react stay the same. No impact on the consumer side.
- (React) [Storybook] DP-17372: Move Placeholder component into atoms. (#919) \n- Import paths from mayflower-react stay the same. No impact on the consumer side.
### Added
- (React) [Color] DP-17253: Addded Color stories and color gradients. (#909)
