### PR TITLE
Fix mayflower-dev not building when a PR is absent.

### DIFF
--- a/changelogs/DP-17781.yml
+++ b/changelogs/DP-17781.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix mayflower-dev not building when a PR is absent.
+    issue: DP-17781

--- a/scripts/build-changelog.php
+++ b/scripts/build-changelog.php
@@ -152,7 +152,7 @@ $data = array("title" => "Release" . $version, "body" => $markdown, "head" => "r
 $data_string = json_encode($data);
 
 curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');
-curl_setopt($ch, CURLOPT_PASSWORD, $_ENV['GITHUB_MASSGOV_BOT_TOKEN']);
+curl_setopt($ch, CURLOPT_PASSWORD, getenv('GITHUB_MASSGOV_BOT_TOKEN'));
 curl_setopt($ch, CURLOPT_POST, '-X');
 curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/openmass/');
 curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/openmass/pulls');

--- a/scripts/ma-mayflower-develop.php
+++ b/scripts/ma-mayflower-develop.php
@@ -62,3 +62,25 @@ echo "Pushed the branch up to GitHub to be deployed to an environment.\n";
 echo "\n";
 echo "----------------------------------------------\n";
 echo "\n";
+
+// Get cURL resource
+$ch = curl_init();
+
+$markdown = 'This PR may be closed after this branch is no longer needed. It is a requirement for automation to run since we have the Advanced Setting _Only build Pull Requests_ enabled at CircleCI.';
+$data = array("title" => "mayflower-dev-' . $branch_name to develop", "draft" => TRUE, "body" => $markdown, "head" => "mayflower-dev-' . $branch_name", "base" => "develop");
+$data_string = json_encode($data);
+
+curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');
+curl_setopt($ch, CURLOPT_PASSWORD, $_ENV['GITHUB_MASSGOV_BOT_TOKEN']);
+curl_setopt($ch, CURLOPT_POST, '-X');
+curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/openmass/');
+curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/openmass/pulls');
+# Accept header comes from https://developer.github.com/v3/pulls/#create-a-pull-request (draft PR feature is not released yet)
+curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.shadow-cat-preview+json', 'Content-Type: application/json'));
+curl_setopt($ch, CURLOPT_POSTFIELDS, $data_string);
+
+// Send the request
+curl_exec($ch);
+
+// Close request to clear up some resources
+curl_close($ch);

--- a/scripts/ma-mayflower-develop.php
+++ b/scripts/ma-mayflower-develop.php
@@ -67,7 +67,7 @@ echo "\n";
 $ch = curl_init();
 
 $markdown = 'This PR may be closed after this branch is no longer needed. It is a requirement for automation to run since we have the Advanced Setting _Only build Pull Requests_ enabled at CircleCI.';
-$data = array("title" => "mayflower-dev-' . $branch_name to develop", "draft" => TRUE, "body" => $markdown, "head" => "mayflower-dev-' . $branch_name", "base" => "develop");
+$data = array("title" => "mayflower-dev-$branch_name to develop", "draft" => TRUE, "body" => $markdown, "head" => "mayflower-dev-$branch_name", "base" => "develop");
 $data_string = json_encode($data);
 
 curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');

--- a/scripts/ma-mayflower-develop.php
+++ b/scripts/ma-mayflower-develop.php
@@ -71,7 +71,7 @@ $data = array("title" => "mayflower-dev-$branch_name to develop", "draft" => TRU
 $data_string = json_encode($data);
 
 curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');
-curl_setopt($ch, CURLOPT_PASSWORD, $_ENV['GITHUB_MASSGOV_BOT_TOKEN']);
+curl_setopt($ch, CURLOPT_PASSWORD, getenv('GITHUB_MASSGOV_BOT_TOKEN'));
 curl_setopt($ch, CURLOPT_POST, '-X');
 curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/openmass/');
 curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/openmass/pulls');


### PR DESCRIPTION
**Description:**
Fix 'Not Run' error at https://circleci.com/workflow-run/998a0bdc-7647-4beb-95d0-ec72a28fcd6b


**Jira:**
https://jira.mass.gov/browse/DP-17781


**To Test:**
- [ ] I made a test file for the new code and it successfully created the PR at https://github.com/massgov/openmass/pull/193. The code I used is

```
<?php

$branch_name = '03-12-2020';

// Get cURL resource
$ch = curl_init();

$markdown = 'This PR may be closed after this branch is no longer needed. It is a requirement for automation to run since we have the Advanced Setting _Only build Pull Requests_ enabled at CircleCI.';
$data = array("title" => "mayflower-dev-$branch_name to develop", "draft" => TRUE, "body" => $markdown, "head" => "mayflower-dev-$branch_name", "base" => "develop");
$data_string = json_encode($data);

curl_setopt($ch, CURLOPT_USERNAME, 'massgov-bot');
curl_setopt($ch, CURLOPT_PASSWORD, getenv('GITHUB_MASSGOV_BOT_TOKEN'));
curl_setopt($ch, CURLOPT_POST, '-X');
curl_setopt($ch, CURLOPT_USERAGENT, 'https://api.github.com/repos/massgov/openmass/');
curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/massgov/openmass/pulls');
# Accept header comes from https://developer.github.com/v3/pulls/#create-a-pull-request (draft PR feature is not released yet)
curl_setopt($ch, CURLOPT_HTTPHEADER, array('Accept: application/vnd.github.shadow-cat-preview+json', 'Content-Type: application/json'));
curl_setopt($ch, CURLOPT_POSTFIELDS, $data_string);

// Send the request
curl_exec($ch);

// Close request to clear up some resources
curl_close($ch);

```


---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
