### PR TITLE
DP-17808: Fix conditional states for emergency alert inputs not worki…

### DIFF
--- a/changelogs/DP-17808.yml
+++ b/changelogs/DP-17808.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix conditional states for emergency alert inputs not working properly.
+    issue: DP-17808

--- a/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
+++ b/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
@@ -91,7 +91,7 @@
 
   Drupal.behaviors.alertsConditional = {
     attach: function (context) {
-      $('.field--name-field-emergency-alert-link-type', context).each(function() {
+      $('.field--name-field-emergency-alert-link-type', context).each(function () {
         var $type = $('input', this);
         var $container = $(this).closest('.paragraphs-subform');
         var $link = $container.find('.field--name-field-emergency-alert-link');
@@ -117,6 +117,6 @@
         handler();
       });
     }
-  }
+  };
 
 })(jQuery, Drupal);

--- a/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
+++ b/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
@@ -89,39 +89,34 @@
     setTimeout(overrideNews, 1);
   })();
 
-  /**
-   * Alert Link Type.
-   * Hide or show options based on the value of the link type field.
-   *
-   * @param {string} val - link type value.
-   *
-   * Field values are defined in the link type field on the emergency_alert
-   * paragraph.
-   */
-  function processLinkType(val) {
-    switch (val) {
-      case '0':
-        $('.field--name-field-emergency-alert-link').hide();
-        $('.field--name-field-emergency-alert-content').show();
-        break;
-      case '1':
-        $('.field--name-field-emergency-alert-link').show();
-        $('.field--name-field-emergency-alert-content').hide();
-        break;
-      case '2':
-        $('.field--name-field-emergency-alert-link').hide();
-        $('.field--name-field-emergency-alert-content').hide();
-        break;
-      default:
+  Drupal.behaviors.alertsConditional = {
+    attach: function (context) {
+      $('.field--name-field-emergency-alert-link-type', context).each(function() {
+        var $type = $('input', this);
+        var $container = $(this).closest('.paragraphs-subform');
+        var $link = $container.find('.field--name-field-emergency-alert-link');
+        var $description = $container.find('.field--name-field-emergency-alert-content');
+        var handler = function () {
+          var val = $type.filter(':checked').val();
+          switch (val) {
+            case '0':
+              $link.hide();
+              $description.show();
+              break;
+            case '1':
+              $link.show();
+              $description.hide();
+              break;
+            case '2':
+              $link.hide();
+              $description.hide();
+          }
+        };
+
+        $type.change(handler);
+        handler();
+      });
     }
   }
 
-  var $linkTypeFields = $('#edit-field-alert-0-subform-field-emergency-alert-link-type input');
-  var $linkTypeChecked = $('#edit-field-alert-0-subform-field-emergency-alert-link-type input[checked=checked]');
-  var linkType = $linkTypeChecked.val();
-  processLinkType(linkType);
-  $linkTypeFields.click(function () {
-    processLinkType($(this).val());
-  });
-
-})(jQuery);
+})(jQuery, Drupal);


### PR DESCRIPTION
…ng properly

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR fixes the conditional field logic for Emergency Alerts. Previously, there were several bugs, including that if you added multiple alert messages, the conditional logic would only apply for the first item. This PR just cleans up the logic and makes it apply universally to all items in that form individually.  


**Jira:**
https://jira.mass.gov/browse/DP-17808


**To Test:**
- [ ] Create a new emergency alert.
- [ ] Add an alert message using "Link to the default alert landing page" as the link type.
- [ ] Add a second alert message using "Provide a custom link" and verify that the link entry box appears. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
