### PR TITLE
DP-18958 Add ma:backstop drush command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,13 @@ parameters:
   ma-cf-deploy:
     type: boolean
     default: false
+  # These params for currently used in drush ma:backstop. target is declared later.
+  ma-backstop:
+    type: boolean
+    default: false
+  reference:
+    type: string
+    default: ""
 
   # These params for currently used in drush ma:release
   ma-release:
@@ -109,7 +116,7 @@ parameters:
   skip-maint:
     type: string
     default: ""
-  # target also used by ma-cf-deploy
+  # target also used by ma-cf-deploy, ma-backstpo
   target:
     type: string
     default: ""
@@ -923,6 +930,16 @@ workflows:
             branches:
               only:
                 - develop
+
+  # Usually triggerred by drush ma:backstop.
+  backstop_ad_hoc:
+    when: << pipeline.parameters.ma-backstop >>
+    jobs:
+      - build
+      - backstop:
+          requires: [build]
+          target: << pipeline.parameters.target >>
+          reference: << pipeline.parameters.reference >>
 
   # Usually triggerred by drush ma:release.
   deploy_ad_hoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ parameters:
   skip-maint:
     type: string
     default: ""
-  # target also used by ma-cf-deploy, ma-backstpo
+  # target also used by ma-cf-deploy, ma-backstop
   target:
     type: string
     default: ""

--- a/changelogs/DP-18958.yml
+++ b/changelogs/DP-18958.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Create method to run adhoc backstop jobs on CircleCI
+    issue: DP-18958

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,6 +61,9 @@ More information about setup or running Nightcrawler can be found in the [Nightc
 #### Open the report from the comparison 
 `open backstop/report/index.html`
 
+#### Run backstop at CircleCI 
+`drush ma:backstop`
+
 More information about setup or running Backstop can be found in the [Backstop documentation](https://github.com/massgov/openmass/blob/develop/backstop/README.md).
 
 ## Good tests


### PR DESCRIPTION
**Description:**
A new drush command for running Backstop at CircleCI.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18958


**To Test:**
- [ ] Run locally `drush ma:backstop prod test --ci-branch=backstop-drush-command -vvv`. Verify that a build is created at Circle and that Backstop uses correct target and reference. Note that Backstop always fails so this experiment will give a red build.




---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
