### PR TITLE
DP-18615 Fix org page 500 error

### DIFF
--- a/changelogs/DP-18615.yml
+++ b/changelogs/DP-18615.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Add check to featured message link formatter to stop 500 error
+    issue: DP-18615

--- a/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
+++ b/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
@@ -35,7 +35,15 @@ class LinkTitleSeparateFormatter extends LinkSeparateFormatter {
         // be formatted as trimmed.
         $uri = $items->getValue()[$page_key]['uri'];
         $url = Url::fromUri($uri);
-        $node_label = Node::load($url->getRouteParameters()['node'])->label();
+
+        if ($url->isRouted() && isset($url->getRouteParameters()['node'])) {
+          $node = \Drupal::entityTypeManager()->getStorage('node')->load($url->getRouteParameters()['node']);
+          $node_label = $node->label();
+        }
+        else {
+          $node_label = $element[$page_key]['#url_title'];
+        }
+
         // Set link title to node label or the trimmed format.
         $element[$page_key]['#title'] = (!empty($settings['trim_length'])) ? Unicode::truncate($node_label, $settings['trim_length'], FALSE, TRUE) : $node_label;
       }

--- a/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
+++ b/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
@@ -36,8 +36,8 @@ class LinkTitleSeparateFormatter extends LinkSeparateFormatter {
         $uri = $items->getValue()[$page_key]['uri'];
         $url = Url::fromUri($uri);
 
-        if ($url->isRouted() && isset($url->getRouteParameters()['node'])) {
-          $node = \Drupal::entityTypeManager()->getStorage('node')->load($url->getRouteParameters()['node']);
+        if ($url->isRouted() && $nid = $url->getRouteParameters()['node']) {
+          $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
           $node_label = $node->label();
         }
         else {


### PR DESCRIPTION
**Description:**
We were receiving this 500 error:

![error](https://user-images.githubusercontent.com/11247942/81329382-7ca0c480-906c-11ea-8ea5-32fa0c45bb79.png)

https://rpm.newrelic.com/accounts/1522041/applications/46704875/traced_errors/565438f5-9072-11ea-a13c-0242ac110009_0_5259

on these pages:
https://www.mass.gov/orgs/office-of-the-child-advocate
https://www.mass.gov/orgs/massachusetts-grownand-fresher

I adjusted `LinkTitleSeparateFormatter.php` to check if the URL is routed before trying `getRouteParameters()`. Also cleaned up the code here and added a fallback. 


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18615


**To Test:**

- [x] Visit an org node like this one http://mass.local/orgs/massachusetts-grownand-fresher/edit
- [x] Edit the node, under the Featured section fill out the Featured message heading, content, and add an internal link but don't fill out the link text.
- [x] Save the node form and verify the link title is the node title of the node you have just referenced
- [x] Edit the same node again and change the link to an external link
- [x] Save the node and verify it just defaults to that link
- [x] If for either internal of external you fill out the link text than that is what should display


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
