### PR TITLE
DP-17677 Hardcode binder node organization label

### DIFF
--- a/docroot/themes/custom/mass_theme/templates/content/node--binder.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--binder.html.twig
@@ -10,7 +10,7 @@
 {% set binder_table_rows = [] %}
 {# Build organization row. #}
 {% set binder_table_rows = binder_table_rows|merge([{
-  "label": node.field_binder_ref_organization.fieldDefinition.label ~ ':',
+  "label": 'Organization:',
   "items": binder_organization_items
 }]) %}
 


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
The organization label displayed on the page was previously pulling from the binder organization field label. I just hardcoded this to "Organization" in the node template because that is what we want to display on the page. 

**Jira:**
https://jira.mass.gov/browse/DP-17677


**To Test:**
- [ ] Visit a binder page like this one: http://mass.local/archive/community-reinvestment-act-compliance
- [ ] Verify "Binder organization" has been replaced by "Organization" 
- [ ] Edit that node to see that the node form still shows "Binder organization"


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
