### PR TITLE
DP-17851 Create redirect manager role

### DIFF
--- a/changelogs/DP-17851.yml
+++ b/changelogs/DP-17851.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add a Redirect Manager role with redirect permissions.
+    issue: DP-17851

--- a/conf/drupal/config/system.action.user_add_role_action.redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_add_role_action.redirect_manager.yml
@@ -1,4 +1,4 @@
-uuid: 4fd5e928-ee11-40d2-9758-bc4fbd140dfb
+uuid: a27b34bb-b82f-47e1-94bb-1653c66e4177
 langcode: en
 status: true
 dependencies:

--- a/conf/drupal/config/system.action.user_add_role_action.redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_add_role_action.redirect_manager.yml
@@ -1,0 +1,14 @@
+uuid: 4fd5e928-ee11-40d2-9758-bc4fbd140dfb
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.redirect_manager
+  module:
+    - user
+id: user_add_role_action.redirect_manager
+label: 'Add the Redirect manager role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: redirect_manager

--- a/conf/drupal/config/system.action.user_remove_role_action.redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_remove_role_action.redirect_manager.yml
@@ -1,0 +1,14 @@
+uuid: 00781b61-9421-4748-a5b3-4b890178c64a
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.redirect_manager
+  module:
+    - user
+id: user_remove_role_action.redirect_manager
+label: 'Remove the Redirect manager role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: redirect_manager

--- a/conf/drupal/config/system.action.user_remove_role_action.redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_remove_role_action.redirect_manager.yml
@@ -1,4 +1,4 @@
-uuid: 00781b61-9421-4748-a5b3-4b890178c64a
+uuid: 041b299d-857a-4d25-bf78-fb79d057d045
 langcode: en
 status: true
 dependencies:

--- a/conf/drupal/config/user.role.redirect_manager.yml
+++ b/conf/drupal/config/user.role.redirect_manager.yml
@@ -1,4 +1,4 @@
-uuid: 63273e73-0316-4ab7-b3fb-b8ed8411ce47
+uuid: 33214140-8b42-4f11-843e-60d9ecfd65c7
 langcode: en
 status: true
 dependencies: {  }

--- a/conf/drupal/config/user.role.redirect_manager.yml
+++ b/conf/drupal/config/user.role.redirect_manager.yml
@@ -1,0 +1,11 @@
+uuid: 63273e73-0316-4ab7-b3fb-b8ed8411ce47
+langcode: en
+status: true
+dependencies: {  }
+id: redirect_manager
+label: 'Redirect manager'
+weight: 3
+is_admin: null
+permissions:
+  - 'administer url aliases'
+  - 'display manage tab'

--- a/conf/drupal/config/user.role.redirect_manager.yml
+++ b/conf/drupal/config/user.role.redirect_manager.yml
@@ -7,5 +7,5 @@ label: 'Redirect manager'
 weight: 3
 is_admin: null
 permissions:
-  - 'administer url aliases'
+  - 'administer redirects'
   - 'display manage tab'


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**

**DO NOT MERGE THIS - THIS BEEN SUPERSEDED BY A NEW PR**


I added a Redirect Manager role with permissions only to view the Manage tab, access the D2D redirects link, and create and edit redirects. 

Here are some rough instructions on how to add a redirect for the users which will have this new role.

1. Click the Manage tab at the top of the page
2. Click the D2D Redirects link
3. Click the Add Redirect button
4. In the "Path" field, enter the path to the page you would like to redirect from without the top-level part of the domain. For example enter something like “/path-to-my/page” and not “https://mass.gov/path-to-my/page”
5. In the "To" field, enter the page you would like to redirect to in the same way as you entered the path or you have the option to use the autocomplete. Just start typing the title of the page you would like to be redirected to and you are provided with a list of pages to choose from.
6. For Redirect Status you will most likely keep the default setting of “301 Moved Permanently”
7. Save the redirect and verify it worked by visiting the path you have redirected from.


**Jira:**
https://jira.mass.gov/browse/DP-17851


**To Test:**
- [ ] Give a user with the Author role the Redirect Manager role as well
- [ ] Verify the Manage tab is visible and you can click on the D2D Redirects link
- [ ] Verify you can create/edit/save a redirect and it works correctly


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
