### PR TITLE
Dp 18453 add field label to pages linking here

### DIFF
--- a/changelogs/DP-18453.yml
+++ b/changelogs/DP-18453.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Added new column to linking pages screen
+    issue: DP-18453

--- a/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
@@ -78,50 +78,55 @@ class LinkingPageController extends ControllerBase {
     $children = $this->descendantManager->getImpact($nid, 'node');
 
     $used_links = [];
-    foreach ($children as $k => $child) {
-      $child_node = Node::load($child);
+    if (!empty($children)) {
+      $unique = array_unique($children);
+      foreach ($unique as $k => $child) {
+        $child_node = Node::load($child);
 
-      $field_names = $this->fetchNodeTypeConfig($child_node);
-      $descendants = $this->fetchRelations($child_node, $field_names);
+        $field_names = $this->fetchNodeTypeConfig($child_node);
+        $descendants = $this->fetchRelations($child_node, $field_names);
 
-      foreach ($descendants as $dependency_status => $fields) {
-        foreach ($fields as $name => $field) {
-          if ($dependency_status === 'linking_pages') {
-            foreach ($field as $field_info) {
-              if ($field_info['id'] == $nid) {
-                $used_links[$child][] = ['label' => $field_info['field_label'], 'used' => 0];
+        foreach ($descendants as $dependency_status => $fields) {
+          foreach ($fields as $name => $field) {
+            if ($dependency_status === 'linking_pages') {
+              foreach ($field as $field_info) {
+                if ($field_info['id'] == $nid) {
+                  $used_links[$child][] = [
+                    'label' => $field_info['field_label'],
+                    'used' => 0,
+                  ];
+                }
               }
             }
           }
         }
-      }
 
-      $label = $child_node->label();
-      $child_link = Url::fromRoute('entity.node.canonical', ['node' => $child]);
-      $output['linking_nodes'][$k]['node'][] = [
-        '#type' => 'link',
-        '#title' => $label,
-        '#url' => $child_link,
-      ];
-      $output['linking_nodes'][$k]['nid'][] = [
-        '#type' => 'item',
-        '#title' => $child,
-      ];
-      $output['linking_nodes'][$k]['type'][] = [
-        '#type' => 'item',
-        '#title' => $child_node->getType(),
-      ];
-      if (!empty($used_links)) {
-        foreach ($used_links as $child_nid => $labels) {
-          if ($child_nid == $child_node->id()) {
-            foreach ($labels as $index => $label) {
-              if ($label['used'] == 0) {
-                $output['linking_nodes'][$k]['field_label'][] = [
-                  '#type' => 'item',
-                  '#title' => $label['label'],
-                ];
-                $used_links[$child_nid][$index]['used'] = 1;
-                break;
+        $label = $child_node->label();
+        $child_link = Url::fromRoute('entity.node.canonical', ['node' => $child]);
+        $output['linking_nodes'][$k]['node'][] = [
+          '#type' => 'link',
+          '#title' => $label,
+          '#url' => $child_link,
+        ];
+        $output['linking_nodes'][$k]['nid'][] = [
+          '#type' => 'item',
+          '#title' => $child,
+        ];
+        $output['linking_nodes'][$k]['type'][] = [
+          '#type' => 'item',
+          '#title' => $child_node->getType(),
+        ];
+        if (!empty($used_links)) {
+          foreach ($used_links as $child_nid => $labels) {
+            if ($child_nid == $child_node->id()) {
+              foreach ($labels as $index => $label) {
+                if ($label['used'] == 0) {
+                  $output['linking_nodes'][$k]['field_label'][] = [
+                    '#type' => 'item',
+                    '#title' => $label['label'],
+                  ];
+                  $used_links[$child_nid][$index]['used'] = 1;
+                }
               }
             }
           }

--- a/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
@@ -70,7 +70,7 @@ class LinkingPageController extends ControllerBase {
         $this->t('Title'),
         $this->t('ID'),
         $this->t('Content Type'),
-        $this->t('Field label'),
+        $this->t('Field Label'),
       ],
       '#empty' => $this->t('No pages link here.'),
     ];
@@ -83,7 +83,7 @@ class LinkingPageController extends ControllerBase {
       $field_names = $this->fetchNodeTypeConfig($child_node);
       $descendants = $this->fetchRelations($child_node, $field_names);
 
-      $machine_name = '';
+      $field_label = '';
       foreach ($descendants as $dependency_status => $fields) {
         foreach ($fields as $name => $field) {
 
@@ -91,20 +91,10 @@ class LinkingPageController extends ControllerBase {
             foreach ($field as $field_info) {
 
               if ($field_info['id'] == $nid) {
-                $machine_name = $name;
+                $field_label = $field_info['field_label'];
               }
             }
           }
-        }
-      }
-
-      if (!empty($child_node->$machine_name)) {
-        $field_label = $child_node->$machine_name->getFieldDefinition()->getLabel();
-      }
-      else {
-        $top_field_machine_name = $this->fetchLinkingPageConfigRefTopParent($child_node, $machine_name);
-        if (!empty($child_node->$top_field_machine_name)) {
-          $field_label = $child_node->$top_field_machine_name->getFieldDefinition()->getLabel();
         }
       }
 

--- a/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
@@ -77,50 +77,56 @@ class MediaLinkingPageController extends ControllerBase {
     $media_id = $this->requestStack->getCurrentRequest()->attributes->get('media');
     $children = $this->descendantManager->getImpact($media_id, 'media');
     $used_links = [];
-    foreach ($children as $k => $child_id) {
-      $child_node = Node::load($child_id);
+    if (!empty($children)) {
+      $unique = array_unique($children);
+      foreach ($unique as $k => $child_id) {
+        $child_node = Node::load($child_id);
 
-      $field_names = $this->fetchNodeTypeConfig($child_node);
-      $descendants = $this->fetchRelations($child_node, $field_names);
+        $field_names = $this->fetchNodeTypeConfig($child_node);
+        $descendants = $this->fetchRelations($child_node, $field_names);
 
-      foreach ($descendants as $dependency_status => $fields) {
-        foreach ($fields as $name => $field) {
-          if ($dependency_status === 'linking_pages') {
-            foreach ($field as $field_info) {
-              if ($field_info['id'] == $media_id) {
-                $used_links[$child_id][] = ['label' => $field_info['field_label'], 'used' => 0];
+        foreach ($descendants as $dependency_status => $fields) {
+          foreach ($fields as $name => $field) {
+            if ($dependency_status === 'linking_pages') {
+              foreach ($field as $field_info) {
+                if ($field_info['id'] == $media_id) {
+                  $used_links[$child_id][] = [
+                    'label' => $field_info['field_label'],
+                    'used' => 0,
+                  ];
+                }
               }
             }
           }
         }
-      }
 
-      $label = $child_node->label();
-      $child_link = Url::fromRoute('entity.node.canonical', ['node' => $child_id]);
-      $output['linking_nodes'][$k]['node'][] = [
-        '#type' => 'link',
-        '#title' => $label,
-        '#url' => $child_link,
-      ];
-      $output['linking_nodes'][$k]['nid'][] = [
-        '#type' => 'item',
-        '#title' => $child_id,
-      ];
-      $output['linking_nodes'][$k]['type'][] = [
-        '#type' => 'item',
-        '#title' => $child_node->getType(),
-      ];
-      if (!empty($used_links)) {
-        foreach ($used_links as $child_nid => $labels) {
-          if ($child_nid == $child_node->id()) {
-            foreach ($labels as $index => $label) {
-              if ($label['used'] == 0) {
-                $output['linking_nodes'][$k]['field_label'][] = [
-                  '#type' => 'item',
-                  '#title' => $label['label'],
-                ];
-                $used_links[$child_nid][$index]['used'] = 1;
-                break;
+        $label = $child_node->label();
+        $child_link = Url::fromRoute('entity.node.canonical', ['node' => $child_id]);
+        $output['linking_nodes'][$k]['node'][] = [
+          '#type' => 'link',
+          '#title' => $label,
+          '#url' => $child_link,
+        ];
+        $output['linking_nodes'][$k]['nid'][] = [
+          '#type' => 'item',
+          '#title' => $child_id,
+        ];
+        $output['linking_nodes'][$k]['type'][] = [
+          '#type' => 'item',
+          '#title' => $child_node->getType(),
+        ];
+
+        if (!empty($used_links)) {
+          foreach ($used_links as $child_nid => $labels) {
+            if ($child_nid == $child_node->id()) {
+              foreach ($labels as $index => $label) {
+                if ($label['used'] == 0) {
+                  $output['linking_nodes'][$k]['field_label'][] = [
+                    '#type' => 'item',
+                    '#title' => $label['label'],
+                  ];
+                  $used_links[$child_nid][$index]['used'] = 1;
+                }
               }
             }
           }

--- a/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
+++ b/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
@@ -165,6 +165,9 @@ trait FieldProcessingTrait {
    */
   private function collectFieldEntities(FieldItemListInterface $field_entity) {
     $collected = [];
+    if (!empty($field_entity->getFieldDefinition())) {
+      $field_label = $field_entity->getFieldDefinition()->getLabel();
+    }
     if ($field_entity instanceof EntityReferenceFieldItemListInterface) {
       // If we can extract entity type and ID without loading up the child,
       // do it. If this results in deleted/unpublished entities ending up in the
@@ -175,7 +178,7 @@ trait FieldProcessingTrait {
           $collected[$child_id] = [
             'id' => $child_id,
             'entity' => $child_entity_type,
-            'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
+            'field_label' => $field_label ?? '',
           ];
         }
       }
@@ -184,7 +187,7 @@ trait FieldProcessingTrait {
           $collected[$child->id()] = [
             'id' => $child->id(),
             'entity' => $child->getEntityTypeId(),
-            'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
+            'field_label' => $field_label ?? '',
           ];
         }
       }
@@ -197,7 +200,7 @@ trait FieldProcessingTrait {
             $collected[$matches[1]] = [
               'id' => $matches[1],
               'entity' => 'node',
-              'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
+              'field_label' => $field_label ?? '',
             ];
           }
         }

--- a/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
+++ b/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
@@ -47,44 +47,6 @@ trait FieldProcessingTrait {
   }
 
   /**
-   * Fetch the third party settings of a given content entity.
-   *
-   * If there are nested fields get top level field machine name.
-   *
-   * @param \Drupal\node\Entity\Node $node
-   *   A node object from which to retrieve any third party settings.
-   *
-   * @param string $field_name
-   *   A node object from which to retrieve any third party settings.
-   *
-   * @return mixed
-   *   If third party settings are present we return them otherwise we return
-   *   nothing.
-   */
-  public function fetchLinkingPageConfigRefTopParent(Node $node, $field_name) {
-    $type = $node->type->entity;
-    if (!$type) {
-      \Drupal::logger('mass_content_api')->warning('Node "@id" does not have a type', ['@id' => $node->id()]);
-      return [];
-    }
-    $node_settings = $type->getThirdPartySettings('mass_content_api');
-    $config = array_filter($node_settings);
-    $related_parent = '';
-    foreach ($config as $dependency_status => $specs) {
-      if ($dependency_status == 'linking_pages') {
-        foreach ($specs as $spec) {
-          if (strpos($spec, $field_name) !== FALSE) {
-            $spec_exploded = explode('>', $spec);
-            // First item in array is the top.
-            $related_parent = $spec_exploded[0];
-          }
-        }
-      }
-    }
-    return $related_parent;
-  }
-
-  /**
    * Fetch IDs and types of related entities given a content entity and config.
    *
    * Spec should be taken from the config array in the content entity's .yml
@@ -213,6 +175,7 @@ trait FieldProcessingTrait {
           $collected[$child_id] = [
             'id' => $child_id,
             'entity' => $child_entity_type,
+            'field_label' => $field_entity->getFieldDefinition()->getLabel(),
           ];
         }
       }
@@ -221,6 +184,7 @@ trait FieldProcessingTrait {
           $collected[$child->id()] = [
             'id' => $child->id(),
             'entity' => $child->getEntityTypeId(),
+            'field_label' => $field_entity->getFieldDefinition()->getLabel(),
           ];
         }
       }
@@ -233,6 +197,7 @@ trait FieldProcessingTrait {
             $collected[$matches[1]] = [
               'id' => $matches[1],
               'entity' => 'node',
+              'field_label' => $field_entity->getFieldDefinition()->getLabel(),
             ];
           }
         }

--- a/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
+++ b/docroot/modules/custom/mass_content_api/src/FieldProcessingTrait.php
@@ -175,7 +175,7 @@ trait FieldProcessingTrait {
           $collected[$child_id] = [
             'id' => $child_id,
             'entity' => $child_entity_type,
-            'field_label' => $field_entity->getFieldDefinition()->getLabel(),
+            'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
           ];
         }
       }
@@ -184,7 +184,7 @@ trait FieldProcessingTrait {
           $collected[$child->id()] = [
             'id' => $child->id(),
             'entity' => $child->getEntityTypeId(),
-            'field_label' => $field_entity->getFieldDefinition()->getLabel(),
+            'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
           ];
         }
       }
@@ -197,7 +197,7 @@ trait FieldProcessingTrait {
             $collected[$matches[1]] = [
               'id' => $matches[1],
               'entity' => 'node',
-              'field_label' => $field_entity->getFieldDefinition()->getLabel(),
+              'field_label' => $field_entity->getFieldDefinition()->getLabel() ?? '',
             ];
           }
         }

--- a/docroot/modules/custom/mass_content_api/tests/src/Kernel/DescendantExtractorTest.php
+++ b/docroot/modules/custom/mass_content_api/tests/src/Kernel/DescendantExtractorTest.php
@@ -24,23 +24,23 @@ class DescendantExtractorTest extends UnitTestCase {
       [
         0 => 'field_1',
         1 => '*',
-      ]
+      ],
     ];
 
     $entity_info = [
       'fields' => [
         'field_1' => [
           'type' => 'entity_reference',
-          'referenced_entities' => []
-        ]
-      ]
+          'referenced_entities' => [],
+        ],
+      ],
     ];
 
     $entity = $this->makeMockContentEntityInterface($entity_info);
     $result = $extractor->fetchRelations($entity, $spec);
 
     $expected = [
-      'parents' => []
+      'parents' => [],
     ];
 
     $this->assertEquals($expected, $result);
@@ -84,7 +84,7 @@ class DescendantExtractorTest extends UnitTestCase {
                         ],
                       ],
                     ],
-                  ]
+                  ],
                 ],
                 'field_4' => [
                   'type' => 'list',
@@ -109,10 +109,12 @@ class DescendantExtractorTest extends UnitTestCase {
           3 => [
             'id' => 3,
             'entity' => 'node',
+            'field_label' => '',
           ],
           4 => [
             'id' => 4,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
       ],
@@ -133,14 +135,14 @@ class DescendantExtractorTest extends UnitTestCase {
         [
           0 => 'field_1',
           1 => '*',
-        ]
+        ],
       ],
       'children' => [
         [
           0 => 'field_2',
           1 => '*',
         ],
-      ]
+      ],
     ];
 
     $entity_info = [
@@ -154,13 +156,13 @@ class DescendantExtractorTest extends UnitTestCase {
                 'field_3' => [
                   'type' => 'list',
                   'list_items' => [
-                     'link' => ['entity:node/1', 'entity:node/2']
+                    'link' => ['entity:node/1', 'entity:node/2'],
                   ],
                 ],
                 'field_5' => [
                   'type' => 'list',
                   'list_items' => [
-                    'link' => ['entity:node/3', 'entity:node/4']
+                    'link' => ['entity:node/3', 'entity:node/4'],
                   ],
                 ],
               ],
@@ -205,20 +207,24 @@ class DescendantExtractorTest extends UnitTestCase {
           1 => [
             'id' => 1,
             'entity' => 'node',
+            'field_label' => '',
           ],
           2 => [
             'id' => 2,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
         'field_5' => [
           3 => [
             'id' => 3,
             'entity' => 'node',
+            'field_label' => '',
           ],
           4 => [
             'id' => 4,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
       ],
@@ -227,16 +233,19 @@ class DescendantExtractorTest extends UnitTestCase {
           5 => [
             'id' => 5,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
         'field_6' => [
           6 => [
             'id' => 6,
             'entity' => 'node',
+            'field_label' => '',
           ],
           7 => [
             'id' => 7,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
       ],
@@ -261,7 +270,7 @@ class DescendantExtractorTest extends UnitTestCase {
           1 => 'field_2',
           2 => 'field_3',
           3 => 'field_4',
-        ]
+        ],
       ],
     ];
 
@@ -296,8 +305,8 @@ class DescendantExtractorTest extends UnitTestCase {
                           ],
                         ],
                       ],
-                    ]
-                  ]
+                    ],
+                  ],
                 ],
               ],
             ],
@@ -316,10 +325,12 @@ class DescendantExtractorTest extends UnitTestCase {
           1 => [
             'id' => 1,
             'entity' => 'node',
+            'field_label' => '',
           ],
           2 => [
             'id' => 2,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
       ],
@@ -342,7 +353,7 @@ class DescendantExtractorTest extends UnitTestCase {
           1 => 'field_2',
           2 => 'field_3',
           3 => '*',
-        ]
+        ],
       ],
     ];
 
@@ -389,8 +400,8 @@ class DescendantExtractorTest extends UnitTestCase {
                           ],
                         ],
                       ],
-                    ]
-                  ]
+                    ],
+                  ],
                 ],
               ],
             ],
@@ -409,30 +420,36 @@ class DescendantExtractorTest extends UnitTestCase {
           1 => [
             'id' => 1,
             'entity' => 'node',
+            'field_label' => '',
           ],
           2 => [
             'id' => 2,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
         'field_5' => [
           3 => [
             'id' => 3,
             'entity' => 'node',
+            'field_label' => '',
           ],
           4 => [
             'id' => 4,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
         'field_6' => [
           5 => [
             'id' => 5,
             'entity' => 'node',
+            'field_label' => '',
           ],
           6 => [
             'id' => 6,
             'entity' => 'node',
+            'field_label' => '',
           ],
         ],
       ],


### PR DESCRIPTION
**Description:**
Added field_label index to the array returned from the child nodes


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18453


**To Test:**
- [ ] Go to Media item page and navigate to "Pages linking here" tab, new column should be available with the target referenced entity fields label(e.g. /doc/ayer-financial-management-review-may-2007-0/linking-page)
- [ ] Go to any Node page and navigate to "Pages linking here" tab, new column should be available with the target referenced entity fields label(e.g. how-to/reset-your-ui-online-password-as-a-claimant/linking-page)

