### PR TITLE
RelatedNodes - several simple queries instead of 1 complex query

### DIFF
--- a/changelogs/DP-15829.yml
+++ b/changelogs/DP-15829.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: RelatedNodes - several simple queries instead of 1 complex query
+    issue: DP-15829

--- a/docroot/modules/custom/mass_content/src/Field/QueryGeneratedEntityReferenceListUpdated.php
+++ b/docroot/modules/custom/mass_content/src/Field/QueryGeneratedEntityReferenceListUpdated.php
@@ -10,7 +10,7 @@ use Drupal\Core\TypedData\ComputedItemListTrait;
  *
  * This can be used to make the results of any query a property on an entity.
  *
- * Currently being used by RelatedNodes.php, PersonOrgRoles.php, and DYnamicDirectoryByLabel.php.
+ * Currently being used by PersonOrgRoles.php, and DynamicDirectoryByLabel.php.
  */
 abstract class QueryGeneratedEntityReferenceListUpdated extends EntityReferenceFieldItemList {
   use ComputedItemListTrait;

--- a/docroot/modules/custom/mass_content/src/Field/RelatedNodes.php
+++ b/docroot/modules/custom/mass_content/src/Field/RelatedNodes.php
@@ -64,9 +64,9 @@ class RelatedNodes extends EntityReferenceFieldItemList {
   }
 
   /**
-   * Lists all the referencing content from a field
+   * Lists all the referencing content from a field.
    *
-   * @return array $nids.
+   * @return array
    *   A list of referenced nids.
    */
   public function fields() {
@@ -99,7 +99,7 @@ class RelatedNodes extends EntityReferenceFieldItemList {
   /**
    * Get nids that are referenced from the configured Link fields.
    *
-   * @return array $nids.
+   * @return array
    *   A list if nids.
    */
   protected function links() {
@@ -156,4 +156,3 @@ class RelatedNodes extends EntityReferenceFieldItemList {
   }
 
 }
-

--- a/docroot/modules/custom/mass_content/src/Field/RelatedNodes.php
+++ b/docroot/modules/custom/mass_content/src/Field/RelatedNodes.php
@@ -2,6 +2,10 @@
 
 namespace Drupal\mass_content\Field;
 
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
 /**
  * Related Nodes computed field.
  *
@@ -41,34 +45,40 @@ namespace Drupal\mass_content\Field;
  *     Example:
  *       ->setSetting('types', ['news', 'organization'])
  */
-class RelatedNodes extends QueryGeneratedEntityReferenceListUpdated {
-
-  protected $length = 25;
-
-  /**
-   * Array of nids already used on this related to field to filter results.
-   *
-   * @var array
-   */
-  protected $nids = [];
+class RelatedNodes extends EntityReferenceFieldItemList {
+  use ComputedItemListTrait;
 
   /**
    * {@inheritdoc}
    */
   public function computeValue() {
-    // Lists all the referencing content from a field prior to building and
-    // running the query to find dynamic links.
+    $nids_fields = $this->fields();
+    $nids_links = $this->links();
+    $nids_total = array_merge($nids_fields, $nids_links);
+    $nids = array_slice(array_filter(array_unique($nids_total)), 0, 25);
+    $i = 0;
+    foreach ($nids as $nid) {
+      $this->list[] = $this->createItem($i, ['target_id' => $nid]);
+      $i++;
+    }
+  }
+
+  /**
+   * Lists all the referencing content from a field
+   *
+   * @return array $nids.
+   *   A list of referenced nids.
+   */
+  public function fields() {
+    $nids = [];
     $fields = $this->getSetting('fields');
     if (!empty($fields)) {
       $entity = $this->getEntity();
       if (!$entity->isNew()) {
-        $i = 0;
-
         foreach ($fields as $field) {
           if ($entity->hasField($field)) {
-            $nodes = $entity->get($field)->referencedEntities();
-
             /** @var \Drupal\node\Entity\Node $node */
+            $nodes = $entity->get($field)->referencedEntities();
             foreach ($nodes as $node) {
               // If the node referenced by an event is an org_page, prevent
               // adding it as a reference on the event's page.
@@ -76,56 +86,74 @@ class RelatedNodes extends QueryGeneratedEntityReferenceListUpdated {
                 continue;
               }
               else {
-                $this->nids[] = $node->id();
-                $this->list[] = $this->createItem($i, ['target_id' => $node->id()]);
-                $i++;
+                $nids[] = $node->id();
               }
             }
           }
         }
       }
     }
-    // Continues loading related content once the event caveat is handled.
-    parent::computeValue();
+    return $nids;
   }
 
   /**
-   * {@inheritdoc}
+   * Get nids that are referenced from the configured Link fields.
+   *
+   * @return array $nids.
+   *   A list if nids.
    */
-  protected function query() {
+  protected function links() {
+    $nids = [];
     /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
     $entity = $this->getEntity();
     $uri = 'entity:node/' . $entity->id();
-    $query = \Drupal::entityQuery('node');
-    $group = $query->orConditionGroup();
 
     $linkFields = $this->getSetting('linkFields');
     if (!empty($linkFields)) {
       foreach ($linkFields as $linkField) {
-        $group->condition($linkField . '.uri', $uri);
+        $query = $this->getQuery();
+        $query->condition($linkField . '.uri', $uri);
+        $return = $query->execute();
+        // Discard the keys in $return as we don't care about revision ids.
+        $nids = array_merge($nids, array_values($return));
       }
     }
 
     $referenceFields = $this->getSetting('referenceFields');
     if (!empty($referenceFields)) {
       foreach ($referenceFields as $referenceField) {
-        $group->condition($referenceField . '.target_id', $entity->id());
+        $query = $this->getQuery();
+        $query->condition($referenceField . '.target_id', $entity->id());
+        $return = $query->execute();
+        // Discard the keys in $return as we don't care about revision ids.
+        $nids = array_merge($nids, array_values($return));
       }
     }
 
     $types = $this->getSetting('types');
     if (!empty($types)) {
+      $query = $this->getQuery();
       $query->condition('type', $types, 'IN');
-    }
-    $query->condition('status', 1)
-      ->condition($group);
-
-    // Filter out any related odes that were manually set against this content.
-    if (!empty($this->nids)) {
-      $query->condition('nid', $this->nids, 'NOT IN');
+      $return = $query->execute();
+      // Discard the keys in $return as we don't care about revision ids.
+      $nids = array_merge($nids, array_values($return));
     }
 
+    return $nids;
+  }
+
+  /**
+   * Get an entity query object with common condition/range applied.
+   *
+   * @return \Drupal\Core\Entity\Query\QueryInterface
+   *   A query object.
+   */
+  protected function getQuery(): QueryInterface {
+    $query = \Drupal::entityQuery('node');
+    $query->condition('status', 1);
+    $query->range(0, 25);
     return $query;
   }
 
 }
+


### PR DESCRIPTION
Speeds up a very slow query.

**Description:**
We no longer inherit from QueryGeneratedEntityReferenceListUpdated as its better to break up this query.


**Jira:** (Skip unless you are MA staff)
DP-15829


**To Test:**
- [ ] Review related nodes for several different kinds of pages. The listed nodes should match whats shown on Prod. The order might be different, but the content should be the same. If they aren't the same, and there are more than 25 pieces of related content,  we need to decide which 25 to show.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
