### PR TITLE
DP-18165: Fix performance regression caused by duplicate JSONAPI requ…

### DIFF
--- a/changelogs/DP-18165.yml
+++ b/changelogs/DP-18165.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Resolve a performance regression due to alert URLs changing
+    issue: DP-18165

--- a/conf/drupal/config/block.block.ajaxpattern_2.yml
+++ b/conf/drupal/config/block.block.ajaxpattern_2.yml
@@ -18,7 +18,7 @@ settings:
   label: 'Ajax Pattern: Page Alerts'
   provider: mayflower
   label_display: '0'
-  ajax_pattern_endpoint: '/jsonapi/node/alert?page[limit]=250&sort=-changed&include=field_target_pages_para_ref,field_alert&filter[status][value]=1&fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display&fields[paragraph--emergency_alert]=id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content&fields[paragraph--target_pages]=field_target_content_ref'
+  ajax_pattern_endpoint: '/jsonapi/node/alert?page[limit]=250&sort=-changed&include=field_target_pages_para_ref,field_alert&filter[status][value]=1&fields[node--alert]=title,changed,entity_url,field_alert_severity,field_alert,field_target_pages_para_ref,field_alert_display&fields[paragraph--emergency_alert]=drupal_internal__id,changed,field_emergency_alert_timestamp,field_emergency_alert_message,field_emergency_alert_link,field_emergency_alert_content&fields[paragraph--target_pages]=field_target_content_ref'
   ajax_pattern_render_pattern: '@organisms/by-template/header-alerts.twig'
   ajax_pattern_custom_selector: js-ajax-page-alerts-jsonapi
 visibility:


### PR DESCRIPTION
…ests

<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
This PR adjusts the page-based alerts block to use the same URL as the site-wide one.  This also resolves an issue where the anchor link used on page based alerts that select "Use the default alerts landing page" shows up as `#undefined`


**Jira:**
https://jira.mass.gov/browse/DP-18165


**To Test:**
- [ ] As an admin or editor, update http://mass.local/alerts/massachusetts-state-parks-covid-19-update/edit.
- [ ] Under "Details -> Alert Message -> Link", remove the page the alert links to.  
- [ ] Under "Details -> Alert Message -> Link Type", select "Link to the default alert landing page", and fill in some Rich Text for the detail page content. 
- [ ] Visit any page the alert is displayed on (eg: http://mass.local/locations/wompatuck-state-park) and verify that the alert still appears correctly, and that the fragment link works (note: alerts are very slow on local, you might have to wait a minute).
- [ ] Open the "Network" tab in your browser, and search for requests containing "jsonapi".  Verify that you only see one.




**Screenshots/GIFs:**
![Screen Shot 2020-04-07 at 11 31 30 AM](https://user-images.githubusercontent.com/654407/78688520-59df8c80-78c3-11ea-9286-6840446eac2f.png)
---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
