### PR TITLE
DP-17535 Remove ability to create document on IEF form in List item document paragraph

### DIFF
--- a/changelogs/DP-17535.yml
+++ b/changelogs/DP-17535.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Remove ability to create documents inline on a Curated List node.
+    issue: DP-17535

--- a/composer.json
+++ b/composer.json
@@ -319,7 +319,8 @@
             },
             "drupal/inline_entity_form": {
                 "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)":
-                "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch"
+                "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch",
+                "Add a setting to enable/disable inline editing of existing entities": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
             },
             "drupal/key": {
                 "Stop adding 'extensions' cache tag on unrelated config objects (https://www.drupal.org/project/key/issues/3080971)": "https://www.drupal.org/files/issues/2019-09-12/no-tag_1.patch"

--- a/composer.json
+++ b/composer.json
@@ -318,9 +318,8 @@
                 "Large amount of fields causes tab functionality to break": "https://www.drupal.org/files/issues/2019-03-28/large-amount-fields-3044224-2.patch"
             },
             "drupal/inline_entity_form": {
-                "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)":
-                "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch",
-                "Add a setting to enable/disable inline editing of existing entities": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
+                "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)": "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch",
+                "Add a setting to enable/disable inline editing of existing entities (https://www.drupal.org/project/inline_entity_form/issues/2913571#comment-12811088)": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
             },
             "drupal/key": {
                 "Stop adding 'extensions' cache tag on unrelated config objects (https://www.drupal.org/project/key/issues/3080971)": "https://www.drupal.org/files/issues/2019-09-12/no-tag_1.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f530eaf31178a354ed2530582d1c043c",
+    "content-hash": "20d18e745b20956b7a044e25861e50f7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2643,10 +2643,6 @@
                     "homepage": "https://www.drupal.org/user/386230"
                 },
                 {
-                    "name": "jsacksick",
-                    "homepage": "https://www.drupal.org/user/972218"
-                },
-                {
                     "name": "mglaman",
                     "homepage": "https://www.drupal.org/user/2416470"
                 },
@@ -3141,16 +3137,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1461060840"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3165,7 +3157,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3617,10 +3609,6 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
-                },
-                {
                     "name": "slashrsm",
                     "homepage": "https://www.drupal.org/user/744628"
                 },
@@ -3632,7 +3620,7 @@
             "description": "Provides storage and API for image crops.",
             "homepage": "https://www.drupal.org/project/crop",
             "support": {
-                "source": "https://git.drupalcode.org/project/crop",
+                "source": "http://cgit.drupalcode.org/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
             }
         },
@@ -4250,7 +4238,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1536250980",
+                    "datestamp": "1516093086",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4981,21 +4969,21 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1504182544",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1485942783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "fabianderijk",
                     "homepage": "https://www.drupal.org/user/278745"
