### PR TITLE
DP-18777 dataviz field order

### DIFF
--- a/changelogs/DP-18777.yml
+++ b/changelogs/DP-18777.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changed Caption field order in Tableau paragraph form displays.
+    issue: DP-18777

--- a/conf/drupal/config/core.entity_form_display.paragraph.tableau_embed.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.tableau_embed.default.yml
@@ -21,7 +21,7 @@ bundle: tableau_embed
 mode: default
 content:
   field_tabl_administrative_title:
-    weight: -98
+    weight: 1
     settings:
       size: 60
       placeholder: ''
@@ -29,14 +29,14 @@ content:
     type: string_textfield
     region: content
   field_tabl_alignment:
-    weight: -96
+    weight: 4
     settings: {  }
     third_party_settings:
       conditional_fields: {  }
     type: options_buttons
     region: content
   field_tabl_caption:
-    weight: -94
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -52,19 +52,19 @@ content:
     type: text_textarea
     region: content
   field_tabl_display_size:
-    weight: -97
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_tabl_wrapping:
-    weight: -95
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_url:
-    weight: -99
+    weight: 0
     settings:
       placeholder_url: ''
       placeholder_title: ''


### PR DESCRIPTION
**Description:**
In this case, we are changing the Caption field order in form displays to make things less confusing for authors. 


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18777


**To Test:**
- [ ] Edit a node with Tableau visualization paragraphs. Or, edit/create an information details node and add a Tableau visualization under Content.
- [ ] Check that the Caption field is no longer displayed below Wrapping. It should now be above the Display size field.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
