### PR TITLE
DP-17737: Alter Cloudflare settings to change edit access for COVID-19

### DIFF
--- a/changelogs/DP-17737.yml
+++ b/changelogs/DP-17737.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Alter Cloudflare settings to change edit access for COVID-19.
+    issue: DP-17737

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -1,11 +1,11 @@
 provider "cloudflare" {
   # email pulled from $CLOUDFLARE_EMAIL
-  # token pulled from $CLOUDFLARE_TOKEN
-  use_org_from_zone = var.domain
+  # api_key pulled from $CLOUDFLARE_API_KEY
+  # account_id pulled from $CLOUDFLARE_ACCOUNT_ID
 
   // This is locked to a specific version to avoid an issue where page rules
   // ended up missing TTL settings in 1.14.0.
-  version = "1.16.0"
+  version = "2.4.0"
 }
 
 locals {
@@ -16,7 +16,7 @@ locals {
 
 // ======== START DNS RECORDS =========
 resource "cloudflare_record" "edit_dns" {
-  domain  = var.domain
+  zone_id = var.zone_id
   name    = local.edit_domain
   value   = var.balancer_ip
   type    = "A"
@@ -24,7 +24,7 @@ resource "cloudflare_record" "edit_dns" {
 }
 
 resource "cloudflare_record" "www_dns" {
-  domain  = var.domain
+  zone_id = var.zone_id
   name    = local.www_domain
   value   = var.balancer_ip
   type    = "A"
@@ -38,13 +38,13 @@ resource "cloudflare_worker_script" "worker" {
 }
 
 resource "cloudflare_worker_route" "edit_route" {
-  zone        = var.domain
+  zone_id = var.zone_id
   pattern     = "${local.edit_domain}/*"
   script_name = cloudflare_worker_script.worker.name
 }
 
 resource "cloudflare_worker_route" "www_route" {
-  zone        = var.domain
+  zone_id = var.zone_id
   pattern     = "${local.www_domain}/*"
   script_name = cloudflare_worker_script.worker.name
 }
@@ -70,6 +70,31 @@ resource "cloudflare_filter" "www_block" {
       )
     )
 EXPR
-
 }
 
+resource "cloudflare_firewall_rule" "edit_geo_restrict" {
+  action = "block"
+  filter_id = cloudflare_filter.edit_geo_restrict.id
+  zone_id = var.zone_id
+  description = "Block ${local.edit_domain} outside the US."
+}
+resource "cloudflare_filter" "edit_geo_restrict" {
+  zone_id = var.zone_id
+  expression = <<EXPR
+(http.host eq "${local.edit_domain}" and ip.geoip.country ne "US")
+EXPR
+}
+
+
+resource "cloudflare_firewall_rule" "edit_block_bots" {
+  action = "block"
+  filter_id = cloudflare_filter.edit_block_bots.id
+  zone_id = var.zone_id
+  description = "Block ${local.edit_domain} for bots."
+}
+resource "cloudflare_filter" "edit_block_bots" {
+  zone_id = var.zone_id
+  expression = <<EXPR
+(http.host eq "${local.edit_domain}" and cf.client.bot)
+EXPR
+}

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -72,16 +72,17 @@ resource "cloudflare_filter" "www_block" {
 EXPR
 }
 
-resource "cloudflare_firewall_rule" "edit_geo_restrict" {
-  action = "block"
-  filter_id = cloudflare_filter.edit_geo_restrict.id
+resource "cloudflare_firewall_rule" "edit_geo_whitelist" {
+  action = "bypass"
+  products = ["zoneLockdown"]
+  filter_id = cloudflare_filter.edit_geo_whitelist.id
   zone_id = var.zone_id
-  description = "Block ${local.edit_domain} outside the US."
+  description = "Whitelist states for ${local.edit_domain}."
 }
-resource "cloudflare_filter" "edit_geo_restrict" {
+resource "cloudflare_filter" "edit_geo_whitelist" {
   zone_id = var.zone_id
   expression = <<EXPR
-(http.host eq "${local.edit_domain}" and ip.geoip.country ne "US")
+(http.host eq "${local.edit_domain}" and ip.geoip.subdivision_1_iso_code in {"US-MA" "US-NH" "US-CT" "US-MA" "US-RI"})
 EXPR
 }
 

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -82,7 +82,7 @@ resource "cloudflare_firewall_rule" "edit_geo_whitelist" {
 resource "cloudflare_filter" "edit_geo_whitelist" {
   zone_id = var.zone_id
   expression = <<EXPR
-(http.host eq "${local.edit_domain}" and ip.geoip.subdivision_1_iso_code in {"US-MA" "US-NH" "US-CT" "US-MA" "US-RI"})
+(http.host eq "${local.edit_domain}" and ip.geoip.subdivision_1_iso_code in {"US-MA" "US-NH" "US-CT" "US-ME" "US-RI" "US-VT"})
 EXPR
 }
 
@@ -99,3 +99,4 @@ resource "cloudflare_filter" "edit_block_bots" {
 (http.host eq "${local.edit_domain}" and cf.client.bot)
 EXPR
 }
+

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -69,20 +69,6 @@ resource "cloudflare_filter" "www_block" {
 EXPR
 }
 
-resource "cloudflare_firewall_rule" "edit_geo_whitelist" {
-  action = "bypass"
-  products = ["zoneLockdown"]
-  filter_id = cloudflare_filter.edit_geo_whitelist.id
-  zone_id = var.zone_id
-  description = "Whitelist states for ${local.edit_domain}."
-}
-resource "cloudflare_filter" "edit_geo_whitelist" {
-  zone_id = var.zone_id
-  expression = <<EXPR
-(http.host eq "${local.edit_domain}" and ip.geoip.subdivision_1_iso_code in {"US-MA" "US-NH" "US-CT" "US-ME" "US-RI" "US-VT"})
-EXPR
-}
-
 
 resource "cloudflare_firewall_rule" "edit_block_bots" {
   action = "block"

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -2,9 +2,6 @@ provider "cloudflare" {
   # email pulled from $CLOUDFLARE_EMAIL
   # api_key pulled from $CLOUDFLARE_API_KEY
   # account_id pulled from $CLOUDFLARE_ACCOUNT_ID
-
-  // This is locked to a specific version to avoid an issue where page rules
-  // ended up missing TTL settings in 1.14.0.
   version = "2.4.0"
 }
 

--- a/cloudflare/terraform/global/main.tf
+++ b/cloudflare/terraform/global/main.tf
@@ -1,15 +1,15 @@
 provider "cloudflare" {
   # email pulled from $CLOUDFLARE_EMAIL
-  # token pulled from $CLOUDFLARE_TOKEN
-  use_org_from_zone = var.domain
+  # api_key pulled from $CLOUDFLARE_API_KEY
+  # account_id pulled from $CLOUDFLARE_ACCOUNT_ID
 
   // This is locked to a specific version to avoid an issue where page rules
   // ended up missing TTL settings in 1.14.0.
-  version = "1.16.0"
+  version = "2.4.0"
 }
 
 resource "cloudflare_zone_settings_override" "default" {
-  name = var.domain
+  zone_id = var.zone_id
   settings {
     always_online = "off"
     brotli        = "on"

--- a/cloudflare/terraform/global/main.tf
+++ b/cloudflare/terraform/global/main.tf
@@ -2,9 +2,6 @@ provider "cloudflare" {
   # email pulled from $CLOUDFLARE_EMAIL
   # api_key pulled from $CLOUDFLARE_API_KEY
   # account_id pulled from $CLOUDFLARE_ACCOUNT_ID
-
-  // This is locked to a specific version to avoid an issue where page rules
-  // ended up missing TTL settings in 1.14.0.
   version = "2.4.0"
 }
 

--- a/cloudflare/terraform/global/rules.tf
+++ b/cloudflare/terraform/global/rules.tf
@@ -8,9 +8,9 @@ locals {
  * Cloudflare's API respects setting page rule priority only if the priority is.
  */
 resource "cloudflare_page_rule" "default_www" {
+  zone_id = var.zone_id
   count    = length(var.www_domains)
   target   = "${element(var.www_domains, count.index)}/*"
-  zone     = var.domain
   priority = count.index
   actions {
     // This setting is only here because we need some action for the page rule.
@@ -22,14 +22,12 @@ resource "cloudflare_page_rule" "default_www" {
 }
 
 resource "cloudflare_page_rule" "default_edit" {
+  zone_id = var.zone_id
   count    = length(var.edit_domains)
   target   = "${element(var.edit_domains, count.index)}/*"
-  zone     = var.domain
   priority = length(var.www_domains) + count.index
   actions {
     cache_level    = "aggressive"
-    security_level = "essentially_off"
-    waf            = "off"
   }
 }
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR:
* Updates the Terraform Cloudflare provider to 2.4.0 and updates resources accordingly (mostly removal of `name`, `domain`, and `zone` properties, and the addition of `zone_id` on every resource.  We'd previously pegged the provider to 1.14.0 due to a TTL setting issue that's been resolved upstream.
* Alters the mechanism of WAF bypass (which I won't put in this ticket or this PR).  
* Restricts access to edit domains to US only, and no bots.


**Jira:**
https://jira.mass.gov/browse/DP-17737


**To Test:**
- [ ] Run `aws-vault exec massgov -- ./scripts/cloudflare-deploy cf` to see the preview of what this will change. You an test the other environments too if you'd like:
```
aws-vault exec massgov -- ./scripts/cloudflare-deploy cf
aws-vault exec massgov -- ./scripts/cloudflare-deploy stage
aws-vault exec massgov -- ./scripts/cloudflare-deploy prod
aws-vault exec massgov -- ./scripts/cloudflare-deploy global
```
Make sure not to approve any of these changes till we're ready to go. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
