### PR TITLE
Force media download links on www to have 60 second TTL at Cloudflare…

### DIFF
--- a/cloudflare/src/backends.js
+++ b/cloudflare/src/backends.js
@@ -112,7 +112,7 @@ export function www(token) {
       browserTTL = 60
     }
     else if(isMediaDownloadUrl(url)) {
-      edgeTTL = RESPECT_ORIGIN
+      edgeTTL = 60
       browserTTL = 60
     }
     else if(isStaticUrl(url)) {


### PR DESCRIPTION
Old value was `RESPECT_ORIGIN`. Now www matches edit.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18608


**To Test:**
- [ ] ?


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
