### PR TITLE
At CircleCI, fail Danger job if no PR exists.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - attach_workspace: {at: /var/www}
       - run:
           #Fail when there is no PR. This helps avoid false positives given by Danger when no PR exists.
-          command: [ -z "${CIRCLE_PULL_REQUEST}" ] && DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors
+          command: "[ -z ${CIRCLE_PULL_REQUEST} ] && DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - attach_workspace: {at: /var/www}
       - run:
           #Fail when there is no PR. This helps avoid false positives given by Danger when no PR exists.
-          command: "[ -z ${CIRCLE_PULL_REQUEST} ] && DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
+          command: "[ -n ${CIRCLE_PULL_REQUEST} ] && DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,8 @@ jobs:
     steps:
       - attach_workspace: {at: /var/www}
       - run:
-          command: "DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors"
+          #Fail when there is no PR. This helps avoid false positives given by Danger when no PR exists.
+          command: [ -z "${CIRCLE_PULL_REQUEST}" ] && DANGER_GITHUB_API_TOKEN=$GITHUB_MASSGOV_BOT_TOKEN yarn danger ci --failOnErrors
 
   # Automate the tagging process in GitHub
   tagging_github:

--- a/changelogs/DP-17938.yml
+++ b/changelogs/DP-17938.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: At CircleCI, fail Danger if no PR exists.
+    issue: DP-17938


### PR DESCRIPTION
This lets us turn back on testing for branches without pull requests. That setting was getting awkward for our hotfix workflow, and PR-from-fork workflow.

**Jira:**
https://jira.mass.gov/browse/DP-17938


**To Test:**
- [ ] Not easily testable until after merge.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
