### PR TITLE
DP-17413 home page related content display issue 

### DIFF
--- a/changelogs/DP-17413.yml
+++ b/changelogs/DP-17413.yml
@@ -1,0 +1,33 @@
+  # Write your changelog entry here.  Every PR must have a changelog.
+  #
+  # You can use the following types:
+  #   Added: For new features.
+  #   Changed: For changes to existing functionality.
+  #   Deprecated: For soon-to-be removed features.
+  #   Removed: For removed features.
+  #   Fixed: For any bug fixes.
+  #   Security: In case of vulnerabilities.
+  #
+  # The format is crucial. Please follow the examples below exactly. For reference, the requirements are:
+  # * All 3 parts are required: you must include type, description, and issue.
+  # * Type must be left aligned and followed by a colon.
+  # * Description must be indented 2 spaces.
+  # * Issue must be indented 4 spaces.
+  # * Issue should include just the Jira ticket number, not a URL.
+  # * No extra spaces, indents, or blank lines are allowed.
+  #
+  # Fixed:
+  #  - description: Fixes scrolling on edit pages in Safari.
+  #    issue: DP-13314
+  #
+  # You may add more than 1 description & issue for each type. Use the following format:
+  # Changed:
+  #  - description: Automating the release branch.
+  #    issue: DP-10166
+  #  - description: Second change item that needs a description.
+  #    issue: DP-19875
+  #  - description: Third change item that needs a description along with an issue.
+  #    issue: DP-19843
+Fixed:
+  - description: Fix the presentation issue of the related content in home page to always redner items with card no matter what conten types are added.
+    issue: DP-17413

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5063,11 +5063,17 @@ function _get_layout(array $total_type_with_count, $total_count) {
   // If all content is Service Pages, user actionCards.
   // If content is Right Rail and Stacked Layout, use actionCards.
   if (
-    $total_type_with_count['action'] == $total_count ||
-    $total_type_with_count['service_page'] == $total_count ||
-    $total_type_with_count['action'] + $total_type_with_count['stacked_layout'] == $total_count ||
-    $total_type_with_count['action'] + $total_type_with_count['how_to_page'] + $total_type_with_count['service_details'] == $total_count ||
-    $total_type_with_count['action'] + $total_type_with_count['how_to_page'] + $total_type_with_count['stacked_layout'] + $total_type_with_count['guide_page'] == $total_count
+    $total_type_with_count['guide_page'] +
+    $total_type_with_count['how_to_page'] +
+    $total_type_with_count['location'] +
+    $total_type_with_count['location_details'] +
+    $total_type_with_count['org_page'] +
+    $total_type_with_count['right-rail'] +
+    $total_type_with_count['service_page'] +
+    $total_type_with_count['service_details'] +
+    $total_type_with_count['stacked_layout'] +
+    $total_type_with_count['topic_page']
+    == $total_count
   ) {
     return 'actionCards';
   }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5066,13 +5066,8 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['action'] +
     $total_type_with_count['guide_page'] +
     $total_type_with_count['how_to_page'] +
-    $total_type_with_count['location'] +
-    $total_type_with_count['location_details'] +
-    $total_type_with_count['org_page'] +
-    $total_type_with_count['right-rail'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
-    $total_type_with_count['stacked_layout'] +
     $total_type_with_count['topic_page']
     == $total_count
   ) {

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5069,9 +5069,9 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['location'] +
     $total_type_with_count['location_details'] +
     $total_type_with_count['org_page'] +
-    $total_type_with_count['right-rail'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
+    $total_type_with_count['stacked_layout'] +
     $total_type_with_count['topic_page']
     == $total_count
   ) {

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5063,6 +5063,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
   // If all content is Service Pages, user actionCards.
   // If content is Right Rail and Stacked Layout, use actionCards.
   if (
+    $total_type_with_count['action'] +
     $total_type_with_count['guide_page'] +
     $total_type_with_count['how_to_page'] +
     $total_type_with_count['location'] +

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5066,6 +5066,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['action'] +
     $total_type_with_count['guide_page'] +
     $total_type_with_count['how_to_page'] +
+    $total_type_with_count['location'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
     $total_type_with_count['topic_page']

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5069,6 +5069,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['location'] +
     $total_type_with_count['location_details'] +
     $total_type_with_count['org_page'] +
+    $total_type_with_count['right-rail'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
     $total_type_with_count['topic_page']

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5067,6 +5067,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['guide_page'] +
     $total_type_with_count['how_to_page'] +
     $total_type_with_count['location'] +
+    $total_type_with_count['location_details'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
     $total_type_with_count['topic_page']

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5068,6 +5068,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
     $total_type_with_count['how_to_page'] +
     $total_type_with_count['location'] +
     $total_type_with_count['location_details'] +
+    $total_type_with_count['org_page'] +
     $total_type_with_count['service_page'] +
     $total_type_with_count['service_details'] +
     $total_type_with_count['topic_page']


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Render the related content paragraph in home page despite of any content types as "card" allowed to add to the paragraph.

- Count any added content types in the related content paragraph as allowed in the paragraph in the condition in `_get_layout()` in `mass_theme.theme` to have `$variables['layout'] = 'actionCards'` at L. 5038.


**Jira:**
https://jira.mass.gov/browse/DP-17413


**To Test:**
- [ ] Edit/add the **Related Content** under the **1up Stacked Row** in the **Rows** tab in Home page(3666).
- [ ] Add any combination of the following content types which allowed in the Related Content paragraph:
      - guide 
      - how to
      - location
      - location details
      - org page
      - right rail
      - service
      - service details
      - stacked layout
      - topic
- [ ] Check no matter what combination of content types added, the area is rendered as cards, no other format.
<img width="714" alt="Mass_gov" src="https://user-images.githubusercontent.com/9633303/73975741-f225b900-48f4-11ea-934c-0127da18eb55.png">


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
