### PR TITLE
DP-17972 Add new banner to info_details page

### DIFF
--- a/changelogs/DP-17972.yml
+++ b/changelogs/DP-17972.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added a new banner-image field to info_details node which provided an alternate header option.
+    issue: DP-17972

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -22,12 +23,14 @@ dependencies:
     - field.field.node.info_details.field_reusable_label
     - field.field.node.info_details.field_short_desc
     - field.field.node.info_details.field_state_organization_tax
+    - image.style.thumbnail
     - node.type.info_details
     - workflows.workflow.editorial
   module:
     - content_moderation
     - datetime
     - field_group
+    - image
     - link
     - mass_validation
     - metatag
@@ -55,6 +58,7 @@ third_party_settings:
       children:
         - title
         - field_short_desc
+        - field_banner_image
         - field_info_detail_overview
         - group_header_media
         - field_info_details_date_publishe
@@ -107,7 +111,7 @@ third_party_settings:
       children:
         - field_info_details_header_media
       parent_name: group_overview
-      weight: 4
+      weight: 5
       format_type: fieldset
       format_settings:
         label: 'Header Media'
@@ -135,6 +139,14 @@ targetEntityType: node
 bundle: info_details
 mode: default
 content:
+  field_banner_image:
+    weight: 3
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
   field_contact:
     weight: 27
     settings:
@@ -146,13 +158,13 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_data_flag:
-    weight: 10
+    weight: 11
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_data_resource_type:
-    weight: 12
+    weight: 13
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -176,7 +188,7 @@ content:
     type: options_buttons
     region: content
   field_details_data_type:
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -216,7 +228,7 @@ content:
     type: string_textfield
     region: content
   field_info_detail_overview:
-    weight: 3
+    weight: 4
     settings:
       rows: 5
       placeholder: ''
@@ -224,7 +236,7 @@ content:
     type: text_textarea
     region: content
   field_info_details_date_publishe:
-    weight: 5
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -242,7 +254,7 @@ content:
     third_party_settings: {  }
     region: content
   field_info_details_last_updated:
-    weight: 6
+    weight: 7
     settings: {  }
     third_party_settings: {  }
     type: datetime_default
@@ -279,13 +291,13 @@ content:
     type: metatag_firehose
     region: content
   field_intended_audience:
-    weight: 13
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_organizations:
-    weight: 9
+    weight: 10
     settings:
       match_operator: CONTAINS
       size: 60
@@ -295,14 +307,14 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_page_template:
-    weight: 7
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_reusable_label:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS

--- a/conf/drupal/config/core.entity_view_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -26,6 +27,7 @@ dependencies:
   module:
     - datetime
     - entity_reference_revisions
+    - image
     - link
     - metatag
     - options
@@ -64,6 +66,15 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_banner_image:
+    weight: 24
+    label: hidden
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
   field_contact:
     weight: 4
     label: hidden

--- a/conf/drupal/config/core.entity_view_display.node.info_details.link_and_description.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.link_and_description.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.link_and_description
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -43,6 +44,7 @@ hidden:
   dm_ancestors_related_to: true
   extra_org_feedback_form: true
   extra_sidebar_contact: true
+  field_banner_image: true
   field_contact: true
   field_data_flag: true
   field_data_resource_type: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.link_only.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.link_only
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -43,6 +44,7 @@ hidden:
   dm_ancestors_related_to: true
   extra_org_feedback_form: true
   extra_sidebar_contact: true
+  field_banner_image: true
   field_contact: true
   field_data_flag: true
   field_data_resource_type: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.teaser.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -76,6 +77,7 @@ hidden:
   content_moderation_control: true
   dm_ancestors_related_to: true
   extra_org_feedback_form: true
+  field_banner_image: true
   field_contact: true
   field_data_flag: true
   field_data_resource_type: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.title_short_desc.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.title_short_desc
+    - field.field.node.info_details.field_banner_image
     - field.field.node.info_details.field_contact
     - field.field.node.info_details.field_data_flag
     - field.field.node.info_details.field_data_resource_type
@@ -50,6 +51,7 @@ hidden:
   dm_ancestors_related_to: true
   extra_org_feedback_form: true
   extra_sidebar_contact: true
+  field_banner_image: true
   field_contact: true
   field_data_flag: true
   field_data_resource_type: true

--- a/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
@@ -1,0 +1,38 @@
+uuid: 44b2decf-3dc8-459e-b764-61746dbc732f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_banner_image
+    - node.type.info_details
+  module:
+    - image
+id: node.info_details.field_banner_image
+field_name: field_banner_image
+entity_type: node
+bundle: info_details
+label: 'Banner Image'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
@@ -12,7 +12,7 @@ field_name: field_banner_image
 entity_type: node
 bundle: info_details
 label: 'Banner Image'
-description: ''
+description: 'If a banner image is selected, the page will get a binder styled image banner. Leave this field empty for a standard information detail page header with no image. This field is only available to Content Administrators.  '
 required: false
 translatable: true
 default_value: {  }

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -1573,5 +1573,9 @@ function mass_validation_form_node_info_details_edit_form_alter(&$form, FormStat
     $form['field_page_template']['#attributes']['class'][] = 'js-hide';
   }
 
+  if (count(array_intersect(['administrator', 'content_team'], $user->getRoles())) === 0) {
+    $form['field_banner_image']['#attributes']['class'][] = 'js-hide';
+  }
+
   $form['field_page_template']['widget']['#options']['_none'] = 'Information details';
 }

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
@@ -59,6 +59,29 @@
     {% endblock %}
   {% endembed %}
   {{ content.referencing_binders }}
+
+  {% if node.field_banner_image is not empty %}
+    {% set bgImage = file_url(node.field_banner_image.entity.fileuri) %}
+    {% include "@organisms/by-template/illustrated-header.twig" with {
+      "illustratedHeader": {
+        "bgImage": bgImage,
+        "category": "",
+        "inverted": true,
+        "pageHeader": {
+          "title": label,
+          "subTitle": "",
+          "optionalContents": [{
+            "path": "@atoms/11-text/paragraph.twig",
+            "data": {
+              "paragraph" : {
+                "text": node.field_short_desc.value
+              }
+            }
+          }]
+        }
+      }
+    } %}
+  {% else %}
   {% include "@organisms/by-template/page-header.twig" with {
     "pageHeader": {
       "divider": false,
@@ -67,6 +90,8 @@
       "widgets": null
     },
   } %}
+  {% endif %}
+
   {% if content.field_info_detail_overview|render|trim is not empty %}
     {% embed "@organisms/by-author/rich-text.twig" with {
       "richText": {}


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
I added a new banner image field to the info_details page. When an image is uploaded an illustrated-header style header is used. The title and short-description fields appear on this header along with the new image. 

If an image is NOT uploaded to this new banner image field, then the standard page-header style header is used. 

This image field only appears for admins and content administrators (content_team role).


**Jira:**
https://jira.mass.gov/browse/DP-17972


**To Test:**
- [ ] Login as an admin or content administrator
- [ ] Visit an info_details page
- [ ] The header should appear exactly as before (it still should use the page-header template)
- [ ] Edit this info_details page
- [ ] You should see a Banner Image field - upload an image here and save the node
- [ ] Now there should be a new illustrated-header style header being used
- [ ] Now logout and login with a user without admin or content administrator roles
- [ ] You should not see the new Banner Image field
- [ ] You should still be able to edit and save the node


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
