### PR TITLE
DP-18638 BackstopJS fails for alert date

### DIFF
--- a/backstop/pages.json
+++ b/backstop/pages.json
@@ -1,6 +1,6 @@
 [
   {"label": "Homepage", "url": "/"},
-  {"label": "HomepageWithAlert", "url":  "/", "showAlerts":  true},
+  {"label": "HomepageWithAlert", "url":  "/", "showAlerts":  true, "readySelector": "span.ma__emergency-alert__time-stamp", "delay": 2000},
   {"label": "404", "url": "/this-page-does-not-exist"},
   {"label": "Document", "url": "/media/1268726"},
   {"label": "Advisory", "url": "/memorandum/qag-advisory"},

--- a/changelogs/DP-18638.yml
+++ b/changelogs/DP-18638.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adjusted backstopJS alert test to wait for timestamp element before taking a screenshot.
+    issue: DP-18638


### PR DESCRIPTION
**Description:**
I think the problem here is the screenshot being taken by backstopJS is occurring while the alerts JS is still running. I added a `readySelector` and a `delay` to the HomepageWithAlert test. This should make backstopJS wait for the timestamp element to exist and delay a little bit before taking a screenshot. 

Check out these backstopJS docs:
https://github.com/garris/BackstopJS#testing-progressive-apps-spas-and-ajax-content

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18638


**To Test:**
- [ ] Run backstopJS test and verify date errors do not occur


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
