### PR TITLE
DP-17809: Resolve media download caching on initial creation

### DIFF
--- a/changelogs/DP-17809.yml
+++ b/changelogs/DP-17809.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Fixed an issue where document download URLs were not being cleared from cache on initial creation of the document.
+    issue: DP-17809

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -75,29 +75,58 @@ function mass_caching_path_update(array $path) {
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ *
+ * Push our hook_entity_update() and hook_entity_insert() implementations to
+ * after pathauto's in order to ensure that media have aliased URLs before we
+ * attempt to clear them.
+ */
+function mass_caching_module_implements_alter(&$implementations, $hook) {
+  if ($hook === 'entity_update' || $hook === 'entity_insert') {
+    $group = $implementations['mass_caching'];
+    unset($implementations['mass_caching']);
+    $implementations['mass_caching'] = $group;
+  }
+}
+
+/**
  * Implements hook_entity_update().
  *
- * Purge media's path when the entity is updated.
+ * Purge media's download path when the entity is updated. This is implemented
+ * as a hook_entity_update() rather than hook_media_update because we need it to
+ * run after pathauto's hook_entity_update().
  */
 function mass_caching_entity_update(EntityInterface $entity) {
-  if ($entity->getEntityTypeId() == 'media') {
-    $path = 'media/' . $entity->id() . '/download';
-    \Drupal::service('manual_purger')->purgePath($path);
-    $aliased_path = $entity->toUrl()->toString() . '/download';
-    \Drupal::service('manual_purger')->purgePath($aliased_path);
+  if ($entity->getEntityTypeId() !== 'media') {
+    return;
+  }
+  $purger = \Drupal::service('manual_purger');
+  $paths = ['/media/' . $entity->id() . '/download'];
+  $paths[] = $entity->toUrl()->toString() . '/download';
+  // array_unique() because the entity provided URL for unaliased media
+  // will be the same as /media/123/download.
+  foreach (array_unique($paths) as $path) {
+    $purger->purgePath($path);
   }
 }
 
 /**
  * Implements hook_entity_insert().
  *
- * Purge media's path when the entity is created.
+ * Purge media's download path when the entity is created. This is implemented
+ * as a hook_entity_insert() rather than hook_media_insert because we need it to
+ * run after pathauto's hook_entity_update().
  */
 function mass_caching_entity_insert(EntityInterface $entity) {
-  if ($entity->getEntityTypeId() == 'media') {
-    $path = 'media/' . $entity->id() . '/download';
-    \Drupal::service('manual_purger')->purgePath($path);
-    $aliased_path = $entity->toUrl()->toString() . '/download';
-    \Drupal::service('manual_purger')->purgePath($aliased_path);
+  if ($entity->getEntityTypeId() !== 'media') {
+    return;
+  }
+  $purger = \Drupal::service('manual_purger');
+  $paths = ['/media/' . $entity->id() . '/download'];
+  $paths[] = $entity->toUrl()->toString() . '/download';
+  // array_unique() because the entity provided URL for unaliased media
+  // will be the same as /media/123/download.
+  foreach (array_unique($paths) as $path) {
+    $purger->purgePath($path);
   }
 }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes an issue where the media download URL for the aliased path is not purged immediately when a document is first created. This turned out to be just an issue with hook ordering - pathauto fired after our hooks, so we didn't have access to the aliased path yet.  


**Jira:**
https://jira.mass.gov/browse/DP-17809


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
