### PR TITLE
DP-17507 Read change log file from current path

### DIFF
--- a/changelogs/DP-17507.yml
+++ b/changelogs/DP-17507.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix the `cat` command call in `tag-release-github` to read `changelog-body.txt` correctly.
+    issue: DP-17507

--- a/scripts/tag-release-github
+++ b/scripts/tag-release-github
@@ -27,7 +27,7 @@ generate_post_data()
     "tag_name":"${TAG}",
     "target_commitish": "master",
     "name": "${TAG}",
-    "body": "$(cat /scripts/changelog-body.txt)"
+    "body": "$(cat ./scripts/changelog-body.txt)"
     "draft": false,
     "prerelease": false
  }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes how we read the changelog file to populate the GitHub tag description body. The command is invoked via `scripts/tag-release-github` within CircleCI's `config.yml`. Previously, the failing command was `cat /scripts/changelog-body.txt`.


**Jira:**
https://jira.mass.gov/browse/DP-17507


**To Test:**
- [x] Locally, run the command `cat ./scripts/changelog-body.txt` from the root of the project.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
