### PR TITLE
Dp 17564 consolidate tokens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ commands:
         type: string
         default: "/var/www/code/drush/sites/self.site.yml"
     steps:
-      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_SELF_SITE_YML_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
+      - run: "curl -f -o << parameters.destination >> -L https://$GITHUB_MASSGOV_BOT_TOKEN@raw.githubusercontent.com/massgov/massgov-internal-docs/master/self.site.yml"
 
 # See https://medium.com/labs42/monorepo-with-circleci-conditional-workflows-69e65d3f1bd0
 parameters:
@@ -179,7 +179,10 @@ jobs:
     <<: *container_config
     steps:
       - attach_workspace: {at: /var/www}
-      - run: yarn danger ci --failOnErrors
+      - run:
+          command: yarn danger ci --failOnErrors
+          environment:
+            DANGER_GITHUB_API_TOKEN: $GITHUB_MASSGOV_BOT_TOKEN
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,10 @@ jobs:
     steps:
       - attach_workspace: {at: /var/www}
       - run:
+          command: echo $FOO
+          environment:
+            FOO: $AC_API_USER
+      - run:
           command: yarn danger ci --failOnErrors
           environment:
             DANGER_GITHUB_API_TOKEN: "$GITHUB_MASSGOV_BOT_TOKEN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,13 +180,7 @@ jobs:
     steps:
       - attach_workspace: {at: /var/www}
       - run:
-          command: echo $FOO
-          environment:
-            FOO: $AC_API_USER
-      - run:
-          command: yarn danger ci --failOnErrors
-          environment:
-            DANGER_GITHUB_API_TOKEN: "$GITHUB_MASSGOV_BOT_TOKEN"
+          command: "DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
       - run:
           command: yarn danger ci --failOnErrors
           environment:
-            DANGER_GITHUB_API_TOKEN: $GITHUB_MASSGOV_BOT_TOKEN
+            DANGER_GITHUB_API_TOKEN: "$GITHUB_MASSGOV_BOT_TOKEN"
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/changelogs/DP-17564-2.yml
+++ b/changelogs/DP-17564-2.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Consolidate Github API token usage to reduce the number of secrets we need to manage in CircleCI.
+    issue: DP-17564

--- a/changelogs/DP-17564.yml
+++ b/changelogs/DP-17564.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Consolidate Github API token usage to reduce the number of secrets we need to manage in CircleCI.
+    issue: DP-17564


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR removes our need for the `DANGER_GITHUB_API_TOKEN`, `GITHUB_MASSGOV_SELF_SITE_YML_TOKEN`, and `GITHUB_TOKEN` environment variables in CircleCI, preferring instead `GITHUB_MASSGOV_BOT_TOKEN`.  

Once this PR is merged, and at least 24 hours have passed (to allow rerunning builds within 24 hours), the following secrets should be deleted from CircleCI:
```
DANGER_GITHUB_API_TOKEN
GITHUB_MASSGOV_SELF_SITE_YML_TOKEN
GITHUB_TOKEN
AC_API_KEY (NOTE: Keep AC_API_USER for now, because we use it in determining who's deploying in New Relic).
```
 

**Jira:**
https://jira.mass.gov/browse/DP-17564


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
