### PR TITLE
Add a new hold to build_tag workflow for releasing without maint mode.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -809,7 +809,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      - hold_for_prod:
+      - hold_for_prod_maint:
           type: approval
           requires:
             - build
@@ -820,14 +820,39 @@ workflows:
             tags:
               only: /.*/
       - deploy:
-          name: deploy-tag-prod-acquia
+          name: deploy-tag-prod-acquia-maint
           requires:
             - build
             - tagging_acquia
             - deploy-tag-stage-acquia
-            - hold_for_prod
+            - hold_for_prod_maint
           target: prod
           gitRef: tags/$CIRCLE_TAG
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+      - hold_for_prod_no_maint:
+          type: approval
+          requires:
+            - build
+            - tagging_acquia
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /.*/
+      - deploy:
+          name: deploy-tag-prod-acquia-no-maint
+          requires:
+            - build
+            - tagging_acquia
+            - deploy-tag-stage-acquia
+            - hold_for_prod_no_maint
+          target: prod
+          gitRef: tags/$CIRCLE_TAG
+          skip-maint: --skip-maint
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,7 +869,7 @@ workflows:
           requires:
             - build
             - tagging_acquia
-            - deploy-tag-prod-acquia
+            - deploy-tag-prod-acquia-maint
           filters:
             branches:
               ignore: /.*/
@@ -877,7 +877,7 @@ workflows:
               only: /.*/
       - backstop:
           name: backstop-prod
-          requires: [deploy-tag-prod-acquia]
+          requires: [deploy-tag-prod-acquia-maint]
           target: prod
           reference: test
           filters:

--- a/changelogs/DP-18558.yml
+++ b/changelogs/DP-18558.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add a new hold to build_tag workflow for releasing without maint mode.
+    issue: DP-18558


### PR DESCRIPTION
**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18558


**To Test:**
- [ ] I think the way to test this is to merge it to develop, release using the regular hold, and then do a test hotfix after this code is on Prod. The stakes are low. I think the only thing that could wrong is that we do maint mode when we prefer not to (i.e our current process).

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
