### PR TITLE
DP-16701 Add alt text for org logo of signee in news page

### DIFF
--- a/changelogs/DP-16701.yml
+++ b/changelogs/DP-16701.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Add alt value to a linked image for an organization as a signee in news page.
+    issue: DP-16701

--- a/docroot/modules/custom/mayflower/src/Prepare/Molecules.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Molecules.php
@@ -160,9 +160,17 @@ class Molecules {
           $src = Helper::getFieldImageUrl($entity, 'activities_image', $fields['image']);
         }
 
+        $alt = '';
+        if ($entity->{$fields['image']}->alt) {
+          $alt = $entity->{$fields['image']}->alt;
+        }
+        else {
+          $alt = $options['alt'];
+        }
+
         $imagePromo['image'] = [
           'src' => $src,
-          'alt' => $entity->{$fields['image']}->alt,
+          'alt' => $alt,
           'href' => $href,
         ];
 

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3428,12 +3428,14 @@ function mass_theme_preprocess_node_news_full(&$variables) {
           if ($org_page = reset($org_refs)) {
             $promo_options = [
               'title' => Helper::fieldValue($org_page, 'title'),
+              'alt' => Helper::fieldValue($org_page, 'title'),
             ];
           }
         }
         else {
           $promo_options = [
             'title' => Helper::fieldValue($signee_entity, $org_data['title']),
+            'alt' => Helper::fieldValue($signee_entity, $org_data['title']),
           ];
         }
       }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Add alt text for a linked org logo of a signee in news page.
Set the `alt` value as the org. name shown as the text title in the component.

**Jira:**
https://jira.mass.gov/browse/DP-16701


**To Test:**
- [ ] Go to any news page with signees at the bottom of the page.
      Samples: /news/qag-newspressrelease, /news/qag-newspressstatement
- [ ] At the signees at the bottom of the page, inspect their images for their `alt` attribute has a value.
- [ ] Find the `alt` value matches its text title as an org name.
<img width="608" alt="sample1" src="https://user-images.githubusercontent.com/9633303/77767475-82d86580-7017-11ea-8d7c-16ba4856f083.png">

<img width="563" alt="sample2" src="https://user-images.githubusercontent.com/9633303/77767482-85d35600-7017-11ea-9dd5-ee7de48c6679.png">

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
