### PR TITLE
DP-17483: Prevent Mayflower breakage with adjustments for text wrapping

### DIFF
--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -16,43 +16,21 @@ module.exports = async function(page, scenario, vp) {
         '  transition-delay: 0ms !important;\n' +
         '}' +
         // Kill Video embeds (show black box instead)
-        '.fluid-width-video-wrapper:after {' +
-        '  background: black;' +
-        '  content: \'\';' +
-        '  position: absolute;' +
-        '  top: 0;' +
-        '  left: 0;' +
-        '  right: 0;' +
-        '  bottom: 0;' +
-        '  z-index: 100;' +
-        '}' +
-        // Kill iframes (show blue box instead)
-        '.ma__iframe__container:after {' +
-        '  background: #357B8F;' +
-        '  content: \'\';' +
-        '  position: absolute;' +
-        '  top: 0;' +
-        '  left: 0;' +
-        '  right: 0;' +
-        '  bottom: 0;' +
-        '  z-index: 100;' +
-        '}' +
-        // Kill google Maps (show a green box instead)
-        // .js-google-map for dynamic maps
-        '.js-google-map {' +
+        '.fluid-width-video-wrapper, .ma__iframe__container, .js-google-map {' +
         '  position: relative;' +
         '}' +
-        '.js-google-map:before {' +
-        '  background: #B2DEA2;\n' +
-        '  content: \' \';\n' +
-        '  display: block;\n' +
-        '  position: absolute;\n' +
-        '  top: 0;\n' +
-        '  left: 0;\n' +
-        '  right: 0;\n' +
-        '  bottom: 0;\n' +
-        '  z-index: 100;\n' +
+        '.fluid-width-video-wrapper:after, .ma__iframe__container:after, .js-google-map:after {' +
+        '  content: \'\';' +
+        '  position: absolute;' +
+        '  top: 0;' +
+        '  left: 0;' +
+        '  right: 0;' +
+        '  bottom: 0;' +
+        '  z-index: 100;' +
         '}' +
+        '.fluid-width-video-wrapper:after { background: black; }' +
+        '.ma__iframe__container:after { background: #357B8F; }' +
+        '.js-google-map:after { background: #B2DEA2; }' +
         // Kill banner image on QAG campaign landing page (show a black box instead)
         '#ID1345331.ma__key-message--image, #imgID1345331 {' +
         '  position: relative;' +

--- a/composer.json
+++ b/composer.json
@@ -208,7 +208,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "guzzlehttp/guzzle": "^6.3",
-        "massgov/mayflower-artifacts": "9.42.0",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-17483_dataviz-textwrapping-container-suggestions",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f530eaf31178a354ed2530582d1c043c",
+    "content-hash": "b848d4165c64f773f96c3de4e1283f40",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2418,7 +2418,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1559549585",
+                    "datestamp": "1531380221",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -2474,7 +2474,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.16",
-                    "datestamp": "1576179185",
+                    "datestamp": "1549478497",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2487,20 +2487,12 @@
             ],
             "authors": [
                 {
-                    "name": "Dane Powell",
-                    "homepage": "https://www.drupal.org/user/339326"
-                },
-                {
                     "name": "Mark Trapp",
                     "homepage": "https://www.drupal.org/user/212019"
                 },
                 {
                     "name": "Stanislav Mixnovich",
                     "homepage": "https://www.drupal.org/user/2859977"
-                },
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
                 },
                 {
                     "name": "ayang",
@@ -2515,16 +2507,16 @@
                     "homepage": "https://www.drupal.org/user/411965"
                 },
                 {
-                    "name": "grasmash",
-                    "homepage": "https://www.drupal.org/user/455714"
-                },
-                {
                     "name": "irek02",
                     "homepage": "https://www.drupal.org/user/736644"
                 },
                 {
                     "name": "kolafson",
                     "homepage": "https://www.drupal.org/user/822402"
+                },
+                {
+                    "name": "mundanity",
+                    "homepage": "https://www.drupal.org/user/373605"
                 },
                 {
                     "name": "vlad.pavlovic",
@@ -2534,7 +2526,7 @@
             "description": "Allows Drupal websites to connect with Acquia.",
             "homepage": "https://www.drupal.org/project/acquia_connector",
             "support": {
-                "source": "https://git.drupalcode.org/project/acquia_connector"
+                "source": "http://cgit.drupalcode.org/acquia_connector"
             }
         },
         {
@@ -2618,7 +2610,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.6",
-                    "datestamp": "1559642884",
+                    "datestamp": "1554334685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2641,10 +2633,6 @@
                 {
                     "name": "googletorp",
                     "homepage": "https://www.drupal.org/user/386230"
-                },
-                {
-                    "name": "jsacksick",
-                    "homepage": "https://www.drupal.org/user/972218"
                 },
                 {
                     "name": "mglaman",
@@ -2685,7 +2673,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.26",
-                    "datestamp": "1558552081",
+                    "datestamp": "1549559402",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2766,7 +2754,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1573747386",
+                    "datestamp": "1492709942",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2786,7 +2774,7 @@
             "description": "Limit which text formats are available for each field instance.",
             "homepage": "https://www.drupal.org/project/allowed_formats",
             "support": {
-                "source": "https://git.drupalcode.org/project/allowed_formats"
+                "source": "http://cgit.drupalcode.org/allowed_formats"
             }
         },
         {
@@ -3141,16 +3129,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1461060840"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3165,7 +3149,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3617,10 +3601,6 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
-                },
-                {
                     "name": "slashrsm",
                     "homepage": "https://www.drupal.org/user/744628"
                 },
@@ -3632,7 +3612,7 @@
             "description": "Provides storage and API for image crops.",
             "homepage": "https://www.drupal.org/project/crop",
             "support": {
-                "source": "https://git.drupalcode.org/project/crop",
+                "source": "http://cgit.drupalcode.org/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
             }
         },
