### PR TITLE
DP-13246 decision tree buttons

### DIFF
--- a/changelogs/DP-13246.yml
+++ b/changelogs/DP-13246.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changed the style of decision tree buttons below 620px width to line up vertically instead of horizontally.
+    issue: DP-13246

--- a/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
+++ b/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
@@ -50,8 +50,24 @@
   color: white;
 }
 
-.page-content .ma__decision-tree-node__responses button + button {
-  margin-left: 15px;
+  .page-content .ma__decision-tree-node__responses button + button {
+    margin-left: 15px;
+  }
+
+@media (max-width: 620px) {
+  .page-content .ma__decision-tree-node__responses button {
+    width: 100%;
+    margin-bottom: 20px;
+    margin-left: 0;
+  }
+
+  .page-content .ma__decision-tree-node__responses button:last-child {
+    margin-bottom: 0;
+  }
+
+  .page-content .ma__decision-tree-node__responses button + button {
+    margin-left: 0;
+  }
 }
 
 .page-content.ma__decision-tree-node .back {

--- a/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
+++ b/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
@@ -50,9 +50,9 @@
   color: white;
 }
 
-  .page-content .ma__decision-tree-node__responses button + button {
-    margin-left: 15px;
-  }
+.page-content .ma__decision-tree-node__responses button + button {
+  margin-left: 15px;
+}
 
 @media (max-width: 620px) {
   .page-content .ma__decision-tree-node__responses button {


### PR DESCRIPTION
**Description:**
Styled decision tree buttons below 620px width to line up vertically instead of horizontally.
Instead of flow them like horizontally, style similar to the callout link style below 620px, so the second button doesn't have left margin when it flows to the next line(See the "before" screenshot below).

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-13246


**To Test:**
- [ ] Go to any decision tree page with buttons. Ex) /decision-tree/how-to-find-historic-court-records#s=456366

- [ ] Set the page width below 620px.

- [ ] Find the button display matches the "after" screenshot below.

**Screenshots/GIFs:**
Before
<img width="626" alt="belore" src="https://user-images.githubusercontent.com/9633303/79158647-b3a0f480-7da4-11ea-8afd-efe70b2050b9.png">

After
<img width="615" alt="after" src="https://user-images.githubusercontent.com/9633303/79158635-ae43aa00-7da4-11ea-9dcd-bf7f18d902ad.png">

Callout link below 620px
<img width="753" alt="Mass_Gov" src="https://user-images.githubusercontent.com/9633303/79159202-a59fa380-7da5-11ea-9818-478c10e57129.png">

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
