### PR TITLE
Use yarn danger local command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
     steps:
       - attach_workspace: {at: /var/www}
       - run:
-          command: "DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
+          command: "DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger local --failOnErrors"
 
   # Automate the tagging process in GitHub
   tagging_github:


### PR DESCRIPTION
This lets us turn back on testing for branches without pull requests. That setting was getting awkward for our hotfix workflow, and PR-from-fork workflow.

**Jira:**
https://jira.mass.gov/browse/DP-17838


**To Test:**
- [ ] Notice that on this very PR a lack of changelog failed and then this PR passes once added.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
