### PR TITLE
Fix how we read changelog-body.txt

### DIFF
--- a/changelogs/DP-17412.yml
+++ b/changelogs/DP-17412.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Fixed:
   - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
-    issue: DP-1234
+    issue: DP-17412

--- a/changelogs/DP-17412.yml
+++ b/changelogs/DP-17412.yml
@@ -37,5 +37,7 @@
 #    issue: DP-19843
 #
 Fixed:
-  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
+  - description: Fix how retrieve and push the release notes when tagging the master branch.
+    issue: DP-17412
+  - description: Edits and fixes to `template.yml` file used by developers to add a release note.
     issue: DP-17412

--- a/changelogs/DP-17412.yml
+++ b/changelogs/DP-17412.yml
@@ -1,15 +1,15 @@
 #
-# Write your changelog entry here. Every PR must have a changelog yml file.
+# Write your changelog entry here. Every pull request must have a changelog yml file.
 #
 # Change types:
 # #############################################################################
 # You can use one of the following types:
-#   Added: For new features.
-#   Changed: For changes to existing functionality.
-#   Deprecated: For soon-to-be removed features.
-#   Removed: For removed features.
-#   Fixed: For any bug fixes.
-#   Security: In case of vulnerabilities.
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
 #
 # Format
 # #############################################################################
@@ -17,7 +17,7 @@
 #  - All 3 parts are required and you must include "Type", "description" and "issue".
 #  - "Type" must be left aligned and followed by a colon.
 #  - "description" must be indented with 2 spaces followed by a colon
-#  - "issue" must be indented 4 spaces followed by a colon.
+#  - "issue" must be indented with 4 spaces followed by a colon.
 #  - "issue" is for the Jira ticket number only e.g. DP-1234
 #  - No extra spaces, indents, or blank lines are allowed.
 #

--- a/changelogs/template.yml
+++ b/changelogs/template.yml
@@ -1,15 +1,15 @@
 #
-# Write your changelog entry here. Every PR must have a changelog yml file.
+# Write your changelog entry here. Every pull request must have a changelog yml file.
 #
 # Change types:
 # #############################################################################
 # You can use one of the following types:
-#   Added: For new features.
-#   Changed: For changes to existing functionality.
-#   Deprecated: For soon-to-be removed features.
-#   Removed: For removed features.
-#   Fixed: For any bug fixes.
-#   Security: In case of vulnerabilities.
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
 #
 # Format
 # #############################################################################
@@ -17,7 +17,7 @@
 #  - All 3 parts are required and you must include "Type", "description" and "issue".
 #  - "Type" must be left aligned and followed by a colon.
 #  - "description" must be indented with 2 spaces followed by a colon
-#  - "issue" must be indented 4 spaces followed by a colon.
+#  - "issue" must be indented with 4 spaces followed by a colon.
 #  - "issue" is for the Jira ticket number only e.g. DP-1234
 #  - No extra spaces, indents, or blank lines are allowed.
 #
@@ -38,4 +38,4 @@
 #
 Type:
   - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
-    issue: DP-1234
+    issue: DP-****

--- a/scripts/tag-release-github
+++ b/scripts/tag-release-github
@@ -27,7 +27,9 @@ generate_post_data()
     "tag_name":"${TAG}",
     "target_commitish": "master",
     "name": "${TAG}",
-    "body": cat /scripts/changelog-body.txt >
+    "body": "$(cat /scripts/changelog-body.txt)"
+    "draft": false,
+    "prerelease": false
  }
 EOF
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes how we read changelog-body.txt to populate the body of the release tag on Github. It also adds `draft=false` and `prerelease: false`.

**Jira:**
https://jira.mass.gov/browse/DP-17412


**To Test:**
- Create a text file with some changelog content in a test or temp directory called `foo.txt`.
- Create a tag variable in your current shell session:
```
$ TAG="1.25.3"
```
- Paste the following code into your shell prompt
```
generate_post_data()
{
  cat <<EOF
{
    "tag_name":"${TAG}",
    "target_commitish": "master",
    "name": "${TAG}",
    "body": "$(cat foo.txt)"
 }
EOF
}
```
- Type `generate_post_data` <enter>
- You should be able to see the following content.
```
{
    "tag_name":"1.25.3",
    "target_commitish": "master",
    "name": "1.25.3",
    "body": "whatever content you pasted in the text test file"
 }
```

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
