### PR TITLE
DP-17054 Disallow query string in robots.txt

### DIFF
--- a/docroot/robots.txt
+++ b/docroot/robots.txt
@@ -64,3 +64,4 @@ Disallow: /index.php/user/register/
 Disallow: /index.php/user/login/
 Disallow: /index.php/user/logout/
 Disallow: /index.php/media/*
+Disallow: /*?auHash=


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
I added a line to the robots.txt file to disallow crawling of urls with "?auHash=".

**Jira:**
https://jira.mass.gov/browse/DP-17054

**To Test:**
I don't have any specific testing steps but here is a reference to confirm the matching pattern makes sense. 
https://developers.google.com/search/reference/robots_txt#url-matching-based-on-path-values



---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
