### PR TITLE
DP-17546: Make Backstop more reliable

### DIFF
--- a/backstop/scripts/before.js
+++ b/backstop/scripts/before.js
@@ -7,10 +7,49 @@ module.exports = async (page, scenario, vp) => {
     page.on('request', interceptRequest);
 }
 
-// Block scripts that can cause problems or do analytics tracking.
-const banned = /(www\.googletagmanager\.com|script\.crazyegg\.com|google-analytics\.com|js-agent\.newrelic\.com|translate\.google\.com)/
+function escapeRegexp(string) {
+  return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
+}
+
+const banned = [
+  'www.googletagmanager.com',
+  'script.crazyegg.com',
+  'www.google-analytics.com',
+  'js-agent.newrelic.com',
+  'translate.google.com',
+  'foresee.com',
+  'www.youtube.com',
+  'bam.nr-data.net',
+  'maps.googleapis.com',
+  '9p83os0fkf.execute-api.us-east-1.amazonaws.com/v1/waittime'
+];
+// Block scripts that do analytics tracking, have side effects based on
+// domain, or cause timeouts on page load because they load in lots of extra
+// stuff.
+const bannedRE = new RegExp(banned.map(escapeRegexp).join('|'))
+
 async function interceptRequest(request) {
-    if(banned.test(request.url())) {
+    let urlMatch;
+
+    // Replace static maps with a placeholder image of the same size.
+    if(urlMatch = request.url().match(/maps\.googleapis\.com\/maps\/api\/staticmap.*size=(\d+x\d+)/)) {
+      request.respond({
+        status: 301,
+        headers: {"Location": `https://via.placeholder.com/${urlMatch[1]}/B2DEA2.png?text=Static%20Map`}
+      })
+      return
+    }
+    // Replace hero images with placeholder images. Hero images can be randomized, so we just
+    // replace them with their
+    if(urlMatch = request.url().match(/\/files\/styles\/hero(\d+x\d+)/)) {
+      request.respond({
+        status: 301,
+        headers: {Location: `https://via.placeholder.com/${urlMatch[1]}.png?text=Hero%20Image`}
+      })
+      return;
+    }
+
+    if(bannedRE.test(request.url())) {
         request.abort()
     } else {
         request.continue()

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -39,13 +39,10 @@ module.exports = async function(page, scenario, vp) {
         '}' +
         // Kill google Maps (show a green box instead)
         // .js-google-map for dynamic maps
-        // .ma__google-map__map.static-image for static images
-        '.js-google-map,\n' +
-        '.ma__google-map__map.static-image {' +
+        '.js-google-map {' +
         '  position: relative;' +
         '}' +
-        '.js-google-map:before,\n' +
-        '.ma__google-map__map.static-image:before {' +
+        '.js-google-map:before {' +
         '  background: #B2DEA2;\n' +
         '  content: \' \';\n' +
         '  display: block;\n' +
@@ -70,10 +67,6 @@ module.exports = async function(page, scenario, vp) {
         '  right: 0;\n' +
         '  bottom: 0;\n' +
         '  z-index: 3;\n' +
-        '}' +
-        // Kill random background image on homepage.
-        '#GUID935283478 {' +
-        '  background: #B2DEA2 !important;\n' +
         '}'
     });
 
@@ -85,6 +78,12 @@ module.exports = async function(page, scenario, vp) {
       jQuery.fx.off = true;
       // Immediately complete any in-progress animations.
       jQuery(':animated').finish();
+
+      // Undo the Google Optimize page-hiding snippet so we can access the page
+      // before the 2s timeout. See https://developers.google.com/optimize.
+      if(window.dataLayer && window.dataLayer.hide && window.dataLayer.hide.end) {
+        window.dataLayer.hide.end();
+      }
 
       // Replace random image credit on homepage.
       document.querySelectorAll('.ma__search-banner__image-name').forEach(function(e) {
@@ -100,9 +99,9 @@ module.exports = async function(page, scenario, vp) {
     // in local environments.
     await page.waitForFunction('jQuery.active == 0');
 
-    // Add a slight delay.  This covers up some of the jitter caused
-    // by weird network conditions, slow javascript, etc. We should
-    // work to reduce this number, since it represents instability
-    // in our styling.
-    await page.waitFor(2000);
+    // We can add a slight delay here. This can cover up jitter caused
+    // by weird network conditions, slow JS, etc, but if we need an extra
+    // delay after page load, it probably indicates there's a problem with
+    // performance.
+    // await page.waitFor(2000);
 }

--- a/changelogs/DP-17546.yml
+++ b/changelogs/DP-17546.yml
@@ -1,0 +1,47 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update BackstopJS to the latest stable version (4.4.2)
+    issue: DP-17546
+  - description: Speed up Backstop tests by removing the delay.
+    issue: DP-17546
+Fixed:
+  - description: Fix false positives for Google Maps in Backstop tests by hot-swapping images with placeholders.
+    issue: DP-17546
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       - BLACKFIRE_SERVER_TOKEN
 
   backstop:
-    image: "backstopjs/backstopjs:v3.9.2"
+    image: "backstopjs/backstopjs:4.4.2"
     volumes:
       - ./backstop:/src
     shm_size: 1gb


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR implements several changes to make Backstop testing more reliable:
1. Block Google Maps API requests outright.  This prevents us from using up map credits.
2. Replace Google Maps static images with placeholders. This makes the maps "look ok" to backstop in any environment, including ones that don't have the maps API setup.
3. Block Youtube requests outright. This fixes an issue where pages containing Youtube videos were timing out. 
3. Block the wait time AJAX request outright. Now the wait time widgets will always say "Unavailable", making them consistent for testing. 
4. Replace hero images with placeholders across the board. We used to only do this for the homepage (where they're random), but I've noticed some spurious diffs from images being partially loaded that are resolved by using a very lightweight placeholder.
5. Fixes an issue where the page could not be rendered in less than 2 seconds because we implement Google Optimize's asynchronous hiding snippet to hide the page until Optimize experiments are loaded.  Removing this allows us to snapshot the page a lot faster. 
6. Remove the extra 2s delay on page load.  This just isn't necessary, and slows down testing. 
7. Updates Backstop to the latest stable version for additional stability and performance.


**Jira:**
https://jira.mass.gov/browse/DP-17546


**To Test:**
- [ ] Run `ahoy backstop reference --target=prod`
- [ ] Run `ahoy backstop test --target=cd`
- [ ] Observe that any diffs that are shown are the result of content changes, not Backstop related issues. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
