### PR TITLE
update pathologic config to include bare domain

### DIFF
--- a/changelogs/DP-16214.yml
+++ b/changelogs/DP-16214.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update configuration of pathologic module to include rewriting links to bare mass.gov domain.
+    issue: DP-16214

--- a/conf/drupal/config/pathologic.settings.yml
+++ b/conf/drupal/config/pathologic.settings.yml
@@ -4,6 +4,6 @@ scheme_whitelist:
   - files
   - internal
 protocol_style: path
-local_paths: "http://edit.mass.gov\r\nhttp://pilot.mass.gov\r\nhttp://www.mass.gov"
+local_paths: "http://edit.mass.gov\r\nhttp://pilot.mass.gov\r\nhttp://www.mass.gov\r\nhttp://mass.gov"
 _core:
   default_config_hash: EKYCulG-Y3pcObfUpVbl-D9T5DDX6d4hpQ-BVlSBAmw


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
update the confirmation of the pathologic module to include the bare mass.gov domain, so that if someone enters such a path, it will be corrected to point to the relative root of the current environment (e.g. https://www.mass.gov on production).


**Jira:**
https://jira.mass.gov/browse/DP-16214


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
