### PR TITLE
DP-18983 form page feedback module

### DIFF
--- a/changelogs/DP-18983.yml
+++ b/changelogs/DP-18983.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix the visual difference of feedback module radio buttons in form page.
+    issue: DP-18983

--- a/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
@@ -27,11 +27,18 @@ div.ma_feedback-fieldset {
   margin-top: -2px;
 }
 
-
 /* Fix the radio button display issues in form page. */
 .feedback-steps label.fsOptionLabel {
   font-size: 1.375rem;
   line-height: 1rem;
+}
+
+@media (max-width: 40em) {
+  .feedback-steps label.fsOptionLabel {
+    border: none;
+    background: none;
+    color: #141414;
+  }
 }
 
 .feedback-steps .ma__input-radio label.ma__input-radio__label::before {
@@ -60,6 +67,13 @@ div.ma_feedback-fieldset {
   height: 8px;
 }
 
+@media (max-width: 610px) {
+  .feedback-steps .ma__input-radio__label::after {
+    left: 7px;
+    top: 6px;
+  }
+}
+
 .feedback-steps .user-response__contact .ma__input-radio__label::after {
   top: 7px;
 }
@@ -79,7 +93,6 @@ div.ma_feedback-fieldset {
 }
 
 .ma__mass-feedback-form__form--user-response div {
-  /* margin-bottom: .25em; */
   padding: 0;
   font-weight: 500;
 }

--- a/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
@@ -23,6 +23,17 @@ div.ma_feedback-fieldset {
   font-weight: 400;
 }
 
+.ma__input-group__items--inline {
+  margin-top: -2px;
+}
+
+
+/* Fix the radio button display issues in form page. */
+.feedback-steps label.fsOptionLabel {
+  font-size: 1.375rem;
+  line-height: 1rem;
+}
+
 .feedback-steps .ma__input-radio label.ma__input-radio__label::before {
   content: '';
   background: transparent;
@@ -32,6 +43,11 @@ div.ma_feedback-fieldset {
   padding-top: 3px;
   padding-bottom: 3px;
 }
+
+.feedback-steps .ma__input-group__items--inline .ma__input-radio__label {
+    padding-top: 3px;
+    padding-bottom: 7px;
+  }
 
 .feedback-steps .ma__input-radio__label::after {
   content: '';

--- a/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
@@ -52,9 +52,9 @@ div.ma_feedback-fieldset {
 }
 
 .feedback-steps .ma__input-group__items--inline .ma__input-radio__label {
-    padding-top: 3px;
-    padding-bottom: 7px;
-  }
+  padding-top: 3px;
+  padding-bottom: 7px;
+}
 
 .feedback-steps .ma__input-radio__label::after {
   content: '';
@@ -73,7 +73,6 @@ div.ma_feedback-fieldset {
   }
 
   .feedback-steps .ma__input-group__items--inline .ma__input-radio__label {
-    /* padding-top: 3px; */
     padding-bottom: 6px;
   }
 

--- a/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/org-page--feedback.css
@@ -68,6 +68,15 @@ div.ma_feedback-fieldset {
 }
 
 @media (max-width: 610px) {
+  .feedback-steps .ma__input-group__items--inline {
+    padding-top: 1px;
+  }
+
+  .feedback-steps .ma__input-group__items--inline .ma__input-radio__label {
+    /* padding-top: 3px; */
+    padding-bottom: 6px;
+  }
+
   .feedback-steps .ma__input-radio__label::after {
     left: 7px;
     top: 6px;


### PR DESCRIPTION
**Description:**
In form page, formstack css for forms in the main content was also applied to the feedback module, which has its own unique styles. Removed the formstack css from the feedback module by overriding in /themes/custom/mass_theme/overrides/css/org-page--feedback.css.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18983


**To Test:**
- [ ] Run backstop against the prod reference.
- [ ] Check if the QAG form page: /forms/qag-formwithfileuploads gets errors in desktop and mobile display.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
