### PR TITLE
DP-17185 add download redirect with media alias is updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
         type: string
         default: "/var/www/code/drush/sites/self.site.yml"
     steps:
-      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_DS_INFRASTRUCTURE_TOKEN@raw.githubusercontent.com/massgov/DS-Infrastructure/develop/docs/massgov/self.site.yml"
+      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_SELF_SITE_YML_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
 
 # See https://medium.com/labs42/monorepo-with-circleci-conditional-workflows-69e65d3f1bd0
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
         type: string
         default: "/var/www/code/drush/sites/self.site.yml"
     steps:
-      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_SELF_SITE_YML_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
+      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_BOT_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
 
 # See https://medium.com/labs42/monorepo-with-circleci-conditional-workflows-69e65d3f1bd0
 parameters:
@@ -179,7 +179,8 @@ jobs:
     <<: *container_config
     steps:
       - attach_workspace: {at: /var/www}
-      - run: yarn danger ci --failOnErrors
+      - run:
+          command: "DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/changelogs/DP-17185.yml
+++ b/changelogs/DP-17185.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Add a redirect to the media download link when a media alias is changed.
+    issue: DP-17185

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -28,6 +28,7 @@ use Drupal\node\Entity\Node;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\user\Entity\User;
+use Drupal\redirect\Entity\Redirect;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -1287,5 +1288,27 @@ function mass_utility_inline_entity_form_entity_form_alter(&$entity_form, &$form
     // Set the default value to published.
     $entity_form['moderation_state']['widget'][0]['state']['#default_value'] = 'published';
 
+  }
+}
+
+/**
+ * Implements hook_path_update().
+ *
+ * Update the media download link when a media entity alias is updated.
+ */
+function mass_utility_path_update(array $path) {
+  if ($path['alias'] != $path['original']['alias']) {
+    $params = Url::fromUserInput($path['source'])->getRouteParameters();
+    if (isset($params['media'])) {
+      $og_document_alias = $path['original']['alias'] . '/download';
+      if (!redirect_repository()->findMatchingRedirect($og_document_alias, [], $path['original']['langcode'])) {
+        $redirect = Redirect::create();
+        $redirect->setSource($og_document_alias);
+        $redirect->setRedirect($path['source'] . '/download');
+        $redirect->setLanguage($path['original']['langcode']);
+        $redirect->setStatusCode(\Drupal::config('redirect.settings')->get('default_status_code'));
+        $redirect->save();
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description:**
Creates a new redirect when a media path alias is updated.


**Jira:**
https://jira.mass.gov/browse/DP-17185


**To Test:**
- [ ] Add a link to a media entity to a WYSIWYG field
- [ ] Verify you can get to the /download URL for the entity
- [ ] Edit the media entity and change the title to automatically update the path alias
- [ ] Revisit the embedded link and verify it still directs to the /download page
- [ ] Additionally, you can search for the redirect in `admin/config/search/redirect`
  - enter the old path to the media entity in the "From" search field or the new path in the "To" search field.
  - verify the redirect has been created for both the entity's "view" page (/doc/[media-title]) and it's download page (/doc/[media-title]/download).


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
