### PR TITLE
DP-17571: Fix super-sanitized database build after 8.8 update

### DIFF
--- a/changelogs/DP-17571.yml
+++ b/changelogs/DP-17571.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes nightly super-sanitized database build that broke following 8.8 update.
+    issue: DP-17571

--- a/lib/Sanitation/SqlEntitySanitizer.php
+++ b/lib/Sanitation/SqlEntitySanitizer.php
@@ -167,7 +167,7 @@ class SqlEntitySanitizer {
     // Delete all records from the revision data table that aren't in the
     // active set.
     if ($revisionDataTable = $mapping->getRevisionDataTable()) {
-      $this->database->delete($mapping->getRevisionDataTable())
+      $this->database->delete($revisionDataTable)
         ->condition($type->getKey('revision'), $okIds, 'NOT IN')
         ->execute();
     }

--- a/lib/Sanitation/SqlEntitySanitizer.php
+++ b/lib/Sanitation/SqlEntitySanitizer.php
@@ -85,31 +85,39 @@ class SqlEntitySanitizer {
       return;
     }
 
+    // Determine the name of the table that contains the published/status col.
+    $dataTable = $mapping->getFieldTableName($type->getKey('published'));
+    $baseTable = $mapping->getBaseTable();
+
     // First delete all unpublished records from the base data table.
-    $count = $this->database->delete($mapping->getDataTable())
+    $count = $this->database->delete($dataTable)
       ->condition($type->getKey('published'), 0)
       ->execute();
     $this->logger->info("Deleting $count unpublished {$type->id()} entities.");
 
     // Select the set of content that's left over. This is the "OK" set, which
     // we'll use as a whitelist when clearing data out of other tables.
-    $okIds = $this->database->select($mapping->getDataTable(), 'b')
+    $okIds = $this->database->select($dataTable, 'b')
       ->fields('b', [$type->getKey('id')]);
 
-    // Clean the base table.
-    $this->database->delete($mapping->getBaseTable())
-      ->condition($type->getKey('id'), $okIds, 'NOT IN')
-      ->execute();
+    // Clean the base table, if necessary.
+    if ($dataTable !== $baseTable) {
+      $this->database->delete($mapping->getBaseTable())
+        ->condition($type->getKey('id'), $okIds, 'NOT IN')
+        ->execute();
+    }
     if ($type->isRevisionable()) {
       // Clean the revision table.
       $this->database->delete($mapping->getRevisionTable())
         ->condition($type->getKey('id'), $okIds, 'NOT IN')
         ->execute();
 
-      // Clean the revision data table.
-      $this->database->delete($mapping->getRevisionDataTable())
-        ->condition($type->getKey('id'), $okIds, 'NOT IN')
-        ->execute();
+      // Clean the revision data table, if there is one.
+      if ($revisionDataTable = $mapping->getRevisionDataTable()) {
+        $this->database->delete($revisionDataTable)
+          ->condition($type->getKey('id'), $okIds, 'NOT IN')
+          ->execute();
+      }
     }
 
     // Delete all records from field data tables that don't have a matching
@@ -158,9 +166,11 @@ class SqlEntitySanitizer {
 
     // Delete all records from the revision data table that aren't in the
     // active set.
-    $this->database->delete($mapping->getRevisionDataTable())
-      ->condition($type->getKey('revision'), $okIds, 'NOT IN')
-      ->execute();
+    if ($revisionDataTable = $mapping->getRevisionDataTable()) {
+      $this->database->delete($mapping->getRevisionDataTable())
+        ->condition($type->getKey('revision'), $okIds, 'NOT IN')
+        ->execute();
+    }
 
     // Finally, delete all records from every field table that aren't in the
     // active set.


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes our nightly "super sanitized" database build, which broke after the 8.8 update.  See this build for the failure it resolves: https://circleci.com/gh/massgov/openmass/4823

Basically, our sanitization process wasn't equipped to deal with the new `path_alias` entity, which has a status field that's on the "base" table, and has no "field data" or "revision field data" table.  This PR lets the table mapping object (which knows about all the tables and columns for an entity) tell us which table to use when limiting by the "published" column.  It also adds a guard to the revision field data deletion query to make sure the entity type has a revision field data table before attempting to delete from it.    

**Jira:**
https://jira.mass.gov/browse/DP-17571


**To Test:**
- [ ] Run `drush sql-sanitize --sanitize-entities -vvv` and ensure it completes. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
