### PR TITLE
Disable cron and lateruntime purge processors

### DIFF
--- a/changelogs/DP-15470.yml
+++ b/changelogs/DP-15470.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Disable cron and lateruntime purge processors
+    issue: DP-15470

--- a/conf/drupal/config/purge.plugins.yml
+++ b/conf/drupal/config/purge.plugins.yml
@@ -21,3 +21,19 @@ queuers:
     plugin_id: purge_ui_block_queuer
     status: true
 queue: database_unique
+processors:
+  -
+    plugin_id: drush_purge_queue_work
+    status: true
+  -
+    plugin_id: drush_purge_invalidate
+    status: true
+  -
+    plugin_id: cron
+    status: false
+  -
+    plugin_id: lateruntime
+    status: false
+  -
+    plugin_id: purge_ui_block_processor
+    status: true


### PR DESCRIPTION
**Description:**
- I've also added a [drush purge cron job in Prod](https://cloud.acquia.com/a/develop/applications/ff8ed1de-b8bc-48a4-b316-cd91bfa192c4/environments/26644-ff8ed1de-b8bc-48a4-b316-cd91bfa192c4/cron). There isn't ever anything for it to do until this PR hits Prod, but thats OK.
- [The above cron job already being monitored at Healthchecks.io](https://healthchecks.io/checks/38f39d6d-9aec-4d88-8f34-a0b172ff8ec4/details/)


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-15470


**To Test:**
- [ ] Browse to admin/config/development/performance/purge and see that the cron and lateruntime processors are not listed. You can see how it looks before this PR by logging to Prod or any other env.
- [ ] Verify that the healthchecks.io link above is green.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
