### PR TITLE
DP-17785 Purge /download media URLs on media entity update

### DIFF
--- a/changelogs/DP-17784.yml
+++ b/changelogs/DP-17784.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Shorten the media download cache lifetime for the browser to avoid content that changes quickly being cached.
+    issue: DP-17784

--- a/changelogs/DP-17785.yml
+++ b/changelogs/DP-17785.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Purge /download media urls when media is updated.
+    issue: DP-17785

--- a/cloudflare/src/backends.js
+++ b/cloudflare/src/backends.js
@@ -45,6 +45,9 @@ export function edit(token) {
     if(isAlertsUrl(url)) {
       browserTTL = 60
     }
+    else if(isMediaDownloadUrl(url)) {
+      browserTTL = 60
+    }
     else if(isStaticUrl(url)) {
       browserTTL = RESPECT_ORIGIN
     }
@@ -64,7 +67,7 @@ export function edit(token) {
       }
     }
 
-    if(browserTTL !== RESPECT_ORIGIN && isDrupalResponse(response)) {
+    if(browserTTL !== RESPECT_ORIGIN) {
       response = overrideBrowserTTL(response)
     }
 
@@ -103,6 +106,10 @@ export function www(token) {
       edgeTTL = 60
       browserTTL = 60
     }
+    else if(isMediaDownloadUrl(url)) {
+      edgeTTL = RESPECT_ORIGIN
+      browserTTL = 60
+    }
     else if(isStaticUrl(url)) {
       edgeTTL = RESPECT_ORIGIN
       browserTTL = RESPECT_ORIGIN
@@ -127,7 +134,7 @@ export function www(token) {
     }
 
     // Apply browser TTL overrides.
-    if(browserTTL !== RESPECT_ORIGIN && isDrupalResponse(response)) {
+    if(browserTTL !== RESPECT_ORIGIN) {
       response = overrideBrowserTTL(response, browserTTL)
     }
 

--- a/cloudflare/tests/backends.js
+++ b/cloudflare/tests/backends.js
@@ -171,7 +171,7 @@ describe('WWW Backend', function() {
     })
   });
 
-  test(`Should not alter cache headers for non-Drupal responses`, async function() {
+  test(`Should alter cache headers for non-Drupal responses`, async function() {
     global.fetch = jest.fn(() => Promise.resolve(new Response('', {
       headers: new Headers({
         'Cache-Control': 'public, max-age=604800',
@@ -181,7 +181,7 @@ describe('WWW Backend', function() {
 
     const request = new Request('https://www.mass.gov/');
     const response = await www('TEST_TOKEN')(request);
-    expect(response.headers.get('cache-control')).toEqual('public, max-age=604800');
+    expect(response.headers.get('cache-control')).toEqual('public, max-age=1800');
   })
 
   const edgeTTLTests = [

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\file\FileInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Implements hook_file_insert().
@@ -70,5 +71,19 @@ function mass_caching_path_insert(array $path) {
 function mass_caching_path_update(array $path) {
   if ($path['alias'] !== $path['original']['alias']) {
     \Drupal::service('manual_purger')->purgePath($path['alias']);
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ *
+ * Purge media's path when the entity is updated.
+ */
+function mass_caching_entity_update(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() == 'media') {
+    $path = 'media/' . $entity->id() . '/download';
+    \Drupal::service('manual_purger')->purgePath($path);
+    $aliased_path = $entity->toUrl()->toString() . '/download';
+    \Drupal::service('manual_purger')->purgePath($aliased_path);
   }
 }

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -87,3 +87,17 @@ function mass_caching_entity_update(EntityInterface $entity) {
     \Drupal::service('manual_purger')->purgePath($aliased_path);
   }
 }
+
+/**
+ * Implements hook_entity_insert().
+ *
+ * Purge media's path when the entity is created.
+ */
+function mass_caching_entity_insert(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() == 'media') {
+    $path = 'media/' . $entity->id() . '/download';
+    \Drupal::service('manual_purger')->purgePath($path);
+    $aliased_path = $entity->toUrl()->toString() . '/download';
+    \Drupal::service('manual_purger')->purgePath($aliased_path);
+  }
+}


### PR DESCRIPTION
**Description:**
This PR causes the `media/[mid]/download` and `[media-alias]/download` URLs to be manually purged when the associated media entity is updated.


**Jira:**
https://jira.mass.gov/browse/DP-17785


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
