### PR TITLE
DP-17139: Change revision cleanup duration to 14 months

### DIFF
--- a/changelogs/DP-17139.yml
+++ b/changelogs/DP-17139.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changing default timestamp for the ma:queue-revision-cleanup drush command to be 14 months ago
+    issue: DP-17139

--- a/changelogs/DP-17139.yml
+++ b/changelogs/DP-17139.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Changing default timestamp for the ma:queue-revision-cleanup drush command to be 14 months ago
+  - description: Change duration for the ma:queue-revision-cleanup drush command to be 14 months ago
     issue: DP-17139

--- a/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
+++ b/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
@@ -301,7 +301,7 @@ class MassUtilityCommands extends DrushCommands {
    * @option offset
    *   Determines how many records to skip. Defaults to 0.
    * @option timestamp
-   *   The timestamp to use when processing revisions. Defaults to 1 year ago.
+   *   The timestamp to use when processing revisions. Defaults to 14 months ago.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Exception

--- a/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
+++ b/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
@@ -321,7 +321,7 @@ class MassUtilityCommands extends DrushCommands {
     $idlist = !empty($options['idlist']) ? explode(',', $options['idlist']) : [];
     // If the user didn't provide a timestamp, then default to a year ago from
     // today's date.
-    $timestamp = !empty($options['timestamp']) ? $options['timestamp'] : strtotime('1 year ago');
+    $timestamp = !empty($options['timestamp']) ? $options['timestamp'] : strtotime('14 months ago');
 
     // Setup the variables that will be used by the while loop.
     $finished = FALSE;


### PR DESCRIPTION
**Description:**
Changing default timestamp to be 14 months ago instead of 1 year for ma:queue-revision-cleanup


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-17139

