### PR TITLE
DP-17682 update mayflower version to 9.42.0

### DIFF
--- a/changelogs/DP-17682.yml
+++ b/changelogs/DP-17682.yml
@@ -1,0 +1,47 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+      Updated Mayflower version to 9.42.0.
+         - DP-15035: Limit pagination output to 10 items. (MF)
+         - DP-17258: Fix "see more" button not appearing after the TOC. (MF)
+         - DP-17532: Added lighter lightest darker darkest variables consistently across all brand colors, adjusted the variable labels in the storybook. (MF)
+         - DP-17651: Added @massds/mayflower-tokens package to auto release, keeping versioning consistent with other mayflower npm packages. (MF)
+         - DP-17652: Added step to bump version in package.json. (MF)
+    issue: DP-17682

--- a/composer.json
+++ b/composer.json
@@ -208,7 +208,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "guzzlehttp/guzzle": "^6.3",
-        "massgov/mayflower-artifacts": "9.40.2",
+        "massgov/mayflower-artifacts": "9.42.0",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b27e5448b75ec109425e47b625ebd9a5",
+    "content-hash": "f530eaf31178a354ed2530582d1c043c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10440,16 +10440,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "9.40.2",
+            "version": "9.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "d9161f783a14c015a034a47b86a78f03e3a065f9"
+                "reference": "24b497d23a208e91de76a5be583edaaffd365a82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d9161f783a14c015a034a47b86a78f03e3a065f9",
-                "reference": "d9161f783a14c015a034a47b86a78f03e3a065f9",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/24b497d23a208e91de76a5be583edaaffd365a82",
+                "reference": "24b497d23a208e91de76a5be583edaaffd365a82",
                 "shasum": ""
             },
             "require": {
@@ -10467,7 +10467,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-02-21T18:45:57+00:00"
+            "time": "2020-03-03T18:40:05+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
## 9.42.0 (3/3/2020)
### Fixed 
- (Patternlab) [Location-listing] DP-15035: Limit pagination output to 10 items

### Changed 
- (Patternlab) [StickyTOC] DP-17258: Fix "see more" button not appearing after the TOC

### Added 
- (Assets) [scripts] DP-17532: Added a build step to map the src to a different structure for distribution `npm run build` and restructured `mayflower-token` package content in a `dist` folder. (#948)
- (Assets) [SCSS] DP-17532: Added `lighter` `lightest` `darker` `darkest` variables consistently across all brand colors, adjusted the variable labels in the storybook. (#948)
- (Assets) [CircleCI] DP-17651: Added @massds/mayflower-tokens package to auto release, keeping versioning consistent with other mayflower npm packages.(#949)
- (React, Patternlab, Assets) [Auto Release] DP-17652: Added step to bump version in package.json. (#956)

**Jira:**
https://jira.mass.gov/browse/DP-17682


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
