### PR TITLE
DP-17989: Only allow content admins to add new paragraph types to inf…

### DIFF
--- a/changelogs/DP-17989.yml
+++ b/changelogs/DP-17989.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Only allow content admins to add Callout Link and Card paragraphs to the Info Details content type.
+    issue: DP-17989

--- a/conf/drupal/config/user.role.content_team.yml
+++ b/conf/drupal/config/user.role.content_team.yml
@@ -22,6 +22,7 @@ permissions:
   - 'access user profiles'
   - 'access video_browser entity browser pages'
   - 'add better descriptions to fields'
+  - 'add special paragraphs to info_details'
   - 'administer embed buttons'
   - 'administer form for help block'
   - 'administer form for node feedback block'

--- a/conf/drupal/config/user.role.developer.yml
+++ b/conf/drupal/config/user.role.developer.yml
@@ -32,6 +32,7 @@ permissions:
   - 'access tour'
   - 'access user profiles'
   - 'add better descriptions to fields'
+  - 'add special paragraphs to info_details'
   - 'administer account settings'
   - 'administer better field descriptions settings'
   - 'administer block_content display'

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -368,7 +368,7 @@ function mass_fields_node_view(array &$build, EntityInterface $entity, EntityVie
         if ($entity->field_service_ref_actions_2->count() > 0 && !empty($build['field_service_ref_actions_2'])) {
           foreach ($entity->field_service_ref_actions_2->getValue() as $delta => $item) {
             if (strpos($item['uri'], 'entity:') !== FALSE) {
-              list($entity_type, $entity_id) = explode('/', str_replace('entity:', '', $item['uri']));
+              [$entity_type, $entity_id] = explode('/', str_replace('entity:', '', $item['uri']));
               $view_builder = $entityTypeManager->getViewBuilder('node');
               $storage = $entityTypeManager->getStorage('node');
               $node = $storage->load($entity_id);
@@ -393,7 +393,7 @@ function mass_fields_node_view(array &$build, EntityInterface $entity, EntityVie
         if ($entity->field_service_ref_actions->count() > 0 && !empty($build['field_service_ref_actions'])) {
           foreach ($entity->field_service_ref_actions->getValue() as $delta => $item) {
             if (strpos($item['uri'], 'entity:') !== FALSE) {
-              list($entity_type, $entity_id) = explode('/', str_replace('entity:', '', $item['uri']));
+              [$entity_type, $entity_id] = explode('/', str_replace('entity:', '', $item['uri']));
               $view_builder = $entityTypeManager->getViewBuilder('node');
               $storage = $entityTypeManager->getStorage('node');
               $node = $storage->load($entity_id);
@@ -425,7 +425,7 @@ function mass_fields_node_view(array &$build, EntityInterface $entity, EntityVie
         $build['extra_node_all_actions'] = $build['field_links_actions_3'];
         foreach ($entity->field_links_actions_3->getValue() as $delta => $item) {
           if (strpos($item['uri'], 'entity:') !== FALSE) {
-            list($entity_type, $entity_id) = explode('/', str_replace('entity:', '', $item['uri']));
+            [$entity_type, $entity_id] = explode('/', str_replace('entity:', '', $item['uri']));
 
             $view_builder = $entityTypeManager->getViewBuilder('node');
             $storage = $entityTypeManager->getStorage('node');
@@ -570,4 +570,34 @@ function mass_fields_theme() {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Block access to add "Callout Link" and "Card Group" paragraphs on the
+ * info details node form unless the user is specially permissioned.
+ */
+function mass_fields_form_node_info_details_edit_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $formState) {
+  $restricted_types = [
+    'callout_link',
+    'info_details_card_group',
+  ];
+  if(isset($form['field_info_details_sections']) && isset($form['field_info_details_sections']['widget'])) {
+    foreach(Element::children($form['field_info_details_sections']['widget']) as $key) {
+      if(isset($form['field_info_details_sections']['widget'][$key]['subform'])) {
+        $subform =& $form['field_info_details_sections']['widget'][$key]['subform'];
+        foreach($restricted_types as $restricted_type) {
+          $add_more_container =& $subform['field_section_long_form_content']['widget']['add_more'];
+          if(isset($add_more_container["add_more_button_{$restricted_type}"])) {
+            $result = AccessResult::allowedIfHasPermission(\Drupal::currentUser(), 'special');
+            if(isset($add_more_container['#access'])) {
+              $result = $result->andIf($add_more_container['#access']);
+            }
+            $add_more_container["add_more_button_{$restricted_type}"]['#access'] = $result;
+          }
+        }
+      }
+    }
+  }
 }

--- a/docroot/modules/custom/mass_fields/mass_fields.permissions.yml
+++ b/docroot/modules/custom/mass_fields/mass_fields.permissions.yml
@@ -2,3 +2,5 @@ access the custom_html field:
   title: "Access the Custom HTML field"
   description: "Access the Custom HTML field within the campaign landing page"
   restrict access: TRUE
+add special paragraphs to info_details:
+  title: Add special paragraphs to "Info Details" pages


### PR DESCRIPTION
…o details

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR implements permissions for the new paragraph types on Info Details pages.  Only content admins should be able to add "Callout Link" and "Card" paragraph types to a section.  Unfortunately, our options for implementing this change were extremely limited and I had to go with a pretty fragile form_alter.  


**Jira:**
https://jira.mass.gov/browse/DP-17989


**To Test:**
- [ ] As a regular author, create a new Info Details page.
- [ ] Add a section, and verify that you cannot add the "Callout Link" or "Card" component to it.
- [ ] Logout, then log back in as a content admin.
- [ ] Add a section and verify that you can add the "Callout Link" or "Card" component to it. 
- [ ] Save the content.
- [ ] As a regular author, edit the newly created info details page, and verify that you are able to edit "Callout link" and "Card" paragraphs.  


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
