### PR TITLE
DP-17995 Allow promo-page links in binder node

### DIFF
--- a/changelogs/DP-17995.yml
+++ b/changelogs/DP-17995.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added ability to link to promotional pages in the binder content-type.
+    issue: DP-17995

--- a/conf/drupal/config/field.field.paragraph.page.field_page_page.yml
+++ b/conf/drupal/config/field.field.paragraph.page.field_page_page.yml
@@ -22,6 +22,7 @@ settings:
   title: 1
   entity_bundles:
     advisory: advisory
+    campaign_landing: campaign_landing
     curated_list: curated_list
     decision: decision
     executive_order: executive_order

--- a/conf/drupal/config/field.field.paragraph.page_group.field_page_group_page.yml
+++ b/conf/drupal/config/field.field.paragraph.page_group.field_page_group_page.yml
@@ -22,6 +22,7 @@ settings:
   title: 1
   entity_bundles:
     advisory: advisory
+    campaign_landing: campaign_landing
     curated_list: curated_list
     decision: decision
     executive_order: executive_order

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -425,7 +425,7 @@ function mass_utility_field_widget_form_alter(&$element, FormStateInterface $for
     }
     elseif ($field_name == 'field_page_group_page' || $field_name == 'field_page_page') {
       // Remove the domain from the field.
-      $element['uri']['#description'] = t('Start typing to choose an existing page on Mass.gov. Allowed types include the following: Advisory, Curated List, Decision, Executive Order Page, Form, How To, Information Details, Regulation Page, or Rules of Court.',
+      $element['uri']['#description'] = t('Start typing to choose an existing page on Mass.gov. Allowed types include the following: Advisory, Curated List, Decision, Executive Order Page, Form, How To, Information Details, Promotional Page, Regulation Page, or Rules of Court.',
         [
           '%front' => '<front>',
           '%add-node' => '/node/add',


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
I allowed Promotional Page (campaign_landing is the machine name) nodes to be selected in the link fields on the page and page-group paragraphs which are used on the binder content-type. Also I adjusted the help text to reflect this. 

**Jira:**
https://jira.mass.gov/browse/DP-17995


**To Test:**
- [ ] Edit a binder page and go to the Pages section where you can add page links
- [ ] Verify the help text above the URL field now includes "Promotional Page"
- [ ] Verify you can add a Promotional Page link and save the node
- [ ] Verify the link appears on the page and links to the Promotional Page
- [ ] Verify no binder table-of-contents appears at the top of the page and no binder pagination appears at the bottom


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
