### PR TITLE
Mayflower/DP-19159 mayflower version 9.52.1

### DIFF
--- a/changelogs/DP-19159.yml
+++ b/changelogs/DP-19159.yml
@@ -1,0 +1,48 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description:  |-
+      Updated Mayflower version to 9.52.1.
+          - DP-17150: Change the label of the secondary set. Change the width of each set. Adjust spacing. (MF)
+          - DP-17404: Match spacing with the current prod(develop) version. (MF)
+          - DP-17404: Align relationship the first terms in primary and secondary sets. (MF)
+          - DP-17404: Position the TOC below the relationship indicator. (MF)
+          - DP-17404: Put back missing mobileNav.js in index.js. (MF)
+          - DP-19085: Modify google-map.twig to print googleMap.link.info value and set it visualy hidden as context info for screen reader users. (MF)
+    issue: DP-19159

--- a/composer.json
+++ b/composer.json
@@ -207,7 +207,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "guzzlehttp/guzzle": "^6.3",
-        "massgov/mayflower-artifacts": "9.52.0",
+        "massgov/mayflower-artifacts": "9.52.1",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",


### PR DESCRIPTION
Changed:
  - description:  |-
      Updated Mayflower version to 9.52.1.
          - DP-17150: Change the label of the secondary set. Change the width of each set. Adjust spacing. (MF)
          - DP-17404: Match spacing with the current prod(develop) version. (MF)
          - DP-17404: Align relationship the first terms in primary and secondary sets. (MF)
          - DP-17404: Position the TOC below the relationship indicator. (MF)
          - DP-17404: Put back missing mobileNav.js in index.js. (MF)
          - DP-19085: Modify google-map.twig to print googleMap.link.info value and set it visualy hidden as context info for screen reader users. (MF)
    issue: DP-19159