### PR TITLE
DP-17564 fix GitHub tagging issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
         type: string
         default: "/var/www/code/drush/sites/self.site.yml"
     steps:
-      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_DS_INFRASTRUCTURE_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
+      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_SELF_SITE_YML_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
 
 # See https://medium.com/labs42/monorepo-with-circleci-conditional-workflows-69e65d3f1bd0
 parameters:

--- a/changelogs/DP-17564.yml
+++ b/changelogs/DP-17564.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Fix how we read "changelog-body.txt" and publish the release tag on Github.
+    issue: DP-17564

--- a/changelogs/DP-17564.yml
+++ b/changelogs/DP-17564.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Fixed:
   - description: Fix how we read "changelog-body.txt" and publish the release tag on Github.
     issue: DP-17564

--- a/scripts/tag-release-github
+++ b/scripts/tag-release-github
@@ -39,4 +39,5 @@ EOF
 }
 
 # Create a release on GitHub for the tag that was just created.
-curl --fail -u massgov-bot:${GITHUB_MASSGOV_BOT_TOKEN} -H "Content-Type:application/json" -X POST https://api.github.com/repos/massgov/openmass/releases --data "$(generate_post_data)"
+curl -X POST --data "$(generate_post_data)" --fail -u massgov-bot:"${GITHUB_MASSGOV_BOT_TOKEN}" -H "Content-Type:application/json" https://api.github.com/repos/massgov/openmass/releases
+

--- a/scripts/tag-release-github
+++ b/scripts/tag-release-github
@@ -19,18 +19,22 @@ echo $TAG
 # Tag the master branch
 git tag $TAG
 
+# Use AWK's output record separator (ORS) to avoid JSON parsing issue.
+# https://linux.die.net/man/1/awk
+cat ./scripts/changelog-body.txt |  awk '{print}' ORS='\\n' > /tmp/changelog-body.txt
+
 # Create post data
 generate_post_data()
 {
   cat <<EOF
-{
-    "tag_name":"${TAG}",
-    "target_commitish": "master",
-    "name": "${TAG}",
-    "body": "$(cat ./scripts/changelog-body.txt)"
-    "draft": false,
-    "prerelease": false
- }
+  {
+  "tag_name": "${TAG}",
+  "target_commitish": "master",
+  "name": "${TAG}",
+  "body": "$(cat /tmp/changelog-body.txt)",
+  "draft": false,
+  "prerelease": false
+  }
 EOF
 }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes how we read the `changelog-body.txt` by adding new lines `\n` before building the JSON object used in the curl POST. Previously, this was causing a JSON parsing error.


**Jira:**
https://jira.mass.gov/browse/DP-17564


**To Test:**
- [ ] Generate a GitHub token for testing purposes and remember to delete it later!
- [ ] Overwrite the content of `tag-release-github` with the code below
```
#!/usr/bin/env bash

# exit when any command fails
set -e

GITHUB_MASSGOV_BOT_TOKEN="**********************************"

# Use AWK's output record separator (ORS) to avoid JSON parsing issue.
# https://linux.die.net/man/1/awk
cat ./scripts/changelog-body.txt |  awk '{print}' ORS='\\n' > /tmp/changelog-body.txt

# Create post data
generate_post_data()
{
  cat <<EOF
  {
  "tag_name": "${TAG}",
  "target_commitish": "master",
  "name": "${TAG}",
  "body": "$(cat /tmp/changelog-body.txt)",
  "draft": false,
  "prerelease": false
  }
EOF
}

# Create a release on GitHub for the tag that was just created.
curl -X POST --data "$(generate_post_data)" --fail -u massgov-bot:"${GITHUB_MASSGOV_BOT_TOKEN}" -H "Content-Type:application/json" https://api.github.com/repos/<YOUR_GITHUB_ID>/<YOUR_GITHUB_PROJECT>/releases
```

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
- [ ] Execute the script 
- [ ] This should have created a release tag on one of your projects.