### PR TITLE
DP-17962 Remove paragraphs_type_help module with composer

### DIFF
--- a/changelogs/DP-17962.yml
+++ b/changelogs/DP-17962.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Removed:
+  - description: Removed the paragraphs_type_help module with composer
+    issue: DP-17962

--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,6 @@
         "drupal/node_title_help_text": "1.x-dev",
         "drupal/office_hours": "^1.0@alpha",
         "drupal/paragraphs": "^1.10",
-        "drupal/paragraphs_type_help": "^1.4",
         "drupal/password_policy": "3.x-dev#435efce3dccfe4adbbe172048e15d28f861025a6",
         "drupal/path_redirect_import": "^1.0@beta",
         "drupal/pathauto": "^1",

--- a/composer.json
+++ b/composer.json
@@ -289,9 +289,6 @@
             "drupal/auto_entitylabel": {
                 "Broken when provider !=entityTypeId; fixes broken handling of taxonomy terms (https://www.drupal.org/project/auto_entitylabel/issues/2923876#comment-12933629)": "https://www.drupal.org/files/issues/2019-01-19/auto_entitylabel-2923876-28-Broken-when-provider-entityId.patch"
             },
-            "drupal/paragraphs_type_help": {
-              "Unable to enable the module": "https://www.drupal.org/files/issues/2019-02-11/paragraphs_type_help-2995397-3.patch"
-            },
             "drupal/password_policy": {
                 "Removes field updates from the install file. (https://www.drupal.org/node/2771129#comment-12108388)": "https://www.drupal.org/files/issues/password-policy-config-import-field-error-2771129-37-D8.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67e4a6db6a928ecbd8840fdbf4aedcbd",
+    "content-hash": "eaa8cb673cc6662fb8c3d2e884c888df",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2643,10 +2643,6 @@
                     "homepage": "https://www.drupal.org/user/386230"
                 },
                 {
-                    "name": "jsacksick",
-                    "homepage": "https://www.drupal.org/user/972218"
-                },
-                {
                     "name": "mglaman",
                     "homepage": "https://www.drupal.org/user/2416470"
                 },
@@ -3141,16 +3137,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1556870881",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1461060840"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -3165,7 +3157,7 @@
             "description": "Registers “component libraries” defined in modules and themes with the Twig system",
             "homepage": "https://www.drupal.org/project/components",
             "support": {
-                "source": "https://git.drupalcode.org/project/components"
+                "source": "http://cgit.drupalcode.org/components"
             }
         },
         {
@@ -3617,10 +3609,6 @@
                     "homepage": "https://www.drupal.org/user/3260690"
                 },
                 {
-                    "name": "phenaproxima",
-                    "homepage": "https://www.drupal.org/user/205645"
-                },
-                {
                     "name": "slashrsm",
                     "homepage": "https://www.drupal.org/user/744628"
                 },
@@ -3632,7 +3620,7 @@
             "description": "Provides storage and API for image crops.",
             "homepage": "https://www.drupal.org/project/crop",
             "support": {
-                "source": "https://git.drupalcode.org/project/crop",
+                "source": "http://cgit.drupalcode.org/crop",
                 "issues": "https://www.drupal.org/project/issues/crop"
             }
         },