@@ -3661,11 +3641,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1514993285",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1470405718"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3681,7 +3657,7 @@
             "description": "Provides CSV as a serialization format.",
             "homepage": "https://www.drupal.org/project/csv_serialization",
             "support": {
-                "source": "https://git.drupalcode.org/project/csv_serialization"
+                "source": "http://cgit.drupalcode.org/csv_serialization"
             }
         },
         {
@@ -4107,11 +4083,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4179,16 +4151,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -4223,7 +4191,7 @@
             "description": "DropzoneJS Entity browser widget",
             "homepage": "https://www.drupal.org/project/dropzonejs",
             "support": {
-                "source": "https://git.drupalcode.org/project/dropzonejs"
+                "source": "http://cgit.drupalcode.org/dropzonejs"
             }
         },
         {
@@ -4250,7 +4218,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1536250980",
+                    "datestamp": "1516093086",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4309,11 +4277,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1575666184",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1490755685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4345,7 +4309,7 @@
             "description": "Provide a framework for various different types of embeds in WYSIWYG editors, common functionality, interfaces, and standards.",
             "homepage": "https://www.drupal.org/project/embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/embed",
+                "source": "http://cgit.drupalcode.org/embed",
                 "issues": "https://www.drupal.org/project/issues/embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -4513,11 +4477,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1502200443",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1492678144"
                 },
                 "patches_applied": {
                     "Fix duplicated image selection when click use selected button": "https://www.drupal.org/files/issues/prevent-duplication.patch",
@@ -4545,20 +4505,12 @@
                     "role": "contributor"
                 },
                 {
-                    "name": "Drupal Media Team",
-                    "homepage": "https://www.drupal.org/user/3260690"
-                },
-                {
                     "name": "Primsi",
                     "homepage": "https://www.drupal.org/user/282629"
                 },
                 {
                     "name": "marcingy",
                     "homepage": "https://www.drupal.org/user/77320"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "samuel.mortenson",
@@ -4605,11 +4557,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1556906881",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476698339"
                 },
                 "patches_applied": {
                     "Use array for class attribute in EntityEmbedBuilder.php": "https://www.drupal.org/files/issues/2019-04-02/entity-embed-beta2-3021505-12.patch"
@@ -4633,20 +4581,8 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
-                },
-                {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "slashrsm",
@@ -4656,7 +4592,7 @@
             "description": "Allows any entity to be embedded within a text area using a WYSIWYG editor.",
             "homepage": "https://www.drupal.org/project/entity_embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/entity_embed",
+                "source": "http://cgit.drupalcode.org/entity_embed",
                 "issues": "https://www.drupal.org/project/issues/entity_embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -4981,21 +4917,21 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1504182544",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1485942783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "fabianderijk",
                     "homepage": "https://www.drupal.org/user/278745"
+                },
+                {
+                    "name": "msankhala",
+                    "homepage": "https://www.drupal.org/user/882726"
                 },
                 {
                     "name": "tomvv",
@@ -5005,7 +4941,7 @@
             "description": "Interface for unblocking ip's that are blocked by the flood table",
             "homepage": "https://www.drupal.org/project/flood_unblock",
             "support": {
-                "source": "https://git.drupalcode.org/project/flood_unblock"
+                "source": "http://cgit.drupalcode.org/flood_unblock"
             }
         },
         {
@@ -5036,7 +4972,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta6",
-                    "datestamp": "1553270584",
+                    "datestamp": "1519932484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5056,7 +4992,7 @@
             "description": "Allows users to specify the focal point of an image for use during cropping.",
             "homepage": "https://www.drupal.org/project/focal_point",
             "support": {
-                "source": "https://git.drupalcode.org/project/focal_point"
+                "source": "http://cgit.drupalcode.org/focal_point"
             }
         },
         {
@@ -5326,16 +5262,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1519597081",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1494796685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5354,7 +5286,7 @@
             "description": "Defines a field type for Google Maps.",
             "homepage": "https://www.drupal.org/project/google_map_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_map_field"
+                "source": "http://cgit.drupalcode.org/google_map_field"
             }
         },
         {
@@ -5381,7 +5313,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1516807385",
+                    "datestamp": "1506872944",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5390,7 +5322,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5401,7 +5333,7 @@
             "description": "Provides some handy cache tags for developers.",
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
-                "source": "https://git.drupalcode.org/project/handy_cache_tags"
+                "source": "http://cgit.drupalcode.org/handy_cache_tags"
             }
         },
         {
@@ -5428,7 +5360,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1578136083",
+                    "datestamp": "1501159742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5452,7 +5384,7 @@
             "description": "Allows addition, removal and modification of http headers.",
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
-                "source": "https://git.drupalcode.org/project/http_response_headers"
+                "source": "http://cgit.drupalcode.org/http_response_headers"
             }
         },
         {
@@ -5648,7 +5580,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1573604580",
+                    "datestamp": "1567172584",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6412,7 +6344,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.9",
-                    "datestamp": "1567099985",
+                    "datestamp": "1563995941",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7086,7 +7018,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta1",
-                    "datestamp": "1565535787",
+                    "datestamp": "1485452283",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -7095,16 +7027,12 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "gabrielu",
                     "homepage": "https://www.drupal.org/user/279352"
-                },
-                {
-                    "name": "otrolopezmas",
-                    "homepage": "https://www.drupal.org/user/3516204"
                 },
                 {
                     "name": "plopesc",
@@ -7118,7 +7046,7 @@
             "description": "Provides the ability to import redirects for the Redirect module",
             "homepage": "https://www.drupal.org/project/path_redirect_import",
             "support": {
-                "source": "https://git.drupalcode.org/project/path_redirect_import"
+                "source": "http://cgit.drupalcode.org/path_redirect_import"
             }
         },
         {
@@ -7260,16 +7188,12 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1550607785",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476410954"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7281,10 +7205,6 @@
                     "homepage": "https://www.drupal.org/user/41738"
                 },
                 {
-                    "name": "heddn",
-                    "homepage": "https://www.drupal.org/user/1463982"
-                },
-                {
                     "name": "jbrauer",
                     "homepage": "https://www.drupal.org/user/12363"
                 }
