### PR TITLE
DP-19075 Reduce alerts layout shift

### DIFF
--- a/changelogs/DP-19075.yml
+++ b/changelogs/DP-19075.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Preload the texta-mediumitalic webfont that is used for the site-wide alert date.
+    issue: DP-19075

--- a/docroot/themes/custom/mass_theme/templates/layout/html.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/layout/html.html.twig
@@ -38,6 +38,7 @@
     <link rel="preload" href="{{ file_url('libraries/mayflower-artifacts/assets/fonts/texta-black-webfont.woff2') }}" as="font" crossorigin />
     <link rel="preload" href="{{ file_url('libraries/mayflower-artifacts/assets/fonts/texta-bold-webfont.woff2') }}" as="font"  crossorigin />
     <link rel="preload" href="{{ file_url('libraries/mayflower-artifacts/assets/fonts/texta-book-webfont.woff2') }}" as="font"  crossorigin />
+    <link rel="preload" href="{{ file_url('libraries/mayflower-artifacts/assets/fonts/texta-mediumitalic-webfont.woff2') }}" as="font"  crossorigin />
   </head>
   <body{{ attributes.addClass(body_classes) }}>
     <svg-sprite-placeholder>


### PR DESCRIPTION
**Description:**
I preloaded the texta-mediumitalic webfont that is used for the date on the site-wide alert. Now the font will be available before the site-wide alert appears. 


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19075


**To Test:**
- [ ] Verify you see something like this in the head of any page:
```<link rel="preload" href="/libraries/mayflower-artifacts/assets/fonts/texta-mediumitalic-webfont.woff2" as="font" crossorigin>```


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
