### PR TITLE
DP-17579 Add logic to display tableau by device size

### DIFF
--- a/changelogs/DP-17579.yml
+++ b/changelogs/DP-17579.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add Tableau JS for sizing dashboard based on container width
+    issue: DP-17579

--- a/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
+++ b/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
@@ -40,3 +40,4 @@ views.ajax.extension:
 tableau:
   js:
     https://public.tableau.com/javascripts/api/tableau-2.3.0.min.js: { type: external }
+    overrides/js/tableau_settings.js: {}

--- a/docroot/themes/custom/mass_theme/overrides/js/tableau_settings.js
+++ b/docroot/themes/custom/mass_theme/overrides/js/tableau_settings.js
@@ -10,13 +10,13 @@
     attach: function (context, settings) {
 
       $(function () {
-        const minDesktop = 800;
-        const minTablet = 501;
+        var minDesktop = 800;
+        var minTablet = 501;
 
         $('.ma_tableau_container', context).each(function () {
-          let currentWidth = $(this).outerWidth();
+          var currentWidth = $(this).outerWidth();
 
-          let deviceType = 'phone';
+          var deviceType = 'phone';
           if (currentWidth >= minDesktop) {
             deviceType = 'desktop';
           }
@@ -24,12 +24,15 @@
             deviceType = 'tablet';
           }
 
-          let $tableauItem = $(this).children(".ma_tableau_item");
-          let id = $tableauItem.attr("id");
-          let url = $tableauItem.data("tableau-url");
-          let options = { device: deviceType };
+          var $tableauItem = $(this).children('.ma_tableau_item');
+          var id = $tableauItem.attr('id');
+          var url = $tableauItem.data('tableau-url');
+          var options = {device: deviceType};
 
+          /* eslint-disable */
           new tableau.Viz(document.getElementById(id), url, options);
+          /* eslint-enable */
+
         });
       });
 

--- a/docroot/themes/custom/mass_theme/overrides/js/tableau_settings.js
+++ b/docroot/themes/custom/mass_theme/overrides/js/tableau_settings.js
@@ -1,0 +1,39 @@
+/**
+ * @file
+ * Tableau Settings.
+ */
+
+(function ($, Drupal, drupalSettings) {
+  'use strict';
+
+  Drupal.behaviors.tableauSettings = {
+    attach: function (context, settings) {
+
+      $(function () {
+        const minDesktop = 800;
+        const minTablet = 501;
+
+        $('.ma_tableau_container', context).each(function () {
+          let currentWidth = $(this).outerWidth();
+
+          let deviceType = 'phone';
+          if (currentWidth >= minDesktop) {
+            deviceType = 'desktop';
+          }
+          else if (currentWidth >= minTablet) {
+            deviceType = 'tablet';
+          }
+
+          let $tableauItem = $(this).children(".ma_tableau_item");
+          let id = $tableauItem.attr("id");
+          let url = $tableauItem.data("tableau-url");
+          let options = { device: deviceType };
+
+          new tableau.Viz(document.getElementById(id), url, options);
+        });
+      });
+
+    }
+  };
+
+})(jQuery, Drupal, drupalSettings);

--- a/docroot/themes/custom/mass_theme/templates/field/mass_content_tableau_embed.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/mass_content_tableau_embed.html.twig
@@ -14,11 +14,5 @@
 #}
 
 <div class="ma_tableau_container" style="max-width:100%">
-  <div id="{{ randId }}"></div>
+  <div class="ma_tableau_item" id="{{ randId }}" data-tableau-url="{{ url }}"></div>
 </div>
-<script type="text/javascript">
-  window.addEventListener("DOMContentLoaded", function() {
-    const url = "{{ url }}"
-    new tableau.Viz(document.getElementById("{{ randId }}"), url);
-  });
-</script>


### PR DESCRIPTION
<!-- NOTE: Please just put "N/A" for any section below that isn't applicable to the work you've done, do not omit entirely. -->

**Description:**
I added and adjusted the JS provided in the ticket. It checks the width of the container the tableau iframe will be placed in and loads the correct size tableau dashboard. Also I moved the logic for this out of the twig template and into a JS file. 


**Jira:**
https://jira.mass.gov/browse/DP-17579


**To Test:**
- [ ] Add this tableau visualization to an info_details page: https://public.tableau.com/views/diversity_update_v22/Diversity_dashboard
- [ ] View the page and observe the visualization appears correctly
- [ ] Now shrink the browser window down to under 500px wide and reload the page
- [ ] This visualization should now load in a more mobile-friendly manner with the visualization items more stacked and less horizontally laid out
- [ ] Now go back and read the ticket. There is a lot of conversation regarding performance and other considerations that were discussed that may be relevant here: https://jira.mass.gov/browse/DP-17579


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/opemass/blob/develop/docs/peer_review_checklist.md)
