### PR TITLE
DP-17971 Style callout links in rich text container in info. details page

### DIFF
--- a/changelogs/DP-17971-2.yml
+++ b/changelogs/DP-17971-2.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Add:
+Added:
   - description: Add a field template to wrap callout links in rich text container as action items and css to style them. 
     issue: DP-17971

--- a/changelogs/DP-17971-2.yml
+++ b/changelogs/DP-17971-2.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Add:
+  - description: Add a field template to wrap callout links in rich text container as action items and css to style them. 
+    issue: DP-17971

--- a/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
+++ b/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
@@ -12,6 +12,7 @@ global-styling:
       overrides/css/search-autocomplete.css: {}
       overrides/css/suggested-locations.css: {}
       overrides/css/hotfix.css: {}
+      overrides/css/callout-link.css: {}
   js:
     overrides/js/fixed-feedback-button.js: {}
   dependencies:

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -1,0 +1,89 @@
+/**
+ * Override css for the callout link in .ma__rich-text.
+ */
+
+/* .ma__action-finder */
+
+.ma__rich-text .ma__action-finder,
+.ma__rich-text .ma__action-finder--no-background
+ {
+    background: none;
+}
+
+/* .ma__action-finder__container */
+
+.ma__rich-text .ma__action-finder__container {
+    padding: 0;
+}
+
+/* .ma__action-finder__items */
+
+/* No override style with .ma__action-finder__items. */
+
+/* .ma__callout-link */
+
+/* .ma__rich-text .ma__callout-link {
+  border: 3px solid;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -ms-flex-flow: column wrap;
+  flex-flow: column wrap;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  padding: 15px 20px;
+  background-color: #e8eef4;
+  border-color: #8aaac7;
+  -webkit-box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.25);
+  box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.25);
+} */
+
+/* .ma__rich-text .ma__callout-link:last-child {
+  margin-bottom: 0;
+} */
+
+/* .ma__rich-text .ma__action-finder .ma__illustrated-link, .ma__rich-text .ma__action-finder .ma__callout-link {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 20px;
+  height: auto;
+  width: 100%;
+  -webkit-box-flex: 0;
+  -ms-flex-positive: 0;
+  flex-grow: 0;
+  -ms-flex-negative: 1;
+  flex-shrink: 1;
+  -ms-flex-preferred-size: auto;
+  flex-basis: auto;
+} */
+
+/* @media (min-width: 911px)
+.ma__rich-text .ma__action-finder .ma__illustrated-link, .ma__rich-text .ma__action-finder .ma__callout-link {
+    float: left;
+    display: block;
+    margin-right: 1.6129%;
+    width: 32.25806%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: flex;
+} */
+
+/* @media (min-width: 911px)
+.ma__rich-text .ma__action-finder .ma__illustrated-link:last-child, .ma__rich-text .ma__action-finder .ma__callout-link:last-child {
+    margin-right: 0;
+} */
+
+/* @media (min-width: 911px)
+.ma__rich-text .ma__action-finder .ma__illustrated-link:nth-child(3n+1), .ma__rich-text .ma__action-finder .ma__callout-link:nth-child(3n+1) {
+    clear: left;
+} */
+
+/* @media (min-width: 911px)
+.ma__action-finder .ma__illustrated-link:nth-child(3n), .ma__action-finder .ma__callout-link:nth-child(3n) {
+    margin-right: 0;
+} */

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -16,12 +16,29 @@
 
 /* .ma__action-finder__items */
 