+                },
+                {
+                    "name": "msankhala",
+                    "homepage": "https://www.drupal.org/user/882726"
                 },
                 {
                     "name": "tomvv",
@@ -5005,7 +4993,7 @@
             "description": "Interface for unblocking ip's that are blocked by the flood table",
             "homepage": "https://www.drupal.org/project/flood_unblock",
             "support": {
-                "source": "https://git.drupalcode.org/project/flood_unblock"
+                "source": "http://cgit.drupalcode.org/flood_unblock"
             }
         },
         {
@@ -5036,7 +5024,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta6",
-                    "datestamp": "1553270584",
+                    "datestamp": "1519932484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5056,7 +5044,7 @@
             "description": "Allows users to specify the focal point of an image for use during cropping.",
             "homepage": "https://www.drupal.org/project/focal_point",
             "support": {
-                "source": "https://git.drupalcode.org/project/focal_point"
+                "source": "http://cgit.drupalcode.org/focal_point"
             }
         },
         {
@@ -5326,16 +5314,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1519597081",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1494796685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5354,7 +5338,7 @@
             "description": "Defines a field type for Google Maps.",
             "homepage": "https://www.drupal.org/project/google_map_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_map_field"
+                "source": "http://cgit.drupalcode.org/google_map_field"
             }
         },
         {
@@ -5381,7 +5365,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1516807385",
+                    "datestamp": "1506872944",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5390,7 +5374,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5401,7 +5385,7 @@
             "description": "Provides some handy cache tags for developers.",
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
-                "source": "https://git.drupalcode.org/project/handy_cache_tags"
+                "source": "http://cgit.drupalcode.org/handy_cache_tags"
             }
         },
         {
@@ -5428,7 +5412,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1578136083",
+                    "datestamp": "1501159742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5452,7 +5436,7 @@
             "description": "Allows addition, removal and modification of http headers.",
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
-                "source": "https://git.drupalcode.org/project/http_response_headers"
+                "source": "http://cgit.drupalcode.org/http_response_headers"
             }
         },
         {
@@ -5519,10 +5503,10 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/inline_entity_form.git",
-                "reference": "f94bbca4a9db359658e0614dad677eb6f28ec4e5"
+                "reference": "dfdd3453b5dbb95b0c4b77d853473d8b3bfb623d"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8.7.7 || ^9"
             },
             "require-dev": {
                 "drupal/entity_reference_revisions": "*"
@@ -5533,15 +5517,16 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0-beta1+12-dev",
-                    "datestamp": "1527028984",
+                    "version": "8.x-1.0-rc2+16-dev",
+                    "datestamp": "1581476673",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
                 },
                 "patches_applied": {
-                    "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)": "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch"
+                    "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)": "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch",
+                    "Add a setting to enable/disable inline editing of existing entities": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5556,6 +5541,26 @@
                 {
                     "name": "dawehner",
                     "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "geek-merlin",
+                    "homepage": "https://www.drupal.org/user/229048"
+                },
+                {
+                    "name": "joachim",
+                    "homepage": "https://www.drupal.org/user/107701"
+                },
+                {
+                    "name": "jsacksick",
+                    "homepage": "https://www.drupal.org/user/972218"
+                },
+                {
+                    "name": "kaythay",
+                    "homepage": "https://www.drupal.org/user/2182186"
+                },
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "rszrama",
@@ -5573,9 +5578,9 @@
             "description": "Provides a widget for inline management (creation, modification, removal) of referenced entities.",
             "homepage": "https://www.drupal.org/project/inline_entity_form",
             "support": {
-                "source": "http://cgit.drupalcode.org/inline_entity_form"
+                "source": "https://git.drupalcode.org/project/inline_entity_form"
             },
-            "time": "2018-05-22T22:41:11+00:00"
+            "time": "2020-02-12T03:02:09+00:00"
         },
         {
             "name": "drupal/jsonapi_page_limit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20d18e745b20956b7a044e25861e50f7",
+    "content-hash": "c63546aca35dadee37cf14eb40169af6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2418,7 +2418,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1559549585",
+                    "datestamp": "1531380221",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -2474,7 +2474,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.16",
-                    "datestamp": "1576179185",
+                    "datestamp": "1549478497",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2487,20 +2487,12 @@
             ],
             "authors": [
                 {
-                    "name": "Dane Powell",
-                    "homepage": "https://www.drupal.org/user/339326"
-                },
-                {
                     "name": "Mark Trapp",
                     "homepage": "https://www.drupal.org/user/212019"
                 },
                 {
                     "name": "Stanislav Mixnovich",
                     "homepage": "https://www.drupal.org/user/2859977"
-                },
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
                 },
                 {
                     "name": "ayang",
@@ -2515,16 +2507,16 @@
                     "homepage": "https://www.drupal.org/user/411965"
                 },
                 {
-                    "name": "grasmash",
-                    "homepage": "https://www.drupal.org/user/455714"
-                },
-                {
                     "name": "irek02",
                     "homepage": "https://www.drupal.org/user/736644"
                 },
                 {
                     "name": "kolafson",
                     "homepage": "https://www.drupal.org/user/822402"
+                },
+                {
+                    "name": "mundanity",
+                    "homepage": "https://www.drupal.org/user/373605"
                 },
                 {
                     "name": "vlad.pavlovic",
@@ -2534,7 +2526,7 @@
             "description": "Allows Drupal websites to connect with Acquia.",
             "homepage": "https://www.drupal.org/project/acquia_connector",
             "support": {
-                "source": "https://git.drupalcode.org/project/acquia_connector"
+                "source": "http://cgit.drupalcode.org/acquia_connector"
             }
         },
         {
@@ -2618,7 +2610,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.6",
-                    "datestamp": "1559642884",
+                    "datestamp": "1554334685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2681,7 +2673,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.26",
-                    "datestamp": "1558552081",
+                    "datestamp": "1549559402",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2762,7 +2754,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1573747386",
+                    "datestamp": "1492709942",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2782,7 +2774,7 @@
             "description": "Limit which text formats are available for each field instance.",
             "homepage": "https://www.drupal.org/project/allowed_formats",
             "support": {
-                "source": "https://git.drupalcode.org/project/allowed_formats"
+                "source": "http://cgit.drupalcode.org/allowed_formats"
             }
         },
         {
@@ -3649,11 +3641,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1514993285",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1470405718"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3669,7 +3657,7 @@
             "description": "Provides CSV as a serialization format.",
             "homepage": "https://www.drupal.org/project/csv_serialization",
             "support": {
-                "source": "https://git.drupalcode.org/project/csv_serialization"
+                "source": "http://cgit.drupalcode.org/csv_serialization"
             }
         },
         {
@@ -4095,11 +4083,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4167,16 +4151,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -4211,7 +4191,7 @@
             "description": "DropzoneJS Entity browser widget",
             "homepage": "https://www.drupal.org/project/dropzonejs",
             "support": {
-                "source": "https://git.drupalcode.org/project/dropzonejs"
+                "source": "http://cgit.drupalcode.org/dropzonejs"
             }
         },
         {
@@ -4297,11 +4277,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1575666184",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1490755685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4333,7 +4309,7 @@
             "description": "Provide a framework for various different types of embeds in WYSIWYG editors, common functionality, interfaces, and standards.",
             "homepage": "https://www.drupal.org/project/embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/embed",
+                "source": "http://cgit.drupalcode.org/embed",
                 "issues": "https://www.drupal.org/project/issues/embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -4501,11 +4477,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1502200443",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1492678144"
                 },
                 "patches_applied": {
                     "Fix duplicated image selection when click use selected button": "https://www.drupal.org/files/issues/prevent-duplication.patch",
@@ -4533,20 +4505,12 @@
                     "role": "contributor"
                 },
                 {
-                    "name": "Drupal Media Team",
-                    "homepage": "https://www.drupal.org/user/3260690"
-                },
-                {
                     "name": "Primsi",
                     "homepage": "https://www.drupal.org/user/282629"
                 },
                 {
                     "name": "marcingy",
                     "homepage": "https://www.drupal.org/user/77320"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "samuel.mortenson",
@@ -4593,11 +4557,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1556906881",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476698339"
                 },
                 "patches_applied": {
                     "Use array for class attribute in EntityEmbedBuilder.php": "https://www.drupal.org/files/issues/2019-04-02/entity-embed-beta2-3021505-12.patch"
@@ -4621,20 +4581,8 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
-                },
-                {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "slashrsm",
@@ -4644,7 +4592,7 @@
             "description": "Allows any entity to be embedded within a text area using a WYSIWYG editor.",
             "homepage": "https://www.drupal.org/project/entity_embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/entity_embed",
+                "source": "http://cgit.drupalcode.org/entity_embed",
                 "issues": "https://www.drupal.org/project/issues/entity_embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -5526,7 +5474,7 @@
                 },
                 "patches_applied": {
                     "Fixes field label when a new entity is created inline (https://www.drupal.org/project/inline_entity_form/issues/2842744)": "https://www.drupal.org/files/issues/inline_entity_form-no_label_required_field_with_no_entries-2842744.patch",
-                    "Add a setting to enable/disable inline editing of existing entities": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
+                    "Add a setting to enable/disable inline editing of existing entities (https://www.drupal.org/project/inline_entity_form/issues/2913571#comment-12811088)": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -5653,7 +5601,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1573604580",
+                    "datestamp": "1567172584",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6417,7 +6365,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.9",
-                    "datestamp": "1567099985",
+                    "datestamp": "1563995941",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7091,7 +7039,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta1",
-                    "datestamp": "1565535787",
+                    "datestamp": "1485452283",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -7100,16 +7048,12 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "gabrielu",
                     "homepage": "https://www.drupal.org/user/279352"
-                },
-                {
-                    "name": "otrolopezmas",
-                    "homepage": "https://www.drupal.org/user/3516204"
                 },
                 {
                     "name": "plopesc",
@@ -7123,7 +7067,7 @@
             "description": "Provides the ability to import redirects for the Redirect module",
             "homepage": "https://www.drupal.org/project/path_redirect_import",
             "support": {
-                "source": "https://git.drupalcode.org/project/path_redirect_import"
+                "source": "http://cgit.drupalcode.org/path_redirect_import"
             }
         },
         {
@@ -7265,16 +7209,12 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1550607785",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476410954"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7286,10 +7226,6 @@
                     "homepage": "https://www.drupal.org/user/41738"
                 },
                 {
-                    "name": "heddn",
-                    "homepage": "https://www.drupal.org/user/1463982"
-                },
-                {
                     "name": "jbrauer",
                     "homepage": "https://www.drupal.org/user/12363"
                 }
