### PR TITLE
DP-17891: Prevent publishing more than one sitewide alert node at a time

### DIFF
--- a/changelogs/DP-17891.yml
+++ b/changelogs/DP-17891.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Add validation to prevent publishing more than 1 sitewide alert at a time.
+    issue: DP-17891

--- a/composer.lock
+++ b/composer.lock
@@ -2418,7 +2418,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1559549585",
+                    "datestamp": "1531380221",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -2474,7 +2474,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.16",
-                    "datestamp": "1576179185",
+                    "datestamp": "1549478497",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2487,20 +2487,12 @@
             ],
             "authors": [
                 {
-                    "name": "Dane Powell",
-                    "homepage": "https://www.drupal.org/user/339326"
-                },
-                {
                     "name": "Mark Trapp",
                     "homepage": "https://www.drupal.org/user/212019"
                 },
                 {
                     "name": "Stanislav Mixnovich",
                     "homepage": "https://www.drupal.org/user/2859977"
-                },
-                {
-                    "name": "acquia",
-                    "homepage": "https://www.drupal.org/user/1231722"
                 },
                 {
                     "name": "ayang",
@@ -2515,16 +2507,16 @@
                     "homepage": "https://www.drupal.org/user/411965"
                 },
                 {
-                    "name": "grasmash",
-                    "homepage": "https://www.drupal.org/user/455714"
-                },
-                {
                     "name": "irek02",
                     "homepage": "https://www.drupal.org/user/736644"
                 },
                 {
                     "name": "kolafson",
                     "homepage": "https://www.drupal.org/user/822402"
+                },
+                {
+                    "name": "mundanity",
+                    "homepage": "https://www.drupal.org/user/373605"
                 },
                 {
                     "name": "vlad.pavlovic",
@@ -2534,7 +2526,7 @@
             "description": "Allows Drupal websites to connect with Acquia.",
             "homepage": "https://www.drupal.org/project/acquia_connector",
             "support": {
-                "source": "https://git.drupalcode.org/project/acquia_connector"
+                "source": "http://cgit.drupalcode.org/acquia_connector"
             }
         },
         {
@@ -2618,7 +2610,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.6",
-                    "datestamp": "1559642884",
+                    "datestamp": "1554334685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2641,10 +2633,6 @@
                 {
                     "name": "googletorp",
                     "homepage": "https://www.drupal.org/user/386230"
-                },
-                {
-                    "name": "jsacksick",
-                    "homepage": "https://www.drupal.org/user/972218"
                 },
                 {
                     "name": "mglaman",
@@ -2685,7 +2673,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.26",
-                    "datestamp": "1558552081",
+                    "datestamp": "1549559402",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2766,7 +2754,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1573747386",
+                    "datestamp": "1492709942",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2786,7 +2774,7 @@
             "description": "Limit which text formats are available for each field instance.",
             "homepage": "https://www.drupal.org/project/allowed_formats",
             "support": {
-                "source": "https://git.drupalcode.org/project/allowed_formats"
+                "source": "http://cgit.drupalcode.org/allowed_formats"
             }
         },
         {
@@ -3141,16 +3129,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1461060840"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3165,7 +3149,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3617,10 +3601,6 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
-                },
-                {
                     "name": "slashrsm",
                     "homepage": "https://www.drupal.org/user/744628"
                 },
@@ -3632,7 +3612,7 @@
             "description": "Provides storage and API for image crops.",
             "homepage": "https://www.drupal.org/project/crop",
             "support": {
-                "source": "https://git.drupalcode.org/project/crop",
+                "source": "http://cgit.drupalcode.org/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
             }
         },
@@ -3661,11 +3641,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1514993285",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1470405718"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3681,7 +3657,7 @@
             "description": "Provides CSV as a serialization format.",
             "homepage": "https://www.drupal.org/project/csv_serialization",
             "support": {
-                "source": "https://git.drupalcode.org/project/csv_serialization"
+                "source": "http://cgit.drupalcode.org/csv_serialization"
             }
         },
         {
@@ -4107,11 +4083,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4179,16 +4151,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha7",
-                    "datestamp": "1508835844",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Project has not opted into security advisory coverage!"
-                    }
+                    "datestamp": "1495200183"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -4223,7 +4191,7 @@
             "description": "DropzoneJS Entity browser widget",
             "homepage": "https://www.drupal.org/project/dropzonejs",
             "support": {
-                "source": "https://git.drupalcode.org/project/dropzonejs"
+                "source": "http://cgit.drupalcode.org/dropzonejs"
             }
         },
         {
@@ -4250,7 +4218,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1536250980",
+                    "datestamp": "1516093086",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4309,11 +4277,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1575666184",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1490755685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -4345,7 +4309,7 @@
             "description": "Provide a framework for various different types of embeds in WYSIWYG editors, common functionality, interfaces, and standards.",
             "homepage": "https://www.drupal.org/project/embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/embed",
+                "source": "http://cgit.drupalcode.org/embed",
                 "issues": "https://www.drupal.org/project/issues/embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -4513,11 +4477,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1502200443",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1492678144"
                 },
                 "patches_applied": {
                     "Fix duplicated image selection when click use selected button": "https://www.drupal.org/files/issues/prevent-duplication.patch",
@@ -4545,20 +4505,12 @@
                     "role": "contributor"
                 },
                 {
-                    "name": "Drupal Media Team",
-                    "homepage": "https://www.drupal.org/user/3260690"
-                },
-                {
                     "name": "Primsi",
                     "homepage": "https://www.drupal.org/user/282629"
                 },
                 {
                     "name": "marcingy",
                     "homepage": "https://www.drupal.org/user/77320"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
                 },
                 {
                     "name": "samuel.mortenson",
@@ -4605,11 +4557,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1556906881",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476698339"
                 },
                 "patches_applied": {
                     "Use array for class attribute in EntityEmbedBuilder.php": "https://www.drupal.org/files/issues/2019-04-02/entity-embed-beta2-3021505-12.patch"
@@ -4633,20 +4581,8 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "Wim Leers",
-                    "homepage": "https://www.drupal.org/user/99777"
-                },
-                {
                     "name": "cs_shadow",
                     "homepage": "https://www.drupal.org/user/2828287"
-                },
-                {
-                    "name": "oknate",
-                    "homepage": "https://www.drupal.org/user/471638"
-                },
-                {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
                 },
                 {
                     "name": "slashrsm",
@@ -4656,7 +4592,7 @@
             "description": "Allows any entity to be embedded within a text area using a WYSIWYG editor.",
             "homepage": "https://www.drupal.org/project/entity_embed",
             "support": {
-                "source": "https://git.drupalcode.org/project/entity_embed",
+                "source": "http://cgit.drupalcode.org/entity_embed",
                 "issues": "https://www.drupal.org/project/issues/entity_embed",
                 "irc": "irc://irc.freenode.org/drupal-media"
             }
@@ -4981,21 +4917,21 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1504182544",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1485942783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "fabianderijk",
                     "homepage": "https://www.drupal.org/user/278745"
+                },
+                {
+                    "name": "msankhala",
+                    "homepage": "https://www.drupal.org/user/882726"
                 },
                 {
                     "name": "tomvv",
@@ -5005,7 +4941,7 @@
             "description": "Interface for unblocking ip's that are blocked by the flood table",
             "homepage": "https://www.drupal.org/project/flood_unblock",
             "support": {
-                "source": "https://git.drupalcode.org/project/flood_unblock"
+                "source": "http://cgit.drupalcode.org/flood_unblock"
             }
         },
         {
@@ -5036,7 +4972,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta6",
-                    "datestamp": "1553270584",
+                    "datestamp": "1519932484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5056,7 +4992,7 @@
             "description": "Allows users to specify the focal point of an image for use during cropping.",
             "homepage": "https://www.drupal.org/project/focal_point",
             "support": {
-                "source": "https://git.drupalcode.org/project/focal_point"
+                "source": "http://cgit.drupalcode.org/focal_point"
             }
         },
         {
@@ -5326,16 +5262,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1519597081",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1494796685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5354,7 +5286,7 @@
             "description": "Defines a field type for Google Maps.",
             "homepage": "https://www.drupal.org/project/google_map_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_map_field"
+                "source": "http://cgit.drupalcode.org/google_map_field"
             }
         },
         {
@@ -5381,7 +5313,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1516807385",
+                    "datestamp": "1506872944",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5390,7 +5322,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5401,7 +5333,7 @@
             "description": "Provides some handy cache tags for developers.",
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
-                "source": "https://git.drupalcode.org/project/handy_cache_tags"
+                "source": "http://cgit.drupalcode.org/handy_cache_tags"
             }
         },
         {
@@ -5428,7 +5360,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1578136083",
+                    "datestamp": "1501159742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5452,7 +5384,7 @@
             "description": "Allows addition, removal and modification of http headers.",
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
-                "source": "https://git.drupalcode.org/project/http_response_headers"
+                "source": "http://cgit.drupalcode.org/http_response_headers"
             }
         },
         {
@@ -5669,7 +5601,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.10",
-                    "datestamp": "1573604580",
+                    "datestamp": "1567172584",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6433,7 +6365,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.9",
-                    "datestamp": "1567099985",
+                    "datestamp": "1563995941",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7107,7 +7039,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta1",
-                    "datestamp": "1565535787",
+                    "datestamp": "1485452283",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Project has not opted into security advisory coverage!"
@@ -7116,16 +7048,12 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "gabrielu",
                     "homepage": "https://www.drupal.org/user/279352"
-                },
-                {
-                    "name": "otrolopezmas",
-                    "homepage": "https://www.drupal.org/user/3516204"
                 },
                 {
                     "name": "plopesc",
@@ -7139,7 +7067,7 @@
             "description": "Provides the ability to import redirects for the Redirect module",
             "homepage": "https://www.drupal.org/project/path_redirect_import",
             "support": {
-                "source": "https://git.drupalcode.org/project/path_redirect_import"
+                "source": "http://cgit.drupalcode.org/path_redirect_import"
             }
         },
         {
@@ -7281,16 +7209,12 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1550607785",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1476410954"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7302,10 +7226,6 @@
                     "homepage": "https://www.drupal.org/user/41738"
                 },
                 {
-                    "name": "heddn",
-                    "homepage": "https://www.drupal.org/user/1463982"
-                },
-                {
                     "name": "jbrauer",
                     "homepage": "https://www.drupal.org/user/12363"
                 }
