### PR TITLE
DP-17784: Fixes for media downloads

### DIFF
--- a/changelogs/DP-17784.yml
+++ b/changelogs/DP-17784.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Shorten the media download cache lifetime for the browser to avoid content that changes quickly being cached.
+    issue: DP-17784

--- a/cloudflare/src/backends.js
+++ b/cloudflare/src/backends.js
@@ -45,6 +45,9 @@ export function edit(token) {
     if(isAlertsUrl(url)) {
       browserTTL = 60
     }
+    else if(isMediaDownloadUrl(url)) {
+      browserTTL = 60
+    }
     else if(isStaticUrl(url)) {
       browserTTL = RESPECT_ORIGIN
     }
@@ -64,7 +67,7 @@ export function edit(token) {
       }
     }
 
-    if(browserTTL !== RESPECT_ORIGIN && isDrupalResponse(response)) {
+    if(browserTTL !== RESPECT_ORIGIN) {
       response = overrideBrowserTTL(response)
     }
 
@@ -103,6 +106,10 @@ export function www(token) {
       edgeTTL = 60
       browserTTL = 60
     }
+    else if(isMediaDownloadUrl(url)) {
+      edgeTTL = RESPECT_ORIGIN
+      browserTTL = 60
+    }
     else if(isStaticUrl(url)) {
       edgeTTL = RESPECT_ORIGIN
       browserTTL = RESPECT_ORIGIN
@@ -127,7 +134,7 @@ export function www(token) {
     }
 
     // Apply browser TTL overrides.
-    if(browserTTL !== RESPECT_ORIGIN && isDrupalResponse(response)) {
+    if(browserTTL !== RESPECT_ORIGIN) {
       response = overrideBrowserTTL(response, browserTTL)
     }
 

--- a/cloudflare/tests/backends.js
+++ b/cloudflare/tests/backends.js
@@ -171,7 +171,7 @@ describe('WWW Backend', function() {
     })
   });
 
-  test(`Should not alter cache headers for non-Drupal responses`, async function() {
+  test(`Should alter cache headers for non-Drupal responses`, async function() {
     global.fetch = jest.fn(() => Promise.resolve(new Response('', {
       headers: new Headers({
         'Cache-Control': 'public, max-age=604800',
@@ -181,7 +181,7 @@ describe('WWW Backend', function() {
 
     const request = new Request('https://www.mass.gov/');
     const response = await www('TEST_TOKEN')(request);
-    expect(response.headers.get('cache-control')).toEqual('public, max-age=604800');
+    expect(response.headers.get('cache-control')).toEqual('public, max-age=1800');
   })
 
   const edgeTTLTests = [

--- a/cloudflare/tests/backends.js
+++ b/cloudflare/tests/backends.js
@@ -263,4 +263,15 @@ describe('WWW Backend', function() {
     expect(fetch.mock.calls.length).toBe(1);
   });
 
+  test('Should set a short cache lifetime for media download redirects', async function() {
+    global.fetch = jest.fn(() => Promise.resolve(new Response('', {
+      status: 404,
+      headers: new Headers({
+        'Cache-Control': 'public, max-age=3000',
+      })
+    })));
+    const response = await www('TEST_TOKEN')(new Request('https://www.mass.gov/media/123/download'));
+    expect(response.headers.get('cache-control')).toEqual('public, max-age=60');
+  })
+
 });


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR shortens the browser cache lifetime for media download URLs to 60 seconds, including all 404s received on a path that looks like a media download URL.  This is to prevent end users from getting stuff stuck in their browser for a really long time, and does not affect the edge lifetime. 

This has the side effect of shortening the cache lifetime for other types of content (content that is not one of our known "static" types, or served through Drupal).  We're not worried about this, because static content still gets a really long lifetime, and the edge lifetime isn't changed at all.


**Jira:**
https://jira.mass.gov/browse/DP-17784


**To Test:**
- [ ] Visit `https://wwwcf.digital.mass.gov/media/12312312321312/download` in your browser and verify that the browser cache lifetime (max age value on the `Cache` header) is 60 seconds, despite being a 404 page.  Do the same test for a valid media download like `https://wwwcf.digital.mass.gov/media/1/download`


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
