### PR TITLE
DP-18429: adding field_template field for author and editor

### DIFF
--- a/changelogs/DP-18429.yml
+++ b/changelogs/DP-18429.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changing field_template permission to be visible for Author and Editor!
+    issue: DP-18429

--- a/changelogs/DP-18429.yml
+++ b/changelogs/DP-18429.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Changing field_template permission to be visible for Author and Editor!
+  - description: Changing field_template permission to be visible for Author and Editor.
     issue: DP-18429

--- a/conf/drupal/config/user.role.author.yml
+++ b/conf/drupal/config/user.role.author.yml
@@ -127,6 +127,7 @@ permissions:
   - 'rabbit hole administer node'
   - 'rabbit hole bypass node'
   - 'require tfa'
+  - 'set service page template'
   - 'setup own tfa'
   - 'update any media'
   - 'update media'

--- a/conf/drupal/config/user.role.editor.yml
+++ b/conf/drupal/config/user.role.editor.yml
@@ -154,6 +154,7 @@ permissions:
   - 'revert service_details revisions'
   - 'revert service_page revisions'
   - 'schedule publishing of nodes'
+  - 'set service page template'
   - 'setup own tfa'
   - 'update any media'
   - 'update media'


### PR DESCRIPTION
**Description:**
Permission set to the the user roles editor and author. The functionality is still there it is controlled with permission 'set service page template'

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18429


**To Test:**
- [ ] Login as a user with role author and add/edit service node
- [ ] Login as a user with role editor and add/edit service node
