### PR TITLE
Dp 18039 additional permitted types related content paragraph

### DIFF
--- a/changelogs/DP-18039.yml
+++ b/changelogs/DP-18039.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Configure related_content paragraph to use actionCards layout (not bullets) by default.
+    issue: DP-18039

--- a/changelogs/DP-18039.yml
+++ b/changelogs/DP-18039.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Configure related_content paragraph to use actionCards layout (not bullets) by default.
+  - description: Configure related_content paragraph to permit more content types and update theme to use actionCards layout (not bullets) as default layout.
     issue: DP-18039

--- a/conf/drupal/config/field.field.paragraph.related_content.field_related_content.yml
+++ b/conf/drupal/config/field.field.paragraph.related_content.field_related_content.yml
@@ -5,12 +5,24 @@ dependencies:
   config:
     - field.storage.paragraph.field_related_content
     - node.type.action
+    - node.type.advisory
+    - node.type.binder
+    - node.type.campaign_landing
+    - node.type.curated_list
+    - node.type.decision
+    - node.type.decision_tree
+    - node.type.event
+    - node.type.executive_order
+    - node.type.form_page
     - node.type.guide_page
     - node.type.how_to_page
-    - node.type.interstitial
+    - node.type.info_details
     - node.type.location
     - node.type.location_details
+    - node.type.news
     - node.type.org_page
+    - node.type.regulation
+    - node.type.rules
     - node.type.service_details
     - node.type.service_page
     - node.type.stacked_layout
@@ -30,19 +42,31 @@ settings:
   handler: mass_select_filter
   handler_settings:
     target_bundles:
+      advisory: advisory
+      binder: binder
+      curated_list: curated_list
+      decision: decision
+      decision_tree: decision_tree
+      event: event
+      executive_order: executive_order
+      form_page: form_page
       guide_page: guide_page
       how_to_page: how_to_page
-      interstitial: interstitial
-      location_details: location_details
+      info_details: info_details
       location: location
+      location_details: location_details
+      news: news
       org_page: org_page
+      campaign_landing: campaign_landing
+      regulation: regulation
       action: action
-      service_details: service_details
+      rules: rules
       service_page: service_page
+      service_details: service_details
       stacked_layout: stacked_layout
       topic_page: topic_page
     sort:
       field: _none
-    auto_create: false
-    auto_create_bundle: interstitial
+    auto_create: 0
+    auto_create_bundle: guide_page
 field_type: entity_reference

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5079,10 +5079,8 @@ function _get_layout(array $total_type_with_count, $total_count) {
   // Pretty sure we don't use this layout anymore; there are no page types called 'topic' or 'subtopic'
   // and we don't use stacked layout except for the homepage.
   if (
-    $total_type_with_count['topic'] + $total_type_with_count['subtopic'] == $total_count ||
-    $total_type_with_count['topic'] + $total_type_with_count['subtopic'] + $total_type_with_count['stacked_layout'] == $total_count ||
-    $total_type_with_count['topic'] + $total_type_with_count['subtopic'] + $total_type_with_count['topic_page'] + $total_type_with_count['service_page'] == $total_count ||
-    $total_type_with_count['topic'] + $total_type_with_count['subtopic'] + $total_type_with_count['topic_page'] + $total_type_with_count['stacked_layout'] == $total_count
+    $total_type_with_count['topic_page'] + $total_type_with_count['service_page'] == $total_count ||
+    $total_type_with_count['topic_page'] + $total_type_with_count['stacked_layout'] == $total_count
   ) {
     return 'topicCards';
   }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5077,7 +5077,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
 
   // Tests for using Topic Card layout.
   // Pretty sure we don't use this layout anymore; there are no page types called 'topic' or 'subtopic'
-  // and we don't use stacked layout except for the homepage
+  // and we don't use stacked layout except for the homepage.
   if (
     $total_type_with_count['topic'] + $total_type_with_count['subtopic'] == $total_count ||
     $total_type_with_count['topic'] + $total_type_with_count['subtopic'] + $total_type_with_count['stacked_layout'] == $total_count ||
@@ -5089,7 +5089,7 @@ function _get_layout(array $total_type_with_count, $total_count) {
   // For all other types or combinations, use actionCards
   // This layout is the only one in active use
   // It's used in the "Features Services" section of the home page
-  // Where it's a part of the "search" paragraph
+  // where it's a part of the "search" paragraph.
   return 'actionCards';
 }
 

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5067,7 +5067,7 @@ function mass_theme_preprocess_paragraph__related_content(&$variables) {
  *   The twig layout to be used.
  */
 function _get_layout(array $total_type_with_count, $total_count) {
-  // If all content is "stacked_layout", we use "bullets".
+  // If all content is "stacked_layout" or "org," we use "bullets".
   if (
     $total_type_with_count['stacked_layout'] == $total_count ||
     $total_type_with_count['org_page'] == $total_count
@@ -5075,26 +5075,9 @@ function _get_layout(array $total_type_with_count, $total_count) {
     return 'bullets';
   }
 
-  // If all content is Right Rail, use actionCards.
-  // If all content is Service Pages, user actionCards.
-  // If content is Right Rail and Stacked Layout, use actionCards.
-  if (
-    $total_type_with_count['action'] +
-    $total_type_with_count['guide_page'] +
-    $total_type_with_count['how_to_page'] +
-    $total_type_with_count['location'] +
-    $total_type_with_count['location_details'] +
-    $total_type_with_count['org_page'] +
-    $total_type_with_count['service_page'] +
-    $total_type_with_count['service_details'] +
-    $total_type_with_count['stacked_layout'] +
-    $total_type_with_count['topic_page']
-    == $total_count
-  ) {
-    return 'actionCards';
-  }
-
   // Tests for using Topic Card layout.
+  // Pretty sure we don't use this layout anymore; there are no page types called 'topic' or 'subtopic'
+  // and we don't use stacked layout except for the homepage
   if (
     $total_type_with_count['topic'] + $total_type_with_count['subtopic'] == $total_count ||
     $total_type_with_count['topic'] + $total_type_with_count['subtopic'] + $total_type_with_count['stacked_layout'] == $total_count ||
@@ -5103,8 +5086,11 @@ function _get_layout(array $total_type_with_count, $total_count) {
   ) {
     return 'topicCards';
   }
-
-  return 'bullets';
+  // For all other types or combinations, use actionCards
+  // This layout is the only one in active use
+  // It's used in the "Features Services" section of the home page
+  // Where it's a part of the "search" paragraph
+  return 'actionCards';
 }
 
 /**


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Configure related_content paragraph to permit more content types and update theme to use actionCards layout (not bullets) as default layout.


**Jira:**
https://jira.mass.gov/browse/DP-18039


**To Test:**
- [ ] Add or edit the home page (nid 3666) and 
- [ ] Find the Row that holds the "Features Services" section of the page - it's called 1up Stacked Row, and comes just after a subhead with that name. It's a "related content" paragraph. Test adding any of the newly permitted content types and confirm the page displays action cards, not a bulleted list, in that area.

Newly permitted types:
Binder, Curated List, Decision Tree, Event, Form, Info Detail, Promo page, News, Service Detail, and law library types


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