-/* No override style with .ma__action-finder__items. */
+.ma__rich-text .ma__action-finder__items {
+  margin: 21.75px 0;
+  margin: 1.5rem 0;
+}
+
+@media (min-width: 621px) {
+  .ma__rich-text .ma__action-finder__items {
+    margin: 1.75rem 0;
+  }
+}
+
+.ma__rich-text .ma__action-finder__items:not(.ma__action-finder__items--all) {
+  padding: 0;
+}
 
 /* .ma__callout-link */
 
 .ma__rich-text .ma__callout-link {
   padding: 15px 20px;
+}
+
+.ma__rich-text .ma__action-finder .ma__callout-link:last-child {
+  margin-bottom: 0;
 }
 
 @media (min-width: 621px) {

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -4,7 +4,8 @@
 
 /* .ma__action-finder */
 
-.ma__rich-text .ma__action-finder, .ma__rich-text .ma__action-finder--no-background {
+.ma__rich-text .ma__action-finder, 
+.ma__rich-text .ma__action-finder--no-background {
   background: none;
 }
 

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -20,7 +20,7 @@
 .ma__rich-text .ma__action-finder__items {
   margin-top: 21.75px;
   margin-bottom: 1.75px;
-  margin-top: 1.5rem ;
+  margin-top: 1.5rem;
   margin-bottom: calc(1.5rem - 20px);
 }
 

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -22,68 +22,12 @@
 
 /* .ma__callout-link */
 
-/* .ma__rich-text .ma__callout-link {
-  border: 3px solid;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-flow: column wrap;
-  flex-flow: column wrap;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  justify-content: center;
+.ma__rich-text .ma__callout-link {
   padding: 15px 20px;
-  background-color: #e8eef4;
-  border-color: #8aaac7;
-  -webkit-box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.25);
-  box-shadow: 0 0.25rem 0.5rem rgba(0,0,0,0.25);
-} */
+}
 
-/* .ma__rich-text .ma__callout-link:last-child {
-  margin-bottom: 0;
-} */
-
-/* .ma__rich-text .ma__action-finder .ma__illustrated-link, .ma__rich-text .ma__action-finder .ma__callout-link {
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  margin-bottom: 20px;
-  height: auto;
-  width: 100%;
-  -webkit-box-flex: 0;
-  -ms-flex-positive: 0;
-  flex-grow: 0;
-  -ms-flex-negative: 1;
-  flex-shrink: 1;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto;
-} */
-
-/* @media (min-width: 911px)
-.ma__rich-text .ma__action-finder .ma__illustrated-link, .ma__rich-text .ma__action-finder .ma__callout-link {
-    float: left;
-    display: block;
-    margin-right: 1.6129%;
-    width: 32.25806%;
-    display: -webkit-box;
-    display: -ms-flexbox;
-    display: flex;
-} */
-
-/* @media (min-width: 911px)
-.ma__rich-text .ma__action-finder .ma__illustrated-link:last-child, .ma__rich-text .ma__action-finder .ma__callout-link:last-child {
-    margin-right: 0;
-} */
-
-/* @media (min-width: 911px)
-.ma__rich-text .ma__action-finder .ma__illustrated-link:nth-child(3n+1), .ma__rich-text .ma__action-finder .ma__callout-link:nth-child(3n+1) {
-    clear: left;
-} */
-
-/* @media (min-width: 911px)
-.ma__action-finder .ma__illustrated-link:nth-child(3n), .ma__action-finder .ma__callout-link:nth-child(3n) {
-    margin-right: 0;
-} */
+@media (min-width: 621px) {
+  .ma__rich-text .ma__callout-link {
+    padding: 20px 30px;
+  }
+}

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -18,13 +18,16 @@
 /* .ma__action-finder__items */
 
 .ma__rich-text .ma__action-finder__items {
-  margin: 21.75px 0;
-  margin: 1.5rem 0;
+  margin-top: 21.75px;
+  margin-bottom: 1.75px;
+  margin-top: 1.5rem ;
+  margin-bottom: calc(1.5rem - 20px);
 }
 
 @media (min-width: 621px) {
   .ma__rich-text .ma__action-finder__items {
-    margin: 1.75rem 0;
+    margin-top: 1.75rem;
+    margin-bottom: calc(1.75rem - 20px);
   }
 }
 
@@ -36,10 +39,6 @@
 
 .ma__rich-text .ma__callout-link {
   padding: 15px 20px;
-}
-
-.ma__rich-text .ma__action-finder .ma__callout-link:last-child {
-  margin-bottom: 0;
 }
 
 @media (min-width: 621px) {

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -4,7 +4,7 @@
 
 /* .ma__action-finder */
 
-.ma__rich-text .ma__action-finder, 
+.ma__rich-text .ma__action-finder,
 .ma__rich-text .ma__action-finder--no-background {
   background: none;
 }

--- a/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/callout-link.css
@@ -4,16 +4,14 @@
 
 /* .ma__action-finder */
 
-.ma__rich-text .ma__action-finder,
-.ma__rich-text .ma__action-finder--no-background
- {
-    background: none;
+.ma__rich-text .ma__action-finder, .ma__rich-text .ma__action-finder--no-background {
+  background: none;
 }
 
 /* .ma__action-finder__container */
 
 .ma__rich-text .ma__action-finder__container {
-    padding: 0;
+  padding: 0;
 }
 
 /* .ma__action-finder__items */

--- a/docroot/themes/custom/mass_theme/templates/field/field--field-section-long-form-content.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--field-section-long-form-content.html.twig
@@ -1,0 +1,55 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+
+{% for item in items %}
+  {% if item.content["#paragraph"].type[0].target_id == 'callout_link' %}
+    {# <section class="ma__key-actions">
+      <div class="ma__key-actions__container">
+        <div class="ma__key-actions__items"> #}
+    <section class="ma__action-finder ma__action-finder--no-background ">
+      <div class="ma__action-finder__container">
+        <div class="ma__action-finder__items">
+          {{ item.content }}
+        </div>
+      </div>
+    </section>
+  {% else %}
+    {{ item.content }}
+  {% endif %}
+{% endfor %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--field-section-long-form-content.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--field-section-long-form-content.html.twig
@@ -39,9 +39,6 @@
 
 {% for item in items %}
   {% if item.content["#paragraph"].type[0].target_id == 'callout_link' %}
-    {# <section class="ma__key-actions">
-      <div class="ma__key-actions__container">
-        <div class="ma__key-actions__items"> #}
     <section class="ma__action-finder ma__action-finder--no-background ">
       <div class="ma__action-finder__container">
         <div class="ma__action-finder__items">


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Add a field template to wrap callout links in rich text container as action items and css to style them.

**Jira:**
https://jira.mass.gov/browse/DP-17971


**To Test:**
- [ ] Create/Edit an info details page.

- [ ] Under the Content tab, click "callout link" in the Information details section.
<img width="478" alt="Edit_Information_Details__QAG_Information_Details_2___Mass_gov" src="https://user-images.githubusercontent.com/9633303/77810766-a8dc2500-706c-11ea-89f2-59b8eede5d01.png">

- [ ] Add at least 4 links to test the layout.

- [ ] Check the layout and styles of the callout links to match the [Mayflower](https://mayflower.digital.mass.gov/patternlab/?p=pages-service).  You can also refer to the **Featured**  in the **What would you like to do?** of https://www.mass.gov/qag-service-page-with-grouped-links:
<img width="808" alt="QAG_Service_page_with_grouped_links___Mass_gov" src="https://user-images.githubusercontent.com/9633303/77811230-6a943500-706f-11ea-88e9-fd5cf2cc9a40.png">



**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