@@ -7297,7 +7233,7 @@
             "description": "Allows form elements to be prepopulated from the URL.",
             "homepage": "https://www.drupal.org/project/prepopulate",
             "support": {
-                "source": "https://git.drupalcode.org/project/prepopulate"
+                "source": "http://cgit.drupalcode.org/prepopulate"
             }
         },
         {
@@ -7324,7 +7260,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0",
-                    "datestamp": "1535381280",
+                    "datestamp": "1524571684",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7343,7 +7279,7 @@
             ],
             "homepage": "https://www.drupal.org/project/private_files_download_permission",
             "support": {
-                "source": "https://git.drupalcode.org/project/private_files_download_permission"
+                "source": "http://cgit.drupalcode.org/private_files_download_permission"
             }
         },
         {
@@ -7760,16 +7696,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.15",
-                    "datestamp": "1541330284",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1496919842"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7792,7 +7724,7 @@
             "description": "Provides a user interface to manage REST resources",
             "homepage": "https://www.drupal.org/project/restui",
             "support": {
-                "source": "https://git.drupalcode.org/project/restui"
+                "source": "http://cgit.drupalcode.org/restui"
             }
         },
         {
@@ -7881,7 +7813,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1566566888",
+                    "datestamp": "1510690385",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7973,10 +7905,6 @@
                 {
                     "name": "thunderbot",
                     "homepage": "https://www.drupal.org/user/3511180"
-                },
-                {
-                    "name": "volkerk",
-                    "homepage": "https://www.drupal.org/user/57527"
                 }
             ],
             "description": "Scheduler content moderation integration",
