### PR TITLE
DP-18242 Disable field_alert_display widget for users w/o permission

### DIFF
--- a/changelogs/DP-18242.yml
+++ b/changelogs/DP-18242.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Disable field_alert_display widget on Alert node for users w/o permission
+  - issue: DP-18242

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -20,6 +20,10 @@ use Drupal\node\Entity\Node;
 function mass_alerts_form_node_alert_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#validate'][] = '_mass_alerts_validate_site_wide_alert_creation';
   $form['#validate'][] = 'mass_alerts_validate_alert_placement';
+
+  if (!\Drupal::currentUser()->hasPermission('create site wide alerts')) {
+    $form['field_alert_display']['widget']['#disabled'] = TRUE;
+  }
 }
 
 /**
@@ -28,6 +32,10 @@ function mass_alerts_form_node_alert_form_alter(&$form, FormStateInterface $form
 function mass_alerts_form_node_alert_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['#validate'][] = '_mass_alerts_validate_site_wide_alert_creation';
   $form['#validate'][] = 'mass_alerts_validate_alert_placement';
+
+  if (!\Drupal::currentUser()->hasPermission('create site wide alerts')) {
+    $form['field_alert_display']['widget']['#disabled'] = TRUE;
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
On the Alert node edit form I disabled the Alert Type (`field_alert_display` is the machine name) widget for users without the `create site wide alerts` permission. The ticket says hide this field but we decided to just disable the field for now so the help text on this page still makes sense and doesn't refer to fields that are hidden. 


**Jira:**
https://jira.mass.gov/browse/DP-18242


**To Test:**
- [ ] Visit an existing alert node as a user without `create site wide alerts` permission (So I think that would be a non-admin user without the "Emergency Alert Publisher" role)
- [ ] Verify the Alert Type field is disabled but you can still fill out the form and save it
- [ ] Visit a new alert node http://mass.local/node/add/alert and verify the Alert Type field is disabled as well
- [ ] Login as an admin or add the "Emergency Alert Publisher" role to your user
- [ ] Verify the same field is not disabled on existing and new alert nodes


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
