### PR TITLE
Add longer timeouts for Alerts in ExistingSite tests

### DIFF
--- a/changelogs/DP-19185.yml
+++ b/changelogs/DP-19185.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Longer timeouts for alerts in ExistingSite tests
+    issue: DP-19185

--- a/docroot/modules/custom/mass_alerts/tests/src/ExistingSiteJavascript/OrganizationAlertsClientSideTest.php
+++ b/docroot/modules/custom/mass_alerts/tests/src/ExistingSiteJavascript/OrganizationAlertsClientSideTest.php
@@ -52,12 +52,12 @@ class OrganizationAlertsClientSideTest extends ExistingSiteWebDriverTestBase {
 
     $this->drupalGet('node/' . $org_node->id());
     $assert_session->pageTextContains($org_node->getTitle());
-    $assert_session->waitForElement('css', '.ma__header-alert__message');
+    $assert_session->waitForElement('css', '.ma__header-alert__message', 30000);
     $assert_session->pageTextContains($alert_message);
 
     $this->drupalGet('node/' . $news_node->id());
     $assert_session->pageTextContains($news_node->getTitle());
-    $assert_session->waitForElement('css', '.ma__header-alert__message');
+    $assert_session->waitForElement('css', '.ma__header-alert__message', 30000);
     $assert_session->pageTextContains($alert_message);
   }
 


### PR DESCRIPTION
**Description:**
If we merge this and get other intermittent fails, then we know that duration is the culprit and will add more extended durations.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19185


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