@@ -8015,7 +7943,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1563033785",
+                    "datestamp": "1527343084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8146,7 +8074,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.13",
-                    "datestamp": "1562599986",
+                    "datestamp": "1557244685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8221,7 +8149,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1575044885",
+                    "datestamp": "1549962207",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8290,16 +8218,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha2",
-                    "datestamp": "1534196880",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1470853439"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8311,10 +8235,6 @@
                     "homepage": "https://www.drupal.org/user/152788"
                 },
                 {
-                    "name": "mcdruid",
-                    "homepage": "https://www.drupal.org/user/255969"
-                },
-                {
                     "name": "p0deje",
                     "homepage": "https://www.drupal.org/user/529960"
                 }
@@ -8322,7 +8242,7 @@
             "description": "Enhance security of your Drupal website.",
             "homepage": "https://www.drupal.org/project/seckit",
             "support": {
-                "source": "https://git.drupalcode.org/project/seckit"
+                "source": "http://cgit.drupalcode.org/seckit"
             }
         },
         {
@@ -8403,7 +8323,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.12",
-                    "datestamp": "1542505221",
+                    "datestamp": "1523203180",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8464,7 +8384,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha3",
-                    "datestamp": "1555515785",
+                    "datestamp": "1499900942",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8481,7 +8401,7 @@
                     "homepage": "https://www.drupal.org/user/107229"
                 },
                 {
-                    "name": "geek.merlin aka axel.rutz",
+                    "name": "axel.rutz",
                     "homepage": "https://www.drupal.org/user/229048"
                 },
                 {
@@ -8512,7 +8432,7 @@
             "description": "Provides stage_file_proxy module.",
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
-                "source": "https://git.drupalcode.org/project/stage_file_proxy"
+                "source": "http://cgit.drupalcode.org/stage_file_proxy"
             }
         },
         {
@@ -8539,7 +8459,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1576842184",
+                    "datestamp": "1538584980",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -8734,7 +8654,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1538316180",
+                    "datestamp": "1496774342",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8743,7 +8663,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8762,7 +8682,7 @@
             "description": "Provides a UI to manage guided tours.",
             "homepage": "https://www.drupal.org/project/tour_ui",
             "support": {
-                "source": "https://git.drupalcode.org/project/tour_ui"
+                "source": "http://cgit.drupalcode.org/tour_ui"
             }
         },
         {
@@ -8789,16 +8709,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1549817580",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1474037939"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8809,7 +8725,7 @@
             "description": "Twig filters for value(s) and label.",
             "homepage": "https://www.drupal.org/project/twig_field_value",
             "support": {
-                "source": "https://git.drupalcode.org/project/twig_field_value"
+                "source": "http://cgit.drupalcode.org/twig_field_value"
             }
         },
         {
@@ -8839,11 +8755,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1505464444",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1495984083"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8891,7 +8803,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1575368885",
+                    "datestamp": "1533049984",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -8911,7 +8823,7 @@
             "description": "Prevents username enumeration on password reset and user pages.",
             "homepage": "https://www.drupal.org/project/username_enumeration_prevention",
             "support": {
-                "source": "https://git.drupalcode.org/project/username_enumeration_prevention"
+                "source": "http://cgit.drupalcode.org/username_enumeration_prevention"
             }
         },
         {
@@ -8943,7 +8855,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x",
-                    "datestamp": "1557724385",
+                    "datestamp": "1523338084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8972,7 +8884,7 @@
             "description": "A pluggable field type for storing videos from external video hosts such as Vimeo and YouTube.",
             "homepage": "https://www.drupal.org/project/video_embed_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/video_embed_field"
+                "source": "http://cgit.drupalcode.org/video_embed_field"
             }
         },
         {
@@ -9025,7 +8937,7 @@
             "description": "Makes it possible to create (additional) paths where entities will be shown in a given view_mode",
             "homepage": "https://www.drupal.org/project/view_mode_page",
             "support": {
-                "source": "https://git.drupalcode.org/project/view_mode_page"
+                "source": "http://cgit.drupalcode.org/view_mode_page"
             }
         },
         {
@@ -9076,7 +8988,7 @@
             "description": "Use Autocomplete for string field filters.",
             "homepage": "https://www.drupal.org/project/views_autocomplete_filters",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_autocomplete_filters"
+                "source": "http://cgit.drupalcode.org/views_autocomplete_filters"
             }
         },
         {
@@ -9176,7 +9088,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1554840781",
+                    "datestamp": "1471704539",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9185,7 +9097,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -9196,7 +9108,7 @@
             "description": "Add views custom cache tag.",
             "homepage": "https://www.drupal.org/project/views_custom_cache_tag",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_custom_cache_tag"
+                "source": "http://cgit.drupalcode.org/views_custom_cache_tag"
             }
         },
         {

--- a/conf/drupal/config/core.entity_form_display.paragraph.list_item_document.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.list_item_document.default.yml
@@ -35,18 +35,24 @@ content:
       form_mode: default
       label_singular: ''
       label_plural: ''
-      allow_new: true
       allow_existing: true
       match_operator: CONTAINS
       override_labels: false
       collapsible: false
       collapsed: false
+      allow_new: false
       allow_duplicate: false
+      allow_edit: false
     third_party_settings:
       entity_browser_entity_form:
         entity_browser_id: media_browser
     type: inline_entity_form_complex
     region: content
+  paragraphs_type_help__default:
+    weight: -100
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   status: true


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
The "List item document" paragraph which appears on the Curated List node has an entity reference field that references document media entities. This field uses the inline-entity-form widget to reference these entities. I was able to uncheck "create new media entities" on the widget settings on this page `/admin/structure/paragraphs_type/list_item_document/form-display` but [this patch](https://www.drupal.org/project/inline_entity_form/issues/2913571) was needed to allow disabling of editing of referenced entities.

As a note this work was done on the "List item document" paragraph and not specifically on the Curated List node. So this change will take effect everywhere this paragraph is used which includes other paragraphs and node types. If we think this is not acceptable or may cause a problem lets close this PR and think of another way to handle this (maybe with CSS or something?). 

Patch used: https://www.drupal.org/project/inline_entity_form/issues/2913571

**Jira:**
https://jira.mass.gov/browse/DP-17535

**To Test:**

1. - [ ] Edit a curated list node
2. - [ ] Add or edit a "List - Manual" paragraph
3. - [ ] Verify you can add/remove the document media entities under List Item Documents 
4. - [ ] Verify you can NOT create/edit the document media entities under List Item Documents 
5. - [ ] Verify the forms save correctly
6. - [ ] Verify the documents display as expected on the page





**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
