### PR TITLE
DP-17511: deleted referenced entity issue fix

### DIFF
--- a/changelogs/DP-17511.yml
+++ b/changelogs/DP-17511.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Solving deleted referenced entity rendering issue causing fatal error
+    issue: DP-17511

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbca7570ac5746405780f416bf69f41e",
+    "content-hash": "e6732deb59c06970ea7a2dd6d3a273a0",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6732deb59c06970ea7a2dd6d3a273a0",
+    "content-hash": "fbca7570ac5746405780f416bf69f41e",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -3,6 +3,7 @@
 namespace Drupal\mayflower\Prepare;
 
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Url;
 use Drupal\mayflower\Helper;
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\ContentEntityInterface;
@@ -537,7 +538,8 @@ class Organisms {
         }
       }
       // On an internal link item, load the referenced node title.
-      elseif (strpos($field_value->getValue()['uri'], 'entity:node') !== FALSE) {
+      // DP-17511: If ref is empty warning can be thrown, adding isset check.
+      elseif (isset($field_value->getValue()['uri']) && strpos($field_value->getValue()['uri'], 'entity:node') !== FALSE) {
         $options['url'] = $field_value->getUrl();
         $options['text'] = $field_value->computed_title;
         if (method_exists($options['url'], 'getRouteParameters') && $options['url']->isRouted() == TRUE) {
@@ -552,7 +554,12 @@ class Organisms {
           }
         }
       }
+      // DP-17511: Solving issue when referenced entity is deleted.
+      elseif (isset($field_value->getValue()['target_id']) && !$field_value->getValue()['_loaded']) {
+        break;
+      }
       else {
+
         $url = $field_value->getUrl();
         $items[] = [
           'title' => [
@@ -560,6 +567,7 @@ class Organisms {
             'text' => $field_value->getValue()['title'] ?: $url,
           ],
         ];
+
       }
     }
 

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -556,7 +556,7 @@ class Organisms {
       }
       // DP-17511: Solving issue when referenced entity is deleted.
       elseif (isset($field_value->getValue()['target_id']) && !$field_value->getValue()['_loaded']) {
-        break;
+        continue;
       }
       else {
 


### PR DESCRIPTION
Description:
The DCAMM org page began producing a 500 error on 2/12/2020. the page hasn't been edited since 1/16/20.

Jira:
https://jira.mass.gov/browse/DP-17511

To Test:
Org pages do not error when an item they reference has been removed.
