### PR TITLE
DP-17557 fix sorting on location listing pages

### DIFF
--- a/changelogs/DP-17557.yml
+++ b/changelogs/DP-17557.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed sorting on location listing pages.
+    issue: DP-17557

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -135,6 +135,7 @@ class MapLocationFetcher {
       // Populate the googleMap.markers and imagePromos data structures.
       $locations['googleMap']['markers'][$key]['infoWindow'] = $locations['imagePromos']['items'][$key]['infoWindow'];
       $locations['googleMap']['markers'][$key]['infoWindow']['name'] = Link::fromTextAndUrl($node->getTitle(), $node->toUrl())->toString();
+      $locations['googleMap']['markers'][$key]['infoWindow']['plain_text_title'] = $node->getTitle();
       $locations['googleMap']['markers'][$key]['infoWindow']['description'] = $node->hasField('field_lede') ? $node->field_lede->value : NULL;
       unset($locations['imagePromos']['items'][$key]['infoWindow']);
 
@@ -280,8 +281,17 @@ class MapLocationFetcher {
     // Sort map markers alphabetically by infoWindow Name by default.
     if (!empty($locations['googleMap']['markers'])) {
       usort($locations['googleMap']['markers'], function ($a, $b) {
-        return strcmp($a['infoWindow']['name'], $b['infoWindow']['name']);
+        return strcmp($a['infoWindow']['plain_text_title'], $b['infoWindow']['plain_text_title']);
       });
+    }
+
+    $gmap = [];
+    foreach ($locations['googleMap']['markers'] as $marker) {
+      $gmap[] = $marker['infoWindow']['name'];
+    }
+    $pi = [];
+    foreach ($locations['imagePromos']['items'] as $we) {
+      $pi[] = $we['title']['text'];
     }
 
     // Scaffold out pagination data structure.

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -285,15 +285,6 @@ class MapLocationFetcher {
       });
     }
 
-    $gmap = [];
-    foreach ($locations['googleMap']['markers'] as $marker) {
-      $gmap[] = $marker['infoWindow']['name'];
-    }
-    $pi = [];
-    foreach ($locations['imagePromos']['items'] as $we) {
-      $pi[] = $we['title']['text'];
-    }
-
     // Scaffold out pagination data structure.
     // See @molecules/pagination.md
     $pages = [


### PR DESCRIPTION
**Description:**
Fixes the alphabetical sort for node titles on location listings by adding a plain text index in place of a link.


**Jira:**
https://jira.mass.gov/browse/DP-17557


**To Test:**
See [ticket comment ](https://jira.mass.gov/browse/DP-17557?focusedCommentId=317299&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-317299)for API key instructions.
- [ ] Go to a [location listing page|http://mass.local/sexual-assault-and-rape-services/locations]
- [ ] Enter the zipcode 01118
- [ ] Verify the first result is "YWCA of Western Massachusetts" in Springfield
- [ ] Clear the results
- [ ] Enter the zipcode 02215
- [ ] Verify the first result is "Violence Recovery Program at Fenway Health" in Boston


**Screenshots/GIFs:**
Production site (searching 01118 zipcode):
![2020-03-02_1452x903](https://user-images.githubusercontent.com/4932789/75692111-0e5a1300-5c73-11ea-8acd-43233915e904.png)
1st result is for Fall River.

Local site (searching 01118 zipcode):
![2020-03-02_1434x907](https://user-images.githubusercontent.com/4932789/75692066-fbdfd980-5c72-11ea-8f9a-ee21178c9442.png)
1st result is for Springfield.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
