### PR TITLE
Reduce edge cache lifetime for COVID-19 pages

### DIFF
--- a/changelogs/DP-17886.yml
+++ b/changelogs/DP-17886.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Shorten edge cache TTLs on COVID-19 related pages.
+    issue: DP-17886

--- a/cloudflare/src/backends.js
+++ b/cloudflare/src/backends.js
@@ -1,5 +1,5 @@
 
-const {isStaticUrl, isAlertsUrl, isDrupalResponse, isMediaDownloadUrl, isValidRedirect, isFileRedirect} = require('./util');
+const {isStaticUrl, isAlertsUrl, isCovidURL, isMediaDownloadUrl, isValidRedirect, isFileRedirect} = require('./util');
 // Used to ensure safe handling of content-disposition headers
 // for media download pre-resolution.
 const contentDisposition = require('content-disposition');
@@ -50,6 +50,11 @@ export function edit(token) {
     }
     else if(isStaticUrl(url)) {
       browserTTL = RESPECT_ORIGIN
+    }
+    // Temporarily shift all COVID-19 related pages to a 1 minute browser
+    // lifetime.
+    else if(isCovidURL(url)) {
+      browserTTL = 60;
     }
 
     let response = await fetch(backendRequest)
@@ -113,6 +118,12 @@ export function www(token) {
     else if(isStaticUrl(url)) {
       edgeTTL = RESPECT_ORIGIN
       browserTTL = RESPECT_ORIGIN
+    }
+    // Temporarily shift all COVID-19 related pages to a 1 minute edge/browser
+    // lifetime.
+    else if(isCovidURL(url)) {
+      edgeTTL = 60
+      browserTTL = 60;
     }
 
     // Fetch from the origin, overriding edge TTL if necessary.

--- a/cloudflare/src/util.js
+++ b/cloudflare/src/util.js
@@ -108,6 +108,10 @@ export function isMediaDownloadUrl(url) {
   return url.pathname.match(/^\/media\/\d+\/download$/) || url.pathname.match(/^\/doc\/[^\/]+\/download$/)
 }
 
+export function isCovidURL(url) {
+  return url.pathname.match(/covid/);
+}
+
 export function isValidRedirect(response) {
   return response.status === 301 && response.headers.has('location');
 }

--- a/cloudflare/tests/backends.js
+++ b/cloudflare/tests/backends.js
@@ -153,6 +153,7 @@ describe('WWW Backend', function() {
       ['https://www.mass.gov/alerts', 'public, max-age=604800, stale-if-error=604800, stale-while-revalidate=604800', 'public, max-age=60, stale-if-error=604800, stale-while-revalidate=604800'],
       ['https://www.mass.gov/', 'public, s-max-age=604800, max-age=604800, stale-if-error=604800, stale-while-revalidate=604800', 'public, s-max-age=604800, max-age=1800, stale-if-error=604800, stale-while-revalidate=604800'],
       ['https://www.mass.gov/', 'private', 'private'],
+      ['https://www.mass.gov/info-details/covid-19-cases-quarantine-and-monitoring', 'public, s-max-age=604800, max-age=604800, stale-if-error=604800, stale-while-revalidate=604800', 'public, s-max-age=604800, max-age=60, stale-if-error=604800, stale-while-revalidate=604800'],
   ]
   browserTTLTests.forEach(function([url, originResponseHeaders, expectedResponseHeaders]) {
 
@@ -192,6 +193,7 @@ describe('WWW Backend', function() {
     ['https://www.mass.gov/jsonapi/node/alert?foo=bar', {cf: {cacheTtl: 60}}],
     // No override is expected for static assets.
     ['https://www.mass.gov/foo.jpg', {cf: {}}],
+    ['https://www.mass.gov/info-details/covid-19-cases-quarantine-and-monitoring', {cf: {cacheTtl: 60}}],
   ]
 
   edgeTTLTests.forEach(function([url, expectedOverrides]) {


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR adjusts the edge TTL for urls that contain `covid` to 1 minute. After that time, requests will fall through to varnish, where they're expected to be cached for longer. 


**Jira:**
https://jira.mass.gov/browse/DP-17886


**To Test:**
- [ ] Deploy to CF, then visit `/info-details/covid-19-cases-quarantine-and-monitoring` in your browser.  Verify that you're getting back a 60 second cache lifetime. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