@@ -7313,7 +7233,7 @@
             "description": "Allows form elements to be prepopulated from the URL.",
             "homepage": "https://www.drupal.org/project/prepopulate",
             "support": {
-                "source": "https://git.drupalcode.org/project/prepopulate"
+                "source": "http://cgit.drupalcode.org/prepopulate"
             }
         },
         {
@@ -7340,7 +7260,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0",
-                    "datestamp": "1535381280",
+                    "datestamp": "1524571684",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7359,7 +7279,7 @@
             ],
             "homepage": "https://www.drupal.org/project/private_files_download_permission",
             "support": {
-                "source": "https://git.drupalcode.org/project/private_files_download_permission"
+                "source": "http://cgit.drupalcode.org/private_files_download_permission"
             }
         },
         {
@@ -7776,16 +7696,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.15",
-                    "datestamp": "1541330284",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1496919842"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -7808,7 +7724,7 @@
             "description": "Provides a user interface to manage REST resources",
             "homepage": "https://www.drupal.org/project/restui",
             "support": {
-                "source": "https://git.drupalcode.org/project/restui"
+                "source": "http://cgit.drupalcode.org/restui"
             }
         },
         {
@@ -7897,7 +7813,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1566566888",
+                    "datestamp": "1510690385",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7989,10 +7905,6 @@
                 {
                     "name": "thunderbot",
                     "homepage": "https://www.drupal.org/user/3511180"
-                },
-                {
-                    "name": "volkerk",
-                    "homepage": "https://www.drupal.org/user/57527"
                 }
             ],
             "description": "Scheduler content moderation integration",
