### PR TITLE
DP-18377 Add languages to google translate widget

### DIFF
--- a/changelogs/DP-18377.yml
+++ b/changelogs/DP-18377.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Added more languages to Google translate feature
+    issue: DP-18377

--- a/conf/drupal/config/mass_theme.settings.yml
+++ b/conf/drupal/config/mass_theme.settings.yml
@@ -11,15 +11,31 @@ favicon:
   mimetype: image/png
 languages:
   ar: ar
+  hy: hy
   es: es
   fr: fr
+  el: el
+  de: de
+  gu: gu
   ht: ht
+  iw: iw
+  hi: hi
   it: it
+  ja: ja
   km: km
   ko: ko
+  lo: lo
+  ml: ml
+  fa: fa
   pl: pl
   pt: pt
   ru: ru
+  te: te
+  tl: tl
+  ta: ta
+  th: th
+  uk: uk
+  ur: ur
   vi: vi
   zh-CN: zh-CN
   aa: 0
@@ -42,13 +58,10 @@ languages:
   cs: 0
   cy: 0
   da: 0
-  de: 0
   dz: 0
-  el: 0
   eo: 0
   et: 0
   eu: 0
-  fa: 0
   fi: 0
   fj: 0
   fo: 0
@@ -57,19 +70,14 @@ languages:
   gd: 0
   gl: 0
   gn: 0
-  gu: 0
   ha: 0
-  hi: 0
   hr: 0
   hu: 0
-  hy: 0
   ia: 0
   ie: 0
   ik: 0
   in: 0
   is: 0
-  iw: 0
-  ja: 0
   ji: 0
   jw: 0
   ka: 0
@@ -81,13 +89,11 @@ languages:
   ky: 0
   la: 0
   ln: 0
-  lo: 0
   lt: 0
   lv: 0
   mg: 0
   mi: 0
   mk: 0
-  ml: 0
   mn: 0
   mo: 0
   mr: 0
@@ -124,21 +130,15 @@ languages:
   su: 0
   sv: 0
   sw: 0
-  ta: 0
-  te: 0
   tg: 0
-  th: 0
   ti: 0
   tk: 0
-  tl: 0
   tn: 0
   to: 0
   tr: 0
   ts: 0
   tt: 0
   tw: 0
-  uk: 0
-  ur: 0
   uz: 0
   vo: 0
   wo: 0


### PR DESCRIPTION
**Description:**
We've added a lot more languages to the Google Translate widget based on languages spoken in MA.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18377


**To Test:**
- [ ] Click "Select language" on the home page. Verify that you see 28 languages now.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