@@ -7292,7 +7212,7 @@
             "description": "Allows form elements to be prepopulated from the URL.",
             "homepage": "https://www.drupal.org/project/prepopulate",
             "support": {
-                "source": "https://git.drupalcode.org/project/prepopulate"
+                "source": "http://cgit.drupalcode.org/prepopulate"
             }
         },
         {
@@ -7319,7 +7239,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0",
-                    "datestamp": "1535381280",
+                    "datestamp": "1524571684",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7338,7 +7258,7 @@
             ],
             "homepage": "https://www.drupal.org/project/private_files_download_permission",
             "support": {
-                "source": "https://git.drupalcode.org/project/private_files_download_permission"
+                "source": "http://cgit.drupalcode.org/private_files_download_permission"
             }
         },
         {
@@ -7755,16 +7675,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.15",
-                    "datestamp": "1541330284",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1496919842"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7787,7 +7703,7 @@
             "description": "Provides a user interface to manage REST resources",
             "homepage": "https://www.drupal.org/project/restui",
             "support": {
-                "source": "https://git.drupalcode.org/project/restui"
+                "source": "http://cgit.drupalcode.org/restui"
             }
         },
         {
@@ -7876,7 +7792,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1566566888",
+                    "datestamp": "1510690385",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7968,10 +7884,6 @@
                 {
                     "name": "thunderbot",
                     "homepage": "https://www.drupal.org/user/3511180"
-                },
-                {
-                    "name": "volkerk",
-                    "homepage": "https://www.drupal.org/user/57527"
                 }
             ],
             "description": "Scheduler content moderation integration",
