### PR TITLE
DP-17810 Adjust json output to fix alert links to ids

### DIFF
--- a/changelogs/DP-17810.yml
+++ b/changelogs/DP-17810.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed the json data to output the correct emergency_alert paragraph id for the alerts block.
+    issue: DP-17810

--- a/conf/drupal/config/block.block.ajaxpattern.yml
+++ b/conf/drupal/config/block.block.ajaxpattern.yml
@@ -18,7 +18,7 @@ settings:
   label: 'Ajax Pattern: Site Alerts'
   provider: mayflower
   label_display: '0'
-  ajax_pattern_endpoint: '/jsonapi/node/alert?page[limit]=250&sort=-changed&include=field_target_pages_para_ref,field_alert&filter[status][value]=1&fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display&fields[paragraph--emergency_alert]=id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content&fields[paragraph--target_pages]=field_target_content_ref'
+  ajax_pattern_endpoint: '/jsonapi/node/alert?page[limit]=250&sort=-changed&include=field_target_pages_para_ref,field_alert&filter[status][value]=1&fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display&fields[paragraph--emergency_alert]=drupal_internal__id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content&fields[paragraph--target_pages]=field_target_content_ref'
   ajax_pattern_render_pattern: '@organisms/by-template/emergency-alerts.twig'
   ajax_pattern_custom_selector: js-ajax-site-alerts-jsonapi
 visibility:

--- a/docroot/modules/custom/mayflower/js/ajax-pattern-alerts.js
+++ b/docroot/modules/custom/mayflower/js/ajax-pattern-alerts.js
@@ -4,7 +4,7 @@
  *
  * Fields used in processing (formatted as query string):
  *  * fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display
- *  * fields[paragraph--emergency_alert]=id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content
+ *  * fields[paragraph--emergency_alert]=drupal_internal__id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content
  *  * fields[paragraph--target_pages]=field_target_content_ref
  *  * include=field_target_pages_para_ref,field_alert
  *  * filter[status][value]=1
@@ -125,14 +125,14 @@
             else if (item.relationships.field_emergency_alert_content.data.length > 0) {
               if (currentAlertItem.attributes.field_alert_display === 'site_wide') {
                 serializedAlertParagraph.link = {
-                  href: '/alerts' + '#' + item.attributes.id,
+                  href: '/alerts' + '#' + item.attributes.drupal_internal__id,
                   text: 'Read more',
                   chevron: true
                 };
               }
               else if (currentAlertItem.attributes.field_alert_display === 'specific_target_pages') {
                 serializedAlertParagraph.link = {
-                  href: currentAlertItem.attributes.entity_url + '#' + item.attributes.id,
+                  href: currentAlertItem.attributes.entity_url + '#' + item.attributes.drupal_internal__id,
                   text: 'Read more',
                   chevron: true
                 };


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
The link was not pointing at the correct html id on the page because the json output was not correct. Apparently the id of the paragraph is under `drupal_internal__id` and not simply id. 

If you visit [this endpoint](https://www.mass.gov/jsonapi/node/alert?page[limit]=250&sort=-changed&include=field_target_pages_para_ref,field_alert&filter[status][value]=1&fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display&fields[paragraph--emergency_alert]=id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content&fields[paragraph--target_pages]=field_target_content_ref) used by the alerts block you will see that there is no id in the json output.

![alert_endpoint](https://user-images.githubusercontent.com/11247942/77169753-69bc3b80-6a90-11ea-9591-631997558ce4.png)

If you visit [this endpoint](https://www.mass.gov/jsonapi/paragraph/emergency_alert) for the emergency_alert paragraph you will see that the id is actually called `drupal_internal__id`. 

![paragraph_endpoint](https://user-images.githubusercontent.com/11247942/77169859-94a68f80-6a90-11ea-993b-c1adc0699cf3.png)

So I adjusted the endpoint on the alerts block to use the correct field and adjusted the `ajax-pattern-alerts.js` file to use the correct field.






**Jira:**
https://jira.mass.gov/browse/DP-17810


**To Test:**
- [ ] Visit the homepage or any page that is showing the alerts bar
- [ ] Verify the links that point to the alerts page no longer have "undefined" as an id. They will have a paragraph id, something like this http://mass.local/alerts#1455786
- [ ] If you click the link you should link to the alerts page and be positioned down the page to that id


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
