### PR TITLE
DP-16023: changing help text on Service page CT

### DIFF
--- a/changelogs/DP-16023.yml
+++ b/changelogs/DP-16023.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changing help text on Service pages.
+    issue: DP-16023

--- a/conf/drupal/config/field.field.node.service_page.field_service_ref_actions_2.yml
+++ b/conf/drupal/config/field.field.node.service_page.field_service_ref_actions_2.yml
@@ -12,7 +12,7 @@ field_name: field_service_ref_actions_2
 entity_type: node
 bundle: service_page
 label: 'Featured tasks'
-description: 'These tasks will be prominently displayed on this page and when the service is shown on other pages.'
+description: "Tasks will be prominently displayed both on this page and when the service is shown on Topic pages. <br>\r\nWe recommend each <strong>Featured task</strong> also typically be included among your links under individual Link groups to ensure those resources can be found in context."
 required: false
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.paragraph.link_group.field_links_documents.yml
+++ b/conf/drupal/config/field.field.paragraph.link_group.field_links_documents.yml
@@ -14,7 +14,7 @@ field_name: field_links_documents
 entity_type: paragraph
 bundle: link_group
 label: 'Links / Documents'
-description: 'Choose an internal or external link, or any document. You can add up to 10 items.'
+description: "Choose an internal or external link, or any document. You can add up to 10 items.<br>\r\nWe suggest keeping most groups to 5 or fewer items so as not to overwhelm users. You can also overwrite the titles of links or documents to make your page cleaner.<br>\r\nDo not link to Organization, Service or Topic pages."
 required: true
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.paragraph.link_group.field_section_title.yml
+++ b/conf/drupal/config/field.field.paragraph.link_group.field_section_title.yml
@@ -10,7 +10,7 @@ field_name: field_section_title
 entity_type: paragraph
 bundle: link_group
 label: 'Group link title'
-description: 'This title will be shown as a header for the list of links.'
+description: "This description will be shown below the <strong>Link group title</strong>.<br>\r\nWhile the description is optional, these are especially useful for elaborating on a longer list of links or documents. Keep to 1 sentence."
 required: true
 translatable: true
 default_value: {  }


### PR DESCRIPTION
**Description:**
Changed help on Service content type field and 2 field from Link group paragraph.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-16023


**To Test:**
http://mass.local/other-capital-projects/edit
See updated texts under "Tasks and Key info" tab


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
