### PR TITLE
DP-19001 Add patch to memcache to address saving nodes in separate tabs issue

### DIFF
--- a/changelogs/DP-19001.yml
+++ b/changelogs/DP-19001.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add patch to memcache module to address caching issue when saving nodes in seperate tabs.
+    issue: DP-19001

--- a/composer.json
+++ b/composer.json
@@ -328,7 +328,8 @@
                 "CKeditor Plugin - using a combined patch to avoid conflict (https://www.drupal.org/node/2928318)": "https://www.drupal.org/files/issues/media_entity_download-ckeditor_plugin-2928318-11-d8.patch"
             },
             "drupal/memcache": {
-                "Split large (> 1mb) items (https://www.drupal.org/node/435694)": "https://www.drupal.org/files/issues/2019-02-26/435694-118-d8-memcache-large-items.patch"
+                "Split large (> 1mb) items (https://www.drupal.org/node/435694)": "https://www.drupal.org/files/issues/2019-02-26/435694-118-d8-memcache-large-items.patch",
+                "Support for cache invalidation (https://www.drupal.org/project/memcache/issues/2996615)": "https://www.drupal.org/files/issues/2019-09-24/cache_tag_item_invalidation-2996615-7.patch"
             },
             "drupal/monolog": {
                 "Update minimum monolog version (https://www.drupal.org/node/3057734)": "https://www.drupal.org/files/issues/2019-05-29/monolog--update-monolog-library-minimum-version--3057734--3.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4cd3f5620da9adbcd7d00a4341b83ec0",
+    "content-hash": "ccae106fb87df3dc6cf4c3f3822d6afe",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6384,7 +6384,8 @@
                     }
                 },
                 "patches_applied": {
-                    "Split large (> 1mb) items (https://www.drupal.org/node/435694)": "https://www.drupal.org/files/issues/2019-02-26/435694-118-d8-memcache-large-items.patch"
+                    "Split large (> 1mb) items (https://www.drupal.org/node/435694)": "https://www.drupal.org/files/issues/2019-02-26/435694-118-d8-memcache-large-items.patch",
+                    "Support for cache invalidation (https://www.drupal.org/project/memcache/issues/2996615)": "https://www.drupal.org/files/issues/2019-09-24/cache_tag_item_invalidation-2996615-7.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -18005,5 +18006,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.18"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
**Description:**
Added this patch:
https://www.drupal.org/project/memcache/issues/2996615

There was a memcache caching problem where when multiple nodes were saved in different tabs in a short amount of time, one of them would stay on an older revision. The DB had the correct new revision for this node in it but the UI was showing outdated memcached results. 

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19001


**To Test:**
- [ ] Please see the ticket for testing instructions. 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
