### PR TITLE
update help text for banner images on binder and info details page types

### DIFF
--- a/changelogs/DP-18033.yml
+++ b/changelogs/DP-18033.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update help text for banner images on info details and binders.
+    issue: DP-18033

--- a/conf/drupal/config/field.field.node.binder.field_binder_banner_image.yml
+++ b/conf/drupal/config/field.field.node.binder.field_binder_banner_image.yml
@@ -12,7 +12,7 @@ field_name: field_binder_banner_image
 entity_type: node
 bundle: binder
 label: 'Banner image'
-description: ''
+description: 'Optional. Add a rectangular image that relates to the overarching theme of the binder. Minimum size: 600 x 450 pixels. Images using a different height to width ratio will be cropped.'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_banner_image.yml
@@ -12,7 +12,7 @@ field_name: field_banner_image
 entity_type: node
 bundle: info_details
 label: 'Banner Image'
-description: 'If a banner image is selected, the page will get a binder styled image banner. Leave this field empty for a standard information detail page header with no image. This field is only available to Content Administrators.  '
+description: 'Optional.  Add a rectangular image that relates to the overarching theme of the page.  If a banner image is added, the page will get a binder-styled banner image. Leave this field empty for a standard information detail page header with no image. This field is only available to Content Administrators. Minimum size: 600 x 450 pixels. Images using a different height to width ratio will be cropped.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Updated help text (description) for the banner image fields in the Binder and Info Details page types.


**Jira:**
https://jira.mass.gov/browse/DP-18033


**To Test:**
- [ ] Create or edit a Binder and an Info Details page and check that the help text matches what the ticket says it should say.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