@@ -4250,7 +4238,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.5",
-                    "datestamp": "1536250980",
+                    "datestamp": "1516093086",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -4981,21 +4969,21 @@
                 },
                 "drupal": {
                     "version": "8.x-1.3",
-                    "datestamp": "1504182544",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1485942783"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
                     "name": "fabianderijk",
                     "homepage": "https://www.drupal.org/user/278745"
+                },
+                {
+                    "name": "msankhala",
+                    "homepage": "https://www.drupal.org/user/882726"
                 },
                 {
                     "name": "tomvv",
@@ -5005,7 +4993,7 @@
             "description": "Interface for unblocking ip's that are blocked by the flood table",
             "homepage": "https://www.drupal.org/project/flood_unblock",
             "support": {
-                "source": "https://git.drupalcode.org/project/flood_unblock"
+                "source": "http://cgit.drupalcode.org/flood_unblock"
             }
         },
         {
@@ -5036,7 +5024,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-beta6",
-                    "datestamp": "1553270584",
+                    "datestamp": "1519932484",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
@@ -5056,7 +5044,7 @@
             "description": "Allows users to specify the focal point of an image for use during cropping.",
             "homepage": "https://www.drupal.org/project/focal_point",
             "support": {
-                "source": "https://git.drupalcode.org/project/focal_point"
+                "source": "http://cgit.drupalcode.org/focal_point"
             }
         },
         {
@@ -5326,16 +5314,12 @@
                 },
                 "drupal": {
                     "version": "8.x-1.4",
-                    "datestamp": "1519597081",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1494796685"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5354,7 +5338,7 @@
             "description": "Defines a field type for Google Maps.",
             "homepage": "https://www.drupal.org/project/google_map_field",
             "support": {
-                "source": "https://git.drupalcode.org/project/google_map_field"
+                "source": "http://cgit.drupalcode.org/google_map_field"
             }
         },
         {
@@ -5381,7 +5365,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0-alpha1",
-                    "datestamp": "1516807385",
+                    "datestamp": "1506872944",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5390,7 +5374,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0-or-later"
+                "GPL-2.0+"
             ],
             "authors": [
                 {
@@ -5401,7 +5385,7 @@
             "description": "Provides some handy cache tags for developers.",
             "homepage": "https://www.drupal.org/project/handy_cache_tags",
             "support": {
-                "source": "https://git.drupalcode.org/project/handy_cache_tags"
+                "source": "http://cgit.drupalcode.org/handy_cache_tags"
             }
         },
         {
@@ -5428,7 +5412,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.0-alpha1",
-                    "datestamp": "1578136083",
+                    "datestamp": "1501159742",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -5452,7 +5436,7 @@
             "description": "Allows addition, removal and modification of http headers.",
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
-                "source": "https://git.drupalcode.org/project/http_response_headers"
+                "source": "http://cgit.drupalcode.org/http_response_headers"
             }
         },
         {
@@ -6971,57 +6955,6 @@
             "homepage": "https://www.drupal.org/project/paragraphs",
             "support": {
                 "source": "https://git.drupalcode.org/project/paragraphs"
-            }
-        },
-        {
-            "name": "drupal/paragraphs_type_help",
-            "version": "1.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/paragraphs_type_help.git",
-                "reference": "8.x-1.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/paragraphs_type_help-8.x-1.4.zip",
-                "reference": "8.x-1.4",
-                "shasum": "f41cc7ae5dfebab2408a85d034a477fa9d88e44e"
-            },
-            "require": {
-                "drupal/core": "*",
-                "drupal/paragraphs": "*"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
-                "drupal": {
-                    "version": "8.x-1.4",
-                    "datestamp": "1519140484",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "patches_applied": {
-                    "Unable to enable the module": "https://www.drupal.org/files/issues/2019-02-11/paragraphs_type_help-2995397-3.patch"
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "recrit",
-                    "homepage": "https://www.drupal.org/user/452914"
-                }
-            ],
-            "description": "Provides a help entity that renders on Paragraphs type displays.",
-            "homepage": "https://www.drupal.org/project/paragraphs_type_help",
-            "support": {
-                "source": "https://git.drupalcode.org/project/paragraphs_type_help"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaa8cb673cc6662fb8c3d2e884c888df",
+    "content-hash": "e6732deb59c06970ea7a2dd6d3a273a0",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
**Description:**
I verified the `paragraphs_type_help` module was uninstalled (and you can see [here](https://github.com/massgov/openmass/blob/master/conf/drupal/config/core.extension.yml) on `master` it is uninstalled) and I ran this command:
`composer remove drupal/paragraphs_type_help`

Also I removed a patch for `paragraphs_type_help`.


**Jira:**
https://jira.mass.gov/browse/DP-17962


**To Test:**
- [ ] No external review is needed for this.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
