### PR TITLE
DP-16911 Update private_files_download_permission from 2.0 to 2.2

### DIFF
--- a/changelogs/DP-16911.yml
+++ b/changelogs/DP-16911.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Update the private_files_download_permission module from 2.0 to 2.2
+    issue: DP-16911

--- a/composer.lock
+++ b/composer.lock
@@ -2643,10 +2643,6 @@
                     "homepage": "https://www.drupal.org/user/386230"
                 },
                 {
-                    "name": "jsacksick",
-                    "homepage": "https://www.drupal.org/user/972218"
-                },
-                {
                     "name": "mglaman",
                     "homepage": "https://www.drupal.org/user/2416470"
                 },
@@ -3141,16 +3137,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1461060840"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3165,7 +3157,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3617,10 +3609,6 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
-                },
-                {
                     "name": "slashrsm",
                     "homepage": "https://www.drupal.org/user/744628"
                 },
@@ -3632,7 +3620,7 @@
             "description": "Provides storage and API for image crops.",
             "homepage": "https://www.drupal.org/project/crop",
             "support": {
-                "source": "https://git.drupalcode.org/project/crop",
+                "source": "http://cgit.drupalcode.org/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
             }
         },
@@ -4250,7 +4238,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1536250980",
+                    "datestamp": "1516093086",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4981,21 +4969,21 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1504182544",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1485942783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "fabianderijk",
                     "homepage": "https://www.drupal.org/user/278745"
+                },
+                {
+                    "name": "msankhala",
+                    "homepage": "https://www.drupal.org/user/882726"
                 },
                 {
                     "name": "tomvv",
@@ -5005,7 +4993,7 @@
             "description": "Interface for unblocking ip's that are blocked by the flood table",
             "homepage": "https://www.drupal.org/project/flood_unblock",
             "support": {
-                "source": "https://git.drupalcode.org/project/flood_unblock"
+                "source": "http://cgit.drupalcode.org/flood_unblock"
             }
         },
         {
@@ -5036,7 +5024,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta6",
-                    "datestamp": "1553270584",
+                    "datestamp": "1519932484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5056,7 +5044,7 @@
             "description": "Allows users to specify the focal point of an image for use during cropping.",
             "homepage": "https://www.drupal.org/project/focal_point",
             "support": {
-                "source": "https://git.drupalcode.org/project/focal_point"
+                "source": "http://cgit.drupalcode.org/focal_point"
             }
         },
         {
@@ -5326,16 +5314,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1519597081",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1494796685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5354,7 +5338,7 @@
             "description": "Defines a field type for Google Maps.",
             "homepage": "https://www.drupal.org/project/google_map_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_map_field"
+                "source": "http://cgit.drupalcode.org/google_map_field"
             }
         },
         {
@@ -5381,7 +5365,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1516807385",
+                    "datestamp": "1506872944",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5390,7 +5374,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5401,7 +5385,7 @@
             "description": "Provides some handy cache tags for developers.",
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
-                "source": "https://git.drupalcode.org/project/handy_cache_tags"
+                "source": "http://cgit.drupalcode.org/handy_cache_tags"
             }
         },
         {
@@ -5428,7 +5412,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1578136083",
+                    "datestamp": "1501159742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5452,7 +5436,7 @@
             "description": "Allows addition, removal and modification of http headers.",
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
-                "source": "https://git.drupalcode.org/project/http_response_headers"
+                "source": "http://cgit.drupalcode.org/http_response_headers"
             }
         },
         {
@@ -7318,29 +7302,26 @@
         },
         {
             "name": "drupal/private_files_download_permission",
-            "version": "2.0.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/private_files_download_permission.git",
-                "reference": "8.x-2.0"
+                "reference": "8.x-2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/private_files_download_permission-8.x-2.0.zip",
-                "reference": "8.x-2.0",
-                "shasum": "1d0c4185cd4772664935b7fef18c2fc5cef2fd37"
+                "url": "https://ftp.drupal.org/files/projects/private_files_download_permission-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "42d0299c3f6b75df32dbd385ec5991873ac42a1f"
             },
             "require": {
                 "drupal/core": "~8.0"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-2.0",
-                    "datestamp": "1535381280",
+                    "version": "8.x-2.2",
+                    "datestamp": "1586013192",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
**Description:**
I updated `private_files_download_permission` from 2.0 to 2.2. I was never able to reproduce the conditions needed for the 500 error to occur locally to test if updating this module actually solved the problem. But this is a minor update that addresses bugs in this module so I don't think it should be a problem if we merge this in and see if it fixes these 500 errors on the live site.

https://jira.mass.gov/browse/DP-16911


**To Test:**
- [ ] These testing steps are to verify the module continues to work correctly after this update
- [ ] Visit http://mass.local/admin/content/media and edit the first media entity
- [ ] Make sure this media entity is published
- [ ] Copy the path to the file. It should look something like this:
http://mass.local/sites/default/files/documents/path-to-file
- [ ] Open this file in an incognito window and verify you can access the file
- [ ] Now unpublish this media entity
- [ ] Copy the path to the file. It should looks something like this:
http://mass.local/system/files/documents/path-to-file
- [ ] Open this file in an incognito window and verify you get a 403 error because you shouldn't be able to access this file on this path
- [ ] And if you visit http://mass.local/sites/default/files/documents/path-to-file when the media entity is unpublished it should be a 404 because the file no longer resides in this path

![copy_file_path](https://user-images.githubusercontent.com/11247942/79354168-0ea02c00-7f0a-11ea-8d44-bc82c920f429.png)




**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
