### PR TITLE
DP-16346: The "More Parks" link on a location page was not updated when an Org page removed the map feature.

### DIFF
--- a/changelogs/DP-16346.yml
+++ b/changelogs/DP-16346.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Solving broken links issue on location pages.
+    issue: DP-16346

--- a/docroot/modules/custom/mass_content/src/Field/RelatedLocations.php
+++ b/docroot/modules/custom/mass_content/src/Field/RelatedLocations.php
@@ -67,19 +67,22 @@ class RelatedLocations extends EntityReferenceFieldItemList {
             }
           }
         }
-
-        if (count($ref_count) > 2) {
-          $items = $this->sortParents($ref_count);
-        }
-        else {
-          $items = array_keys($ref_count);
+        if (!empty($ref_count)) {
+          if (count($ref_count) > 2) {
+            $items = $this->sortParents($ref_count);
+          }
+          else {
+            $items = array_keys($ref_count);
+          }
         }
       }
 
       $delta = 0;
-      foreach ($items as $item) {
-        $this->list[$delta] = $this->createItem($delta, ['target_id' => $item]);
-        $delta++;
+      if (!empty($items)) {
+        foreach ($items as $item) {
+          $this->list[$delta] = $this->createItem($delta, ['target_id' => $item]);
+          $delta++;
+        }
       }
     }
   }

--- a/docroot/modules/custom/mass_content/src/Field/RelatedLocations.php
+++ b/docroot/modules/custom/mass_content/src/Field/RelatedLocations.php
@@ -4,6 +4,7 @@ namespace Drupal\mass_content\Field;
 
 use Drupal\Core\TypedData\ComputedItemListTrait;
 use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\mayflower\Helper;
 use Drupal\node\Entity\Node;
 
 /**
@@ -59,7 +60,10 @@ class RelatedLocations extends EntityReferenceFieldItemList {
         foreach ($fields as $field) {
           foreach ($parent_nodes as $parent_node) {
             if ($parent_node->hasField($field)) {
-              $ref_count[$parent_node->id()] = count($parent_node->{$field});
+              // We check here to see if field has value to avoid broken links.
+              if (Helper::getReferencedEntitiesFromField($parent_node, $field)) {
+                $ref_count[$parent_node->id()] = count($parent_node->{$field});
+              }
             }
           }
         }


### PR DESCRIPTION
**Description:**
Added a check to see if field actually has some values


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-16346


**To Test:**
- [ ] Go to example url /locations/mount-greylock-state-reservation
- [ ] Edit one of the nodes that appear on the More parks section
- [ ] Delete all the locations from that node
- [ ] Refresh the initial page and node link should be gone