### PR TITLE
Dp 18819 missing tableau viz wrapping alignment

### DIFF
--- a/changelogs/DP-18819.yml
+++ b/changelogs/DP-18819.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed Tableau visualization conditional fields toggle.
+    issue: DP-18819

--- a/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
+++ b/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
@@ -128,22 +128,17 @@
    */
   Drupal.behaviors.tableauembedConditional = {
     attach: function (context) {
-      $('.field--name-field-tabl-display-size .form-select', context).change(function () {
-        $('.field--name-field-tabl-display-size .form-select option:selected').each(function () {
-          var $size = $(this).val();
-          if ($size === 'x-large') {
-            $('.field--name-field-tabl-alignment').hide();
-            $('.field--name-field-tabl-wrapping').hide();
-            $('.field--name-field-tabl-alignment .fieldgroup').removeAttr('required');
-          }
-          else {
-            $('.field--name-field-tabl-alignment').show();
-            $('.field--name-field-tabl-alignment .fieldgroup').prop('required', true);
-            $('.field--name-field-tabl-wrapping').show();
-          }
-        });
-      })
-        .change();
+      $('.field--name-field-tabl-display-size', context).change(function() {
+        if ($(this).find('option:selected').val() === 'x-large') {
+          $(this).siblings('.field--name-field-tabl-alignment').hide().find('.fieldgroup').removeAttr('required');
+          $(this).siblings('.field--name-field-tabl-wrapping').hide();
+        }
+        else {
+          $(this).siblings('.field--name-field-tabl-alignment').show().find('.fieldgroup').attr('required', 'required');
+          $(this).siblings('.field--name-field-tabl-wrapping').show();
+        }
+      }).change();
     }
   };
+
 })(jQuery, Drupal);


### PR DESCRIPTION
**Description:**
Tableau visualization paragraphs have jQuery in place to conditionally hide the alignment and wrapping fields when the display size field is set to X-large. This was causing issues where all alignment and wrapping fields would become hidden if a single visualization set its size to X-large. The testing includes steps to test saving the nodes. The reason for this is that one of the fields that we conditionally hide is a required field when shown.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18819


**To Test:**
- [ ] Edit a page using a tableau visualization.
- [ ] Check any tableau visualization entries that have the display size set to X-Large and check that the alignment and wrapping fields are hidden. For any fields not set to X-Large, verify that the fields are not hidden.
- [ ] Without making changes, save the node and verify that it successfully saves the node.
- [ ] Edit the page again and change display size values for a 2-3 visualizations. Check each visualization and ensure that X-large display size fields hide the alignment and wrapping and non-X-large display size fields show the fields.
- [ ] Save the node and verify that it successfully saves the node.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