@@ -8010,7 +7922,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1563033785",
+                    "datestamp": "1527343084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8141,7 +8053,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.13",
-                    "datestamp": "1562599986",
+                    "datestamp": "1557244685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8216,7 +8128,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1575044885",
+                    "datestamp": "1549962207",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8285,16 +8197,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha2",
-                    "datestamp": "1534196880",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1470853439"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8306,10 +8214,6 @@
                     "homepage": "https://www.drupal.org/user/152788"
                 },
                 {
-                    "name": "mcdruid",
-                    "homepage": "https://www.drupal.org/user/255969"
-                },
-                {
                     "name": "p0deje",
                     "homepage": "https://www.drupal.org/user/529960"
                 }
@@ -8317,7 +8221,7 @@
             "description": "Enhance security of your Drupal website.",
             "homepage": "https://www.drupal.org/project/seckit",
             "support": {
-                "source": "https://git.drupalcode.org/project/seckit"
+                "source": "http://cgit.drupalcode.org/seckit"
             }
         },
         {
@@ -8398,7 +8302,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.12",
-                    "datestamp": "1542505221",
+                    "datestamp": "1523203180",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8459,7 +8363,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha3",
-                    "datestamp": "1555515785",
+                    "datestamp": "1499900942",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8476,7 +8380,7 @@
                     "homepage": "https://www.drupal.org/user/107229"
                 },
                 {
-                    "name": "geek.merlin aka axel.rutz",
+                    "name": "axel.rutz",
                     "homepage": "https://www.drupal.org/user/229048"
                 },
                 {
@@ -8507,7 +8411,7 @@
             "description": "Provides stage_file_proxy module.",
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
-                "source": "https://git.drupalcode.org/project/stage_file_proxy"
+                "source": "http://cgit.drupalcode.org/stage_file_proxy"
             }
         },
         {
@@ -8534,7 +8438,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1576842184",
+                    "datestamp": "1538584980",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -8729,7 +8633,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1538316180",
+                    "datestamp": "1496774342",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8738,7 +8642,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8757,7 +8661,7 @@
             "description": "Provides a UI to manage guided tours.",
             "homepage": "https://www.drupal.org/project/tour_ui",
             "support": {
-                "source": "https://git.drupalcode.org/project/tour_ui"
+                "source": "http://cgit.drupalcode.org/tour_ui"
             }
         },
         {
@@ -8784,16 +8688,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1549817580",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1474037939"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8804,7 +8704,7 @@
             "description": "Twig filters for value(s) and label.",
             "homepage": "https://www.drupal.org/project/twig_field_value",
             "support": {
-                "source": "https://git.drupalcode.org/project/twig_field_value"
+                "source": "http://cgit.drupalcode.org/twig_field_value"
             }
         },
         {
@@ -8834,11 +8734,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1505464444",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1495984083"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8886,7 +8782,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1575368885",
+                    "datestamp": "1533049984",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -8906,7 +8802,7 @@
             "description": "Prevents username enumeration on password reset and user pages.",
             "homepage": "https://www.drupal.org/project/username_enumeration_prevention",
             "support": {
-                "source": "https://git.drupalcode.org/project/username_enumeration_prevention"
+                "source": "http://cgit.drupalcode.org/username_enumeration_prevention"
             }
         },
         {
@@ -8938,7 +8834,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x",
-                    "datestamp": "1557724385",
+                    "datestamp": "1523338084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8967,7 +8863,7 @@
             "description": "A pluggable field type for storing videos from external video hosts such as Vimeo and YouTube.",
             "homepage": "https://www.drupal.org/project/video_embed_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/video_embed_field"
+                "source": "http://cgit.drupalcode.org/video_embed_field"
             }
         },
         {
@@ -9020,7 +8916,7 @@
             "description": "Makes it possible to create (additional) paths where entities will be shown in a given view_mode",
             "homepage": "https://www.drupal.org/project/view_mode_page",
             "support": {
-                "source": "https://git.drupalcode.org/project/view_mode_page"
+                "source": "http://cgit.drupalcode.org/view_mode_page"
             }
         },
         {
@@ -9071,7 +8967,7 @@
             "description": "Use Autocomplete for string field filters.",
             "homepage": "https://www.drupal.org/project/views_autocomplete_filters",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_autocomplete_filters"
+                "source": "http://cgit.drupalcode.org/views_autocomplete_filters"
             }
         },
         {
@@ -9171,7 +9067,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1554840781",
+                    "datestamp": "1471704539",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9180,7 +9076,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -9191,7 +9087,7 @@
             "description": "Add views custom cache tag.",
             "homepage": "https://www.drupal.org/project/views_custom_cache_tag",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_custom_cache_tag"
+                "source": "http://cgit.drupalcode.org/views_custom_cache_tag"
             }
         },
         {
@@ -10440,16 +10336,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "9.42.0",
+            "version": "dev-patternlab/DP-17483_dataviz-textwrapping-container-suggestions",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "24b497d23a208e91de76a5be583edaaffd365a82"
+                "reference": "fb12248c87399174f99320c0c98c1aef3f1b4893"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/24b497d23a208e91de76a5be583edaaffd365a82",
-                "reference": "24b497d23a208e91de76a5be583edaaffd365a82",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/fb12248c87399174f99320c0c98c1aef3f1b4893",
+                "reference": "fb12248c87399174f99320c0c98c1aef3f1b4893",
                 "shasum": ""
             },
             "require": {
@@ -10467,7 +10363,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-03-03T18:40:05+00:00"
+            "time": "2020-03-09T16:54:52+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -17588,6 +17484,7 @@
         "drupal/security_review": 20,
         "drupal/stage_file_proxy": 15,
         "drupal/views_data_export": 20,
+        "massgov/mayflower-artifacts": 20,
         "mikeyp/google_tag": 20,
         "behat/mink-selenium2-driver": 20,
         "weitzman/logintrait": 20

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -1482,17 +1482,6 @@ function mass_theme_preprocess_node_info_details(&$variables) {
     /** @var \Drupal\node\Entity\Node $node */
     $node = $variables['node'];
 
-    $variables['tableauEmbeded'] = FALSE;
-
-    foreach ($node->get('field_info_details_sections')->referencedEntities() as $section) {
-      $ref_entities = $section->get('field_section_long_form_content')->referencedEntities();
-      foreach ($ref_entities as $entity) {
-        if ($entity->bundle() == 'tableau_embed') {
-          $variables['tableauEmbeded'] = TRUE;
-        }
-      }
-    }
-
     // Get the page title for title context.
     $page_title = $node->getTitle();
     // Set up options for formDownloads prepare.

--- a/docroot/themes/custom/mass_theme/templates/content/node--decision.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--decision.html.twig
@@ -61,8 +61,11 @@
     <div class="page-content">
         {% for i in range(1, numOfSections) %}
           {% if sections[i]['title'] %}
-            {% set richText = sections[i]['title'] %}
-            {% include "@organisms/by-author/rich-text.twig" %}
+            <div class="ma__rich-text">
+              {% include "@atoms/04-headings/comp-heading.twig" with {
+                'compHeading': sections[i]['title']['compHeading']
+              } %}
+            </div>
           {% endif %}
           {% if sections[i]['richText'] %}
             {% set richText = sections[i]['richText'] %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
@@ -29,9 +29,6 @@
 {% set level = 1 %}
 
 {% block preContent %}
-  {% if tableauEmbeded %}
-    {{ attach_library('mass_theme/tableau') }}
-  {% endif %}
   {# If the contextual navigation should be set for this node, then add it. #}
   {% if node.computed_log_in_links is not empty %}
     {{ contextual_log_in_links }}

--- a/docroot/themes/custom/mass_theme/templates/content/node--location-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--location-details.html.twig
@@ -51,8 +51,11 @@
       {% include "@atoms/09-media/iframe.twig" %}
     {% endif %}
     {% if pageContent[i]['title'] %}
-      {% set richText = pageContent[i]['title'] %}
-      {% include "@organisms/by-author/rich-text.twig" %}
+      <div class="ma__rich-text">
+        {% include "@atoms/04-headings/comp-heading.twig" with {
+          'compHeading': pageContent[i]['title']['compHeading']
+        } %}
+      </div>
     {% endif %}
     {% if pageContent[i]['richText'] %}
       {% set richText = pageContent[i]['richText'] %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--news.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--news.html.twig
@@ -62,8 +62,9 @@
         {% endif %}
         {% for i in range(1, numOfSections) %}
           {% if pageContent[i]['title'] %}
-            {% set richText = pageContent[i]['title'] %}
-            {% include "@organisms/by-author/rich-text.twig" %}
+            {% include "@atoms/04-headings/comp-heading.twig" with {
+              'compHeading': pageContent[i]['title']['compHeading']
+            } %}
           {% endif %}
           {% if pageContent[i]['richText'] %}
             {% set richText = pageContent[i]['richText'] %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--field-event-image.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--field-event-image.html.twig
@@ -49,13 +49,13 @@
     {% endif %}
   {% endfor %}
   {% set src = versions|last %}
-  {% include "@atoms/09-media/figure.twig" with {
+  {% include "@atoms/09-media/figure--image.twig" with {
     "figure": {
       "image": {
         "alt": element['#items'][key].alt,
         "src": src.url,
         "versions": versions,
-          "sizes": "(min-width: 621px) 450px, 100vw"
+        "sizes": "(min-width: 621px) 450px, 100vw"
       }
     }
   } %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--field-news-image.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--field-news-image.html.twig
@@ -49,7 +49,7 @@
     {% endif %}
   {% endfor %}
   {% set src = versions|last %}
-  {% include "@atoms/09-media/figure.twig" with {
+  {% include "@atoms/09-media/figure--image.twig" with {
     "figure": {
       "image": {
         "alt": element['#items'][key].alt,

--- a/docroot/themes/custom/mass_theme/templates/field/mass_content_tableau_embed.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/mass_content_tableau_embed.html.twig
@@ -12,7 +12,7 @@
  * @see template_preprocess_link_formatter_link_separate()
  */
 #}
-
+{{ attach_library('mass_theme/tableau') }}
 <div class="ma_tableau_container" style="max-width:100%">
   <div id="{{ randId }}"></div>
 </div>

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--image.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--image.html.twig
@@ -36,7 +36,7 @@
  * @ingroup themeable
  */
 #}
-{% include "@atoms/09-media/figure.twig" with {
+{% include "@atoms/09-media/figure--image.twig" with {
   "figure": {
     "image": {
       "alt": paragraph.field_image.alt,


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR is an attempt to avoid any visual breakage with the changes coming down from https://github.com/massgov/mayflower/pull/954.  After this PR, we're hoping to see 0 visual changes, despite the fact that we've adjusted the `rich-text` and `figure` components. 

This is an alternate approach to #170 that does not override the `rich-text` paragraph type.  We might end up needing to override that type, but I didn't want to go there yet, to minimize the risk of visual breakage and the need for further styling overrides on the mass.gov side. 


**Jira:**
https://jira.mass.gov/browse/DP-17483


**To Test:**
- [ ] Run backstop to visually compare pages. 
- [ ] Spot check various types of content for visual breakage.
- [ ] Create and place a new Tableau visualization paragraph to ensure it still loads.  


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
