### PR TITLE
DP-15128 static google map directions link context

### DIFF
--- a/changelogs/DP-15128.yml
+++ b/changelogs/DP-15128.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Set a page title as googlMap.link.info property value as static Google map directions link context for assistive technology.
+    issue: DP-15128

--- a/docroot/themes/custom/mass_theme/templates/content/node--contact-information--map.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--contact-information--map.html.twig
@@ -77,7 +77,7 @@
     "link": {
       "href": static_map_link,
       "text": 'Get Directions'|t,
-      "info": 'Get Directions'
+      "info": node.label
     },
     "picture": {
       "defaultImage": static_map_600x450,


### PR DESCRIPTION
**Description:**
This PR has associated Mayflower PR:  https://github.com/massgov/mayflower/pull/1089

Set a page title as `googlMap.link.info` property value as static Google map directions link context for assistive technology.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-15128


**To Test:**
- [ ] Build the site with the Mayflower, https://github.com/massgov/mayflower/pull/1089.
- [ ] Go to any location page.
- [ ] In the Inspect, check the markup for the Google Map component for:
       - no `aria-hidden` and `role` attributes on `div.ma__google-map` (enable screen readers to recognize the component)
       - no `title` attribute in `a`
       - `span.ma__visually-hidden` with its content of "to a location name" after the "Get Directions" in the span
       - the location name matches the page title
<img width="604" alt="_QAG_Location_Park_3___Mass_gov" src="https://user-images.githubusercontent.com/9633303/84694224-d8d1f080-af16-11ea-9e6f-b102fe019e0d.png">




**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
