### PR TITLE
Bump composer cache key.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,12 @@ references:
     restore_cache:
       name: Restore Composer Cache
       keys:
-        - site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-{{ checksum "composer.lock" }}
-        - site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-
+        - site-composer-v7-{{ checksum "composer.lock" }}
 
   save_composer_cache: &save_composer_cache
     save_cache:
       name: Save Composer cache
-      key: site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-{{ checksum "composer.lock" }}
+      key: site-composer-v7-{{ checksum "composer.lock" }}
       paths: [ vendor, docroot/core, docroot/modules/contrib, docroot/themes/contrib ]
 
   branch_ignore: &branch_ignore

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,13 @@ references:
     restore_cache:
       name: Restore Composer Cache
       keys:
-        - site-composer-v6-{{ checksum "composer.lock" }}
-        - site-composer-v6-
+        - site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-{{ checksum "composer.lock" }}
+        - site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-
 
   save_composer_cache: &save_composer_cache
     save_cache:
       name: Save Composer cache
-      key: site-composer-v6-{{ checksum "composer.lock" }}
+      key: site-composer-{{ .Environment.MASS_COMPOSER_CACHE_KEY }}-{{ checksum "composer.lock" }}
       paths: [ vendor, docroot/core, docroot/modules/contrib, docroot/themes/contrib ]
 
   branch_ignore: &branch_ignore

--- a/changelogs/DP-19131.yml
+++ b/changelogs/DP-19131.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Bump composer cache key at CircleCI
+    issue: DP-19131


### PR DESCRIPTION
I suspect that the composer cache at Circle is hurting us in this issue. Change cache key 

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19131


**To Test:**
- [ ] Try to ma:release this branch and if it succeeds we are good. If you just want to verify mine, I ran `drush ma:release dev circle-cache-keys` and the log is at https://circleci.com/workflow-run/05f4cf72-6ac8-45b6-a879-c72594a75f24


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
