### PR TITLE
Hide the display of separate link and title formatted links when internal link is invalid - DP-18954

### DIFF
--- a/changelogs/DP-18954.yml
+++ b/changelogs/DP-18954.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes an issue with link fields breaking node views when linked internal content is deleted.
+    issue: DP-18954

--- a/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
+++ b/docroot/modules/custom/mass_formatters/src/Plugin/Field/FieldFormatter/LinkTitleSeparateFormatter.php
@@ -35,10 +35,15 @@ class LinkTitleSeparateFormatter extends LinkSeparateFormatter {
         // be formatted as trimmed.
         $uri = $items->getValue()[$page_key]['uri'];
         $url = Url::fromUri($uri);
+        $node_label = '';
 
         if ($url->isRouted() && $nid = $url->getRouteParameters()['node']) {
-          $node = \Drupal::entityTypeManager()->getStorage('node')->load($nid);
-          $node_label = $node->label();
+          if ($node = \Drupal::entityTypeManager()->getStorage('node')->load($nid)) {
+            $node_label = $node->label();
+          }
+          else {
+            $element[$page_key]['#access'] = FALSE;
+          }
         }
         else {
           $node_label = $element[$page_key]['#url_title'];


### PR DESCRIPTION
Hide the display of separate link and title formatted links when internal link is invalid - DP-18954

**Description:**
This pull request addresses an issue found in binders that occurs when nodes referenced in link fields are deleted. This fix simply addresses the 500 errors on affected nodes, it does not address the detection and fixing of these errors on nodes that contain links to deleted nodes. The good news is that in those cases, users are alerted with an error to fix to the bad links the next time the node is saved.

This formatter is used in three different fields on three different paragraph types: 
- Featured Message (field_featured_message_link)
- Page (field_page_page)
- Page Group (field_page_group_page)

These paragraphs/fields are included on these content types:
- Organization
- Binder


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18954


**To Test:**

***Binder***
- [ ] Create a Binder node
- [ ] Complete required fields for the Binder
- [ ] Under Content > Pages, create both a Page and a Page Group, both referencing other nodes on the site (note that you will be deleting the referenced nodes in a moment)
- [ ] Save the Binder node
- [ ] Go to the nodes you referenced, and delete them
- [ ] Return to the Binder node that you created. This should load without error.
- [ ] Edit the Binder node and attempt to save it. It should alert you that you need to fix the fields containing the deleted nodes.

***Organization***
- [ ] Create an Organization node
- [ ] Complete required fields for the Organization
- [ ] Under Featured, add a "Featured message"
- [ ] Complete the required fields for Featured message
- [ ] Add a "Featured message link," referencing another node on the site in the URL field (note that you will be deleting the referenced nodes in a moment)
- [ ] Save the Organization node
- [ ] Go to the node you referenced and delete it
- [ ] Return to the Organization node that you created. This should load without error.
- [ ] Edit the Organization node and attempt to save it. It should alert you that you need to fix the fields containing the deleted nodes.




**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
