### PR TITLE
[DP-14628] author message subject length

### DIFF
--- a/changelogs/DP-14628.yml
+++ b/changelogs/DP-14628.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Truncates node title as needed when contacting authors.
+    issue: DP-14628

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -146,10 +146,18 @@ function mass_utility_form_node_form_alter(&$form, FormStateInterface $form_stat
 
   // Add link for contacting a user in the publish area.
   if (isset($form['meta']['author']['#markup'])) {
-    $title = $node->getTitle();
-    $author = $node->getOwner();
+    $title_prefix = 'Outreach about Mass.gov page "';
     $nid = $node->id();
-    $title_nid = "Outreach about Mass.gov page \"$title\" ($nid)";
+    $title_suffix = '" (' . $nid . ')';
+    $prefix_suffix_combo_lenth = strlen($title_prefix . $title_suffix);
+    // Fits title into 100 characters or less.
+    $title_max_length = 100 - $prefix_suffix_combo_lenth;
+    $title = $node->getTitle();
+    // Truncates title as needed when forming combined `$title_nid` string.
+    $title_nid = $title_prefix .
+      ((strlen($title) > $title_max_length) ? substr($title, 0, $title_max_length - 1) . '…' : $title) .
+      $title_suffix;
+    $author = $node->getOwner();
     $contact_url = new Url('entity.user.contact_form', ['user' => $author->id()], [
       // Set 'query' option for use by Prepopulate contrib module.
       // Will be used to pre-fill subject in contact form.


### PR DESCRIPTION
**Description:**
Truncates node title as needed when contacting authors.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-14628


**To Test:**
- [ ] Edit a node with a long title that exceeds 100 characters (e.g., `/service-details/local-options-relating-to-property-taxation-cpa-meals-and-room-occupancy`)
- [ ] Click the "Contact the author" link in the top righthand corner of the form
- [ ] Confirm that the title in the subject line was automatically truncated
- [ ] Confirm that the form can be submitted without error


**Screenshots/GIFs:**
![Demo of truncating functionality](https://user-images.githubusercontent.com/5386199/79159430-0d55ee80-7da6-11ea-8d74-d3237c43d994.gif)

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