@@ -8031,7 +7943,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1563033785",
+                    "datestamp": "1527343084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8162,7 +8074,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.13",
-                    "datestamp": "1562599986",
+                    "datestamp": "1557244685",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8237,7 +8149,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.2",
-                    "datestamp": "1575044885",
+                    "datestamp": "1549962207",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8306,16 +8218,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha2",
-                    "datestamp": "1534196880",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
+                    "datestamp": "1470853439"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8327,10 +8235,6 @@
                     "homepage": "https://www.drupal.org/user/152788"
                 },
                 {
-                    "name": "mcdruid",
-                    "homepage": "https://www.drupal.org/user/255969"
-                },
-                {
                     "name": "p0deje",
                     "homepage": "https://www.drupal.org/user/529960"
                 }
@@ -8338,7 +8242,7 @@
             "description": "Enhance security of your Drupal website.",
             "homepage": "https://www.drupal.org/project/seckit",
             "support": {
-                "source": "https://git.drupalcode.org/project/seckit"
+                "source": "http://cgit.drupalcode.org/seckit"
             }
         },
         {
@@ -8419,7 +8323,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.12",
-                    "datestamp": "1542505221",
+                    "datestamp": "1523203180",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8480,7 +8384,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha3",
-                    "datestamp": "1555515785",
+                    "datestamp": "1499900942",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8497,7 +8401,7 @@
                     "homepage": "https://www.drupal.org/user/107229"
                 },
                 {
-                    "name": "geek.merlin aka axel.rutz",
+                    "name": "axel.rutz",
                     "homepage": "https://www.drupal.org/user/229048"
                 },
                 {
@@ -8528,7 +8432,7 @@
             "description": "Provides stage_file_proxy module.",
             "homepage": "https://www.drupal.org/project/stage_file_proxy",
             "support": {
-                "source": "https://git.drupalcode.org/project/stage_file_proxy"
+                "source": "http://cgit.drupalcode.org/stage_file_proxy"
             }
         },
         {
@@ -8555,7 +8459,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-rc1",
-                    "datestamp": "1576842184",
+                    "datestamp": "1538584980",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
@@ -8750,7 +8654,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1538316180",
+                    "datestamp": "1496774342",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -8759,7 +8663,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8778,7 +8682,7 @@
             "description": "Provides a UI to manage guided tours.",
             "homepage": "https://www.drupal.org/project/tour_ui",
             "support": {
-                "source": "https://git.drupalcode.org/project/tour_ui"
+                "source": "http://cgit.drupalcode.org/tour_ui"
             }
         },
         {
@@ -8805,16 +8709,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.1",
-                    "datestamp": "1549817580",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1474037939"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -8825,7 +8725,7 @@
             "description": "Twig filters for value(s) and label.",
             "homepage": "https://www.drupal.org/project/twig_field_value",
             "support": {
-                "source": "https://git.drupalcode.org/project/twig_field_value"
+                "source": "http://cgit.drupalcode.org/twig_field_value"
             }
         },
         {
@@ -8855,11 +8755,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.8",
-                    "datestamp": "1505464444",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1495984083"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8907,7 +8803,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta2",
-                    "datestamp": "1575368885",
+                    "datestamp": "1533049984",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -8927,7 +8823,7 @@
             "description": "Prevents username enumeration on password reset and user pages.",
             "homepage": "https://www.drupal.org/project/username_enumeration_prevention",
             "support": {
-                "source": "https://git.drupalcode.org/project/username_enumeration_prevention"
+                "source": "http://cgit.drupalcode.org/username_enumeration_prevention"
             }
         },
         {
@@ -8959,7 +8855,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.x",
-                    "datestamp": "1557724385",
+                    "datestamp": "1523338084",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -8988,7 +8884,7 @@
             "description": "A pluggable field type for storing videos from external video hosts such as Vimeo and YouTube.",
             "homepage": "https://www.drupal.org/project/video_embed_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/video_embed_field"
+                "source": "http://cgit.drupalcode.org/video_embed_field"
             }
         },
         {
@@ -9041,7 +8937,7 @@
             "description": "Makes it possible to create (additional) paths where entities will be shown in a given view_mode",
             "homepage": "https://www.drupal.org/project/view_mode_page",
             "support": {
-                "source": "https://git.drupalcode.org/project/view_mode_page"
+                "source": "http://cgit.drupalcode.org/view_mode_page"
             }
         },
         {
@@ -9092,7 +8988,7 @@
             "description": "Use Autocomplete for string field filters.",
             "homepage": "https://www.drupal.org/project/views_autocomplete_filters",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_autocomplete_filters"
+                "source": "http://cgit.drupalcode.org/views_autocomplete_filters"
             }
         },
         {
@@ -9192,7 +9088,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1554840781",
+                    "datestamp": "1471704539",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -9201,7 +9097,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -9212,7 +9108,7 @@
             "description": "Add views custom cache tag.",
             "homepage": "https://www.drupal.org/project/views_custom_cache_tag",
             "support": {
-                "source": "https://git.drupalcode.org/project/views_custom_cache_tag"
+                "source": "http://cgit.drupalcode.org/views_custom_cache_tag"
             }
         },
         {
@@ -17540,12 +17436,12 @@
             "source": {
                 "type": "git",
                 "url": "https://gitlab.com/weitzman/logintrait.git",
-                "reference": "e3e3c66754d03c501c9b6248a1d2c88c51647f20"
+                "reference": "56fc9f9719c5bde1ce9770f27c0732c11a96a479"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/weitzman%2Flogintrait/repository/archive.zip?sha=e3e3c66754d03c501c9b6248a1d2c88c51647f20",
-                "reference": "e3e3c66754d03c501c9b6248a1d2c88c51647f20",
+                "url": "https://gitlab.com/api/v4/projects/weitzman%2Flogintrait/repository/archive.zip?sha=56fc9f9719c5bde1ce9770f27c0732c11a96a479",
+                "reference": "56fc9f9719c5bde1ce9770f27c0732c11a96a479",
                 "shasum": ""
             },
             "require-dev": {
@@ -17569,7 +17465,7 @@
                 }
             ],
             "description": "Provides login/logout via user reset URL instead of forms.",
