### PR TITLE
DP-19027 Fix problems with watched-content page

### DIFF
--- a/changelogs/DP-19027.yml
+++ b/changelogs/DP-19027.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed broken bulk-operations select field on watched-content view.
+    issue: DP-19027

--- a/conf/drupal/config/views.view.watched_content.yml
+++ b/conf/drupal/config/views.view.watched_content.yml
@@ -202,7 +202,8 @@ display:
           action_title: 'Unwatch multiple pieces of content (selected via checkboxes below)'
           include_exclude: include
           selected_actions:
-            - flag_action.watch_content.unflag
+            - flag_action.watch_content_flag
+            - flag_action.watch_content_unflag
           entity_type: node
           plugin_id: node_bulk_form
         title:

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.libraries.yml
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.libraries.yml
@@ -39,7 +39,6 @@ admin_overrides:
       css/components/user-form.css: {}
       css/components/views.css: {}
       css/components/views-ui.css: {}
-      css/components/blocks/help-support-block.css: {}
       css/components/blocks/help-blocks.css: {}
       css/components/blocks/release-notes-block.css: {}
       css/components/blocks/alerts-block.css: {}


### PR DESCRIPTION
**Description:**
I fixed the broken bulk operations dropdown on the watched-content view. This was most likely the cause of the 500 error I suspect. Also I saw a 404 from a reference to a CSS file that doesn't exist anymore so I fixed that too. 

Here is the error from NewRelic
https://rpm.newrelic.com/accounts/1522041/applications/46704875/traced_errors/429f8574-ab1c-11ea-a437-0242ac11000c_0_4515


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19027


**To Test:**
- [ ] Visit http://mass.local/admin/ma-dash/watched-content and test it works well


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
