### PR TITLE
DP-17772: Block alerts on most backstop pages

### DIFF
--- a/backstop/all.json
+++ b/backstop/all.json
@@ -2,6 +2,7 @@
   {"label": "404", "url": "/this-page-does-not-exist"},
   {"label": "Document", "url": "/media/1268726"},
   {"label": "Homepage", "url": "/"},
+  {"label": "HomepageWithAlert", "url":  "/", "showAlerts":  true},
   {"label": "StateAZ", "url": "/state-a-to-z"},
   {"label": "Advisory", "url": "/memorandum/qag-advisory"},
   {"label": "BinderAudit", "url": "/audit/qag-binderaudit"},

--- a/backstop/backstop.js
+++ b/backstop/backstop.js
@@ -39,10 +39,10 @@ const scenarios = pages.map(function(page) {
       auth = getAuth();
   }
   return {
-      label: page.label,
-      url: `${base}${page.url}`,
-      auth: auth,
-      misMatchThreshold: 0.05,
+    ...page,
+    url: `${base}${page.url}`,
+    misMatchThreshold: 0.05,
+    auth,
   }
 });
 

--- a/backstop/pages.json
+++ b/backstop/pages.json
@@ -1,5 +1,6 @@
 [
   {"label": "Homepage", "url": "/"},
+  {"label": "HomepageWithAlert", "url":  "/", "showAlerts":  true},
   {"label": "404", "url": "/this-page-does-not-exist"},
   {"label": "Document", "url": "/media/1268726"},
   {"label": "Advisory", "url": "/memorandum/qag-advisory"},

--- a/backstop/scripts/before.js
+++ b/backstop/scripts/before.js
@@ -4,7 +4,7 @@ module.exports = async (page, scenario, vp) => {
       await page.authenticate(scenario.auth)
     }
     await page.setRequestInterception(true);
-    page.on('request', interceptRequest);
+    page.on('request', createRequestInterceptor(scenario));
 }
 
 function escapeRegexp(string) {
@@ -21,37 +21,54 @@ const banned = [
   'www.youtube.com',
   'bam.nr-data.net',
   'maps.googleapis.com',
-  '9p83os0fkf.execute-api.us-east-1.amazonaws.com/v1/waittime'
+  '9p83os0fkf.execute-api.us-east-1.amazonaws.com/v1/waittime',
+  'player.vimeo.com',
+  'https://massgov.github.io/FWE/PondMaps/dfw-pond-maps-table.html',
 ];
 // Block scripts that do analytics tracking, have side effects based on
 // domain, or cause timeouts on page load because they load in lots of extra
 // stuff.
 const bannedRE = new RegExp(banned.map(escapeRegexp).join('|'))
 
-async function interceptRequest(request) {
+function createRequestInterceptor(scenario) {
+
+  return function intercept(request) {
     let urlMatch;
+    const url = request.url();
 
     // Replace static maps with a placeholder image of the same size.
-    if(urlMatch = request.url().match(/maps\.googleapis\.com\/maps\/api\/staticmap.*size=(\d+x\d+)/)) {
-      request.respond({
+    if(urlMatch = url.match(/maps\.googleapis\.com\/maps\/api\/staticmap.*size=(\d+x\d+)/)) {
+      return request.respond({
         status: 301,
         headers: {"Location": `https://via.placeholder.com/${urlMatch[1]}/B2DEA2.png?text=Static%20Map`}
-      })
-      return
+      });
     }
     // Replace hero images with placeholder images. Hero images can be randomized, so we just
-    // replace them with their
-    if(urlMatch = request.url().match(/\/files\/styles\/hero(\d+x\d+)/)) {
-      request.respond({
+    // replace them with their placeholder equivalents.
+    if(urlMatch = url.match(/\/files\/styles\/hero(\d+x\d+)/)) {
+      return request.respond({
         status: 301,
         headers: {Location: `https://via.placeholder.com/${urlMatch[1]}.png?text=Hero%20Image`}
-      })
-      return;
+      });
     }
 
-    if(bannedRE.test(request.url())) {
-        request.abort()
-    } else {
-        request.continue()
+    if(!scenario.showAlerts && url.match(/\/jsonapi\/node\/alert/)) {
+      return request.respond({
+        status: 200,
+        headers: {"Content-Type": 'application/json'},
+        body: JSON.stringify({
+          jsonapi: {},
+          data: [],
+          included: [],
+          links: {}
+        })
+      });
     }
+
+    if(bannedRE.test(url)) {
+      return request.abort()
+    } else {
+      return request.continue();
+    }
+  }
 }

--- a/changelogs/DP-17772.yml
+++ b/changelogs/DP-17772.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Block alerts in most BackstopJS tests.
+    issue: DP-17772


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR hides alerts from most BackstopJS tests by returning an empty JSON response for the `/jsonapi/node/alerts` endpoint when it is requested.  The blocking can be enabled/disabled by using the `showAlerts` property on any scenario.  I kept a version of the homepage that allows alerts as per the ticket. 

**Jira:**
https://jira.mass.gov/browse/DP-17772


**To Test:**
- [ ] Run `backstop reference --target=production`
- [ ] Run `backstop test --reference=production`
- [ ] Run `open backstop/reports/index.html` to open the report in your browser.
- [ ] Verify that alerts are not displaying on any page but `HomepageWithAlert`.  


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