-            "time": "2019-02-02T12:59:52+00:00"
+            "time": "2019-04-19T11:52:16+00:00"
         }
     ],
     "aliases": [],

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -12,6 +12,7 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\mass_content_moderation\MassModeration;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_form_FORM_ID_alter() for the FORM_ID() form.
@@ -84,8 +85,12 @@ function _mass_alerts_validate_site_wide_alert_creation(array &$form, FormStateI
       if ($entity->id()) {
         $query->condition('nid', $entity->id(), '!=');
       }
-      if ($query->count()->execute() > 0) {
-        $form_state->setErrorByName('moderation_state', 'A published site wide alert already exists.');
+      $existing = $query->execute();
+      if (count($existing) > 0) {
+        if ($existingNode = Node::load(reset($existing))) {
+          $link = $existingNode->toLink()->toString();
+          $form_state->setError($form, t('This sitewide alert cannot be published because another sitewide alert is currently active: %link. Only one sitewide alert can be active at a time. To publish this alert, please unpublish the existing one first.', ['%link' => $link]));
+        }
       }
     }
   }

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -65,7 +65,7 @@ function mass_alerts_validate_alert_placement(array &$form, FormStateInterface $
  * Validates site wide alert creation.
  */
 function _mass_alerts_validate_site_wide_alert_creation(array &$form, FormStateInterface $form_state) {
-  $alert_display = $form_state->getValue(['field_alert_display', 0, 'value']);
+  $alert_display = $form_state->getValue(['field_alert_display', '0', 'value']);
   if ($alert_display == "site_wide") {
     // Only users with permission should be allowed site wide alert creation.
     if (!\Drupal::currentUser()->hasPermission('create site wide alerts')) {

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -64,8 +64,8 @@ function mass_alerts_validate_alert_placement(array &$form, FormStateInterface $
  * Validates site wide alert creation.
  */
 function _mass_alerts_validate_site_wide_alert_creation(array &$form, FormStateInterface $form_state) {
-  $alert_display_scope = $form_state->getValue('field_alert_display');
-  if ($alert_display_scope[0]["value"] == "site_wide") {
+  $alert_display = $form_state->getValue(['field_alert_display', 0, 'value']);
+  if ($alert_display == "site_wide") {
     // Only users with permission should be allowed site wide alert creation.
     if (!\Drupal::currentUser()->hasPermission('create site wide alerts')) {
       $form_state->setErrorByName('field_alert_display', t('Only users with elevated permissions can manage sitewide alerts.'));
@@ -73,24 +73,19 @@ function _mass_alerts_validate_site_wide_alert_creation(array &$form, FormStateI
 
     // A maximum of only 1 site wide alert should be publishable at any given time.
     // Only prevent publishing, not drafting.
-    $trigger = $form_state->getTriggeringElement();
-    if (array_key_exists('#moderation_state', $trigger) && $trigger['#moderation_state'] == "published") {
-      $thisFormsAlertNode = $form_state->getFormObject()->getEntity();
+    $moderationState = $form_state->getValue(['moderation_state', '0', 'value']);
+    if ($moderationState === 'published') {
+      $entity = $form_state->getFormObject()->getEntity();
       $query = \Drupal::entityQuery('node')
-        ->condition('status', NODE_PUBLISHED)
+        ->condition('status', NodeInterface::PUBLISHED)
         ->condition('type', 'alert')
         ->condition('field_alert_display', 'site_wide');
-      $result = $query->execute();
-      $existingAlertNodeIds = array_values($result);
-      if (count($existingAlertNodeIds) > 1) {
-        drupal_set_message(t("Multiple site wide alerts are already published."), 'error');
-        $form_state->setRebuild();
+      // Exclude the current node from our search if it's already been saved.
+      if ($entity->id()) {
+        $query->condition('nid', $entity->id(), '!=');
       }
-      else {
-        if (count($existingAlertNodeIds) == 1 && $existingAlertNodeIds[0] != $thisFormsAlertNode->id()) {
-          drupal_set_message(t("A published site wide alert already exists."), 'error');
-          $form_state->setRebuild();
-        }
+      if ($query->count()->execute() > 0) {
+        $form_state->setErrorByName('moderation_state', 'A published site wide alert already exists.');
       }
     }
   }

--- a/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
+++ b/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
@@ -79,6 +79,10 @@ class EmergencyAlertsTest extends ExistingSiteBase {
    * Assert that our validation prevents saving multiple sitewide alerts.
    */
   public function testSitewideAlert() {
+    $user = User::load(1)->set('status', 1);
+    $user->save();
+    $this->drupalLogin($user);
+
     // Save 1 sitewide alert to start with.
     $this->createNode([
       'type' => 'alert',
@@ -90,10 +94,6 @@ class EmergencyAlertsTest extends ExistingSiteBase {
         'field_emergency_alert_message' => 'test',
       ])
     ]);
-
-    $user = User::load(1)->set('status', 1);
-    $user->save();
-    $this->drupalLogin($user);
     $session = $this->getSession();
     $session->visit('/node/add/alert');
     $page = $session->getPage();

--- a/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
+++ b/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
@@ -74,4 +74,28 @@ class EmergencyAlertsTest extends ExistingSiteBase {
     $this->assertContains('must show on at least one page', $page->getText());
   }
 
+  /**
+   * Assert that our validation prevents saving multiple sitewide alerts.
+   */
+  public function testSitewideAlert() {
+    // Save 1 sitewide alert to start with.
+    $this->createNode([
+      'type' => 'alert',
+      'field_alert_display' => 'site_wide',
+      'moderation_state' => 'published',
+      'status' => 1,
+    ]);
+
+    $user = User::load(1)->set('status', 1);
+    $user->save();
+    $this->drupalLogin($user);
+    $session = $this->getSession();
+    $session->visit('/node/add/alert');
+    $page = $session->getPage();
+    $page->fillField('field_alert_display', 'site_wide');
+    $page->selectFieldOption('moderation_state[0][state]', 'published');
+    $page->findButton('Save')->press();
+    $this->assertContains('A published site wide alert already exists.', $page->getText());
+  }
+
 }

--- a/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
+++ b/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
@@ -95,7 +95,7 @@ class EmergencyAlertsTest extends ExistingSiteBase {
     $page->fillField('field_alert_display', 'site_wide');
     $page->selectFieldOption('moderation_state[0][state]', 'published');
     $page->findButton('Save')->press();
-    $this->assertContains('A published site wide alert already exists.', $page->getText());
+    $this->assertContains('This sitewide alert cannot be published because another sitewide alert is currently active:', $page->getText());
   }
 
 }

--- a/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
+++ b/docroot/modules/custom/mass_alerts/tests/src/ExistingSite/EmergencyAlertsTest.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\mass_alerts\ExistingSite;
 
 use Drupal\mass_content_moderation\MassModeration;
 use Drupal\node\Entity\Node;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\user\Entity\User;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 use weitzman\LoginTrait\LoginTrait;
@@ -84,6 +85,10 @@ class EmergencyAlertsTest extends ExistingSiteBase {
       'field_alert_display' => 'site_wide',
       'moderation_state' => 'published',
       'status' => 1,
+      'field_alert' => Paragraph::create([
+        'type' => 'emergency_alert',
+        'field_emergency_alert_message' => 'test',
+      ])
     ]);
 
     $user = User::load(1)->set('status', 1);


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR adjusts some validation code we had in place to prevent publishing more than one site wide alert at a time.  I suspect this code broke in the content moderation upgrade.  Anyway, it works now, and there's a test for it. 


**Jira:**
https://jira.mass.gov/browse/DP-17891


**To Test:**
- [ ] Ensure that there is a sitewide emergency alert published.  If there isn't one, create one.
- [ ] Attempt to create a new sitewide emergency alert and verify that you receive an error message.
- [ ] Attempt to edit the currently published emergency alert and verify that you are able to update it. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
