### PR TITLE
adjust config to suppress rabbit hole settings on 2 content types

### DIFF
--- a/changelogs/DP-17449.yml
+++ b/changelogs/DP-17449.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
+    issue: DP-****

--- a/changelogs/DP-17449.yml
+++ b/changelogs/DP-17449.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Type:
-  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
-    issue: DP-****
+  - description: Update configuration to suppress Rabbit hole settings on info details, promo page.
+    issue: DP-17449

--- a/changelogs/DP-17449.yml
+++ b/changelogs/DP-17449.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: Update configuration to suppress Rabbit hole settings on info details, promo page.
     issue: DP-17449

--- a/conf/drupal/config/rabbit_hole.behavior_settings.node_type_campaign_landing.yml
+++ b/conf/drupal/config/rabbit_hole.behavior_settings.node_type_campaign_landing.yml
@@ -6,6 +6,6 @@ dependencies:
     - node.type.campaign_landing
 id: node_type_campaign_landing
 action: display_page
-allow_override: 1
+allow_override: 0
 redirect: ''
 redirect_code: 301

--- a/conf/drupal/config/rabbit_hole.behavior_settings.node_type_info_details.yml
+++ b/conf/drupal/config/rabbit_hole.behavior_settings.node_type_info_details.yml
@@ -6,6 +6,6 @@ dependencies:
     - node.type.info_details
 id: node_type_info_details
 action: display_page
-allow_override: 1
+allow_override: 0
 redirect: ''
 redirect_code: 301


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Uncheck the box to permit overriding rabbit hole settings on the information details and promotional page content types


**Jira:**
https://jira.mass.gov/browse/DP-17449


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
