### PR TITLE
DP-17619 Remove the bottom border of the related links when it has no content

### DIFF
--- a/changelogs/DP-17619.yml
+++ b/changelogs/DP-17619.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Change the condition to check sideContent.linkList to check if its content is not null.
+    issue: DP-17619

--- a/docroot/themes/custom/mass_theme/templates/content/node--binder.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--binder.html.twig
@@ -130,7 +130,7 @@
 
 {% block sidebar %}
   {{ content.extra_sidebar_contact }}
-  {% if sideContent.linkList %}
+  {% if sideContent.linkList.links %}
     {% set linkList = sideContent.linkList %}
     {% set linkList = linkList|merge({'compHeading': {
       'title': linkList.compHeading.title,


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
Modify the condition to check **sideContent.linkList** to check its content **sideContent.linkList.links**.

**Jira:**
https://jira.mass.gov/browse/DP-17619


**To Test:**
- [ ] Go to any binder page with related links in the side column. Ex) http://mass.local/audit/qag-binderaudit

- [ ] Remove the related links and check the page.

- [ ] Find nothing is rendered as related links.  The line described in the ticket is the bottom border of its comp heading. Without any content to render, the whole component shouldn't be rendered.

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
