### PR TITLE
Dp 18795 robots allow doc folder

### DIFF
--- a/changelogs/DP-18795.yml
+++ b/changelogs/DP-18795.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Removing robots disallow for doc and media top level folders.
+    issue: DP-18795

--- a/changelogs/DP-18795.yml
+++ b/changelogs/DP-18795.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Fixed:
-  - description: Removing robots disallow for doc and media top level folders.
+  - description: Removing robots disallow for doc top level folders.
     issue: DP-18795

--- a/docroot/robots.txt
+++ b/docroot/robots.txt
@@ -49,6 +49,7 @@ Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/
 Disallow: /user/logout/
+Disallow: /media/*
 Disallow: /taxonomy/term/*
 Disallow: /node/*
 # Paths (no clean URLs)

--- a/docroot/robots.txt
+++ b/docroot/robots.txt
@@ -49,8 +49,6 @@ Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/
 Disallow: /user/logout/
-Disallow: /media/*
-Disallow: /doc/*
 Disallow: /taxonomy/term/*
 Disallow: /node/*
 # Paths (no clean URLs)


### PR DESCRIPTION
**Description:**
Remove robot disallow for /doc directory.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18795


**To Test:**
- [ ] Review robots.txt and verify that we are not disallowing /doc path.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
