### PR TITLE
DP-18778 Fix add content page bug

### DIFF
--- a/changelogs/DP-18778.yml
+++ b/changelogs/DP-18778.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed bug on Add Content page where list-items were disappearing when filtering.
+    issue: DP-18778

--- a/docroot/modules/custom/mass_admin_pages/js/mass_admin_pages.search.js
+++ b/docroot/modules/custom/mass_admin_pages/js/mass_admin_pages.search.js
@@ -12,7 +12,7 @@
 
       var $parent = $('.admin-category-list');
       var $categoryListItem = $('.admin-category-list > li');
-      var $contentTypeListItem = $('.admin-list li');
+      var $contentTypeListItem = $('.admin-list > li');
 
       $parent.append('<li class="no-results-msg" >No results found</li>');
       $('.no-results-msg').hide();
@@ -35,7 +35,7 @@
         var numTotal = 0;
         $categoryListItem.each(function () {
           var numShown = 0;
-          var $children = $(this).find('.admin-list li');
+          var $children = $(this).find($contentTypeListItem);
           $children.each(function () {
             if (!$(this).hasClass('hidden')) {
               numShown++;


### PR DESCRIPTION
**Description:**
I adjusted the JS on the Add Content page so when we filter the categories the list-items of each individual category doesn't disappear as well. 


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18778


**To Test:**
- [ ] Filter items on the Add Content page and verify the list-items don't disappear and everything still seems to work well


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
