### PR TITLE
DP-17851 Create redirect manager role - VERSION 2

### DIFF
--- a/changelogs/DP-17851.yml
+++ b/changelogs/DP-17851.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add a Redirect Manager role with redirect permissions.
+    issue: DP-17851

--- a/conf/drupal/config/system.action.user_add_role_action.d2d_redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_add_role_action.d2d_redirect_manager.yml
@@ -1,0 +1,14 @@
+uuid: a27b34bb-b82f-47e1-94bb-1653c66e4177
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.d2d_redirect_manager
+  module:
+    - user
+id: user_add_role_action.d2d_redirect_manager
+label: 'Add the D2D redirect manager role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: d2d_redirect_manager

--- a/conf/drupal/config/system.action.user_remove_role_action.d2d_redirect_manager.yml
+++ b/conf/drupal/config/system.action.user_remove_role_action.d2d_redirect_manager.yml
@@ -1,0 +1,14 @@
+uuid: 041b299d-857a-4d25-bf78-fb79d057d045
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.d2d_redirect_manager
+  module:
+    - user
+id: user_remove_role_action.d2d_redirect_manager
+label: 'Remove the D2D redirect manager role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: d2d_redirect_manager

--- a/conf/drupal/config/user.role.d2d_redirect_manager.yml
+++ b/conf/drupal/config/user.role.d2d_redirect_manager.yml
@@ -1,0 +1,11 @@
+uuid: 33214140-8b42-4f11-843e-60d9ecfd65c7
+langcode: en
+status: true
+dependencies: {  }
+id: d2d_redirect_manager
+label: 'D2D redirect manager'
+weight: 3
+is_admin: null
+permissions:
+  - 'administer redirects'
+  - 'display manage tab'


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
As a background on this ticket, a Redirect Manager role was created directly on the LIVE site. The LIVE site DB was then copied to the Feature3 environment. Now what we are doing is getting the config into code so the changes made directly to the LIVE site will not be overridden next deploy.

So I created a DB backup from the Feature3 Acquia environment and pulled this locally. I exported config and committed the 3 Redirect Manager config files. 

**Jira:**
https://jira.mass.gov/browse/DP-17851


**To Test:**
- [ ] Give a user with the Author role the Redirect Manager role as well
- [ ] Verify the Manage tab is visible and you can click on the D2D Redirects link
- [ ] Verify you can create/edit/save a redirect and it works correctly

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
