### PR TITLE
Fixed issue where noindex erroneously added to certain pages - DP-19070

### DIFF
--- a/changelogs/DP-19070.yml
+++ b/changelogs/DP-19070.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed issue where noindex was removed on certain pages matching a list of keywords.
+    issue: DP-19070

--- a/docroot/modules/custom/mass_metatag/mass_metatag.module
+++ b/docroot/modules/custom/mass_metatag/mass_metatag.module
@@ -14,6 +14,7 @@ use Drupal\node\NodeInterface;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_token_info().
@@ -363,12 +364,11 @@ function mass_metatag_page_attachments(array &$attachments) {
     'resources',
   ];
 
-  // Convert the array into a regex pattern for matching.
-  $patterns_flattened = implode('|', $paths);
-  $current_uri = \Drupal::request()->getRequestUri();
+  $current_uri = Url::fromRoute('<current>')->toString();
+  $uri_parts = explode('/', $current_uri);
+  $uri_end = end($uri_parts);
 
-  // URI has more than 1 segment and its ending matches one of the paths.
-  if ((preg_match("/\/$patterns_flattened$/", $current_uri) === 1) && substr_count($current_uri, '/') > 1) {
+  if (in_array($uri_end, $paths) && substr_count($current_uri, '/')) {
     $noindex = [
       '#tag' => 'meta',
       '#attributes' => [

--- a/docroot/modules/custom/mass_metatag/mass_metatag.module
+++ b/docroot/modules/custom/mass_metatag/mass_metatag.module
@@ -368,7 +368,7 @@ function mass_metatag_page_attachments(array &$attachments) {
   $uri_parts = explode('/', $current_uri);
   $uri_end = end($uri_parts);
 
-  if (in_array($uri_end, $paths) && substr_count($current_uri, '/')) {
+  if (in_array($uri_end, $paths) && substr_count($current_uri, '/') > 1) {
     $noindex = [
       '#tag' => 'meta',
       '#attributes' => [


### PR DESCRIPTION
**Description:**
Fixed issue where pages with certain keywords in their paths were set to "noindex, follow."


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19070


**To Test:**
- [ ] Load pages with the following in their paths: 'need-to-know', 'tasks', 'related', 'resources'
- [ ] Confirm that those pages do not have a robots metatag with "noindex, follow" that isn't set in the node configuration
- [ ] Visit pages that have a final path segment of one of the following keywords: 'need-to-know', 'tasks', 'related', 'resources'
- [ ]  Confirm that those pages have a robots metatag with "noindex, follow"



**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
