### PR TITLE
Fix Unpublish Reminder test

### DIFF
--- a/changelogs/DP-19338.yml
+++ b/changelogs/DP-19338.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Unpublish Reminder test was failing
+    issue: DP-19338

--- a/composer.json
+++ b/composer.json
@@ -240,6 +240,7 @@
         "drupal/coder": "^8.2.12",
         "drupal/console": "^1.0.1",
         "drupal/drupal-extension": "^4.0.0beta1",
+        "drupaltest/queue-runner-trait": "^1",
         "imbo/behat-api-extension": "^2.0",
         "squizlabs/php_codesniffer": "2.*",
         "weitzman/drupal-test-traits": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4ab4f738375797d7ea6ccb6219ca047",
+    "content-hash": "afd825c5788fe763b45c9e185baf4827",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1781,6 +1781,20 @@
                 "redis",
                 "xcache"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-27T16:24:54+00:00"
         },
         {
@@ -1845,6 +1859,20 @@
                 "collections",
                 "iterators",
                 "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcollections",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-05-25T19:24:35+00:00"
         },
@@ -1928,6 +1956,20 @@
                 "common",
                 "doctrine",
                 "php"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-05T16:46:05+00:00"
         },
@@ -5900,12 +5942,9 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-4.x": "4.x-dev"
-                },
                 "drupal": {
                     "version": "8.x-4.1",
-                    "datestamp": "1467993646",
+                    "datestamp": "1574194688",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -5926,6 +5965,10 @@
                     "homepage": "https://www.drupal.org/user/84263"
                 },
                 {
+                    "name": "Manuel Garcia",
+                    "homepage": "https://www.drupal.org/user/213194"
+                },
+                {
                     "name": "Nafes",
                     "homepage": "https://www.drupal.org/user/2489926"
                 },
@@ -5941,7 +5984,7 @@
             "description": "Mail System",
             "homepage": "https://www.drupal.org/project/mailsystem",
             "support": {
-                "source": "http://cgit.drupalcode.org/mailsystem"
+                "source": "https://git.drupalcode.org/project/mailsystem"
             }
         },
         {
@@ -10416,6 +10459,12 @@
                 "laminas",
                 "zf"
             ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
             "time": "2020-05-20T16:45:56+00:00"
         },
         {
@@ -14245,6 +14294,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-06-06T08:46:27+00:00"
         },
         {
@@ -14307,6 +14370,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-06T08:46:27+00:00"
         },
@@ -15238,6 +15315,12 @@
                 }
             ],
             "description": "A PHP SDK for Acquia CloudAPI v2",
+            "funding": [
+                {
+                    "url": "https://github.com/typhonius",
+                    "type": "github"
+                }
+            ],
             "time": "2020-06-01T19:47:03+00:00"
         },
         {
@@ -16864,6 +16947,58 @@
             "time": "2018-04-17T17:48:19+00:00"
         },
         {
+            "name": "drupaltest/queue-runner-trait",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drupaltest/queue-runner-trait.git",
+                "reference": "15cdc7237b5f838574d259d7bf0059296527f638"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drupaltest/queue-runner-trait/zipball/15cdc7237b5f838574d259d7bf0059296527f638",
+                "reference": "15cdc7237b5f838574d259d7bf0059296527f638",
+                "shasum": ""
+            },
+            "require": {
+                "weitzman/drupal-test-traits": "^1.2"
+            },
+            "require-dev": {
+                "composer/installers": "^1.7",
+                "drupal-composer/drupal-scaffold": "^2.6",
+                "drupal/core": "^8.7",
+                "drush/drush": "^9.7",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "squizlabs/php_codesniffer": "^3.4",
+                "zaporylie/composer-drupal-optimizations": "^1.1"
+            },
+            "type": "drupal-dtt",
+            "extra": {
+                "installer-paths": {
+                    "web/core": [
+                        "type:drupal-core"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DrupalTest\\QueueRunnerTrait\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Hedstrom",
+                    "email": "jhedstrom@gmail.com"
+                }
+            ],
+            "description": "A Drupal queue runner trait for use with Drupal Test Traits.",
+            "time": "2019-08-22T22:26:23+00:00"
+        },
+        {
             "name": "fabpot/goutte",
             "version": "v3.2.1",
             "source": {
@@ -18081,5 +18216,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1.18"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/docroot/modules/custom/mass_flagging/src/Plugin/QueueWorker/EmailQueue.php
+++ b/docroot/modules/custom/mass_flagging/src/Plugin/QueueWorker/EmailQueue.php
@@ -9,8 +9,7 @@ use Drupal\Core\Queue\QueueWorkerBase;
  *
  * @QueueWorker(
  *   id = "mass_flagging_email_queue",
- *   title = @Translation("Watching task worker: email queue"),
- *   cron = {"time" = 60}
+ *   title = @Translation("Watching task worker: email queue")
  * )
  */
 class EmailQueue extends QueueWorkerBase {

--- a/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
@@ -11,8 +11,7 @@ use Drupal\Core\Url;
  *
  * @QueueWorker(
  *   id = "mass_unpublish_reminders_queue",
- *   title = @Translation("Node Unpublish Reminders: email queue"),
- *   cron = {"time" = 60}
+ *   title = @Translation("Node Unpublish Reminders: email queue")
  * )
  */
 class UnpublishReminderQueue extends QueueWorkerBase {
@@ -21,7 +20,9 @@ class UnpublishReminderQueue extends QueueWorkerBase {
    * {@inheritdoc}
    */
   public function processItem($nid) {
-    $node = Node::load($nid);
+    if (!$node = Node::load($nid)) {
+      throw new \Exception("Unable to load node $nid");
+    }
     $author = $node->getOwner();
     if (!empty($author)) {
       $author_mail = $author->getEmail();

--- a/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
@@ -70,7 +70,8 @@ class UnpublishReminderQueue extends QueueWorkerBase {
 
       $mailManager = \Drupal::service('plugin.manager.mail');
       $result = $mailManager->mail('mass_unpublish_reminders', 'unpublish_reminder', $author_mail, 'en', $params, TRUE);
-      if ($result['result'] == TRUE) {
+      if ($result['result']) {
+        // Log the email so we don't resend.
         $database = \Drupal::database();
         $query = $database->insert('mass_unpublish_reminders');
         $query->fields([

--- a/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
@@ -2,14 +2,12 @@
 
 namespace Drupal\Tests\mass_unpublish_reminders\ExistingSite;
 
-use Drupal\mailsystem\MailsystemManager;
 use Drupal\taxonomy\Entity\Vocabulary;
 use weitzman\DrupalTestTraits\ExistingSiteBase;
 use weitzman\DrupalTestTraits\Mail\MailCollectionAssertTrait;
 use weitzman\DrupalTestTraits\Mail\MailCollectionTrait;
 use weitzman\DrupalTestTraits\Entity\UserCreationTrait;
 use weitzman\DrupalTestTraits\Entity\TaxonomyCreationTrait;
-use Drupal\Tests\Traits\Core\CronRunTrait;
 
 /**
  * Tests reminder emails functionality.
@@ -23,8 +21,6 @@ class UnpublishRemindersTest extends ExistingSiteBase {
   use UserCreationTrait;
 
   use TaxonomyCreationTrait;
-
-  use CronRunTrait;
 
   const MASS_UNPUBLISH_MODULENAME = 'mass_unpublish_reminders';
   const MASS_UNPUBLISH_MAILKEY = 'unpublish_reminder';
@@ -44,17 +40,14 @@ class UnpublishRemindersTest extends ExistingSiteBase {
     parent::setUp();
     $this->startMailCollection();
 
+    // mass.gov use a settings.vm.php config override. Override it so mail collection works.
+    // No better way than GLOBALS. See \Drupal\Core\Config\ConfigFactory::doGet.
+    $GLOBALS['config']['mailsystem.settings']['defaults']['sender'] = 'test_mail_collector';
+    $this->container->get('config.factory')->clearStaticCache();
+
     $last_run = \Drupal::state()->get('mass_unpublish_reminders.last_cron', 0);
     $this->lastRun = $last_run;
-
     \Drupal::state()->set('mass_unpublish_reminder.last_cron', 0);
-    $module_key = static::MASS_UNPUBLISH_MODULENAME . '.' . (static::MASS_UNPUBLISH_MAILKEY ?: 'none');
-    $prefix = MailsystemManager::MAILSYSTEM_MODULES_CONFIG . '.' . $module_key;
-
-    $config = $this->container->get('config.factory')->getEditable('mailsystem.settings');
-    $config->set($prefix . '.' . MailsystemManager::MAILSYSTEM_TYPE_FORMATTING, 'test_mail_collector');
-    $config->set($prefix . '.' . MailsystemManager::MAILSYSTEM_TYPE_SENDING, 'test_mail_collector');
-    $config->save();
 
     $this->organization = $this->createTerm(Vocabulary::load('user_organization'), [
       'name' => 'TestOrganization',
@@ -63,7 +56,7 @@ class UnpublishRemindersTest extends ExistingSiteBase {
       'field_user_org' => $this->organization->tid->value,
       'mail' => 'testauthor@mass.local',
     ];
-    $this->author = $this->createUser([], 'TestNodeAuthor', FALSE, $author_values);
+    $this->author = $this->createUser([], NULL, FALSE, $author_values);
 
     for ($x = 0; $x <= 2; $x++) {
       $users[] = $this->createUser([], NULL, FALSE, [
@@ -101,8 +94,10 @@ class UnpublishRemindersTest extends ExistingSiteBase {
       'unpublish_on' => strtotime('+3 days', \Drupal::time()->getRequestTime()),
       'moderation_state' => 'published',
     ]);
-
-    $this->cronRun();
+    // Send the emails.
+    /** @var \Drupal\Core\CronInterface $cron */
+    $cron = \Drupal::service('cron');
+    $cron->run();
 
     $this->assertMailCollection()
       ->seekToModule(static::MASS_UNPUBLISH_MODULENAME)
@@ -129,7 +124,10 @@ class UnpublishRemindersTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
 
-    $this->cronRun();
+    // Send the emails.
+    /** @var \Drupal\Core\CronInterface $cron */
+    $cron = \Drupal::service('cron');
+    $cron->run();
 
     $this->assertMailCollection()
       ->seekToModule(static::MASS_UNPUBLISH_MODULENAME)

--- a/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
@@ -96,7 +96,7 @@ class UnpublishRemindersTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
     // Look at upcoming transitions and enqueue the emails.
-    mass_unpublish_reminders_cron()
+    mass_unpublish_reminders_cron();
     // Send the emails.
     $this->runQueue('mass_unpublish_reminders_queue');
 

--- a/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/tests/ExistingSite/UnpublishRemindersTest.php
@@ -96,9 +96,7 @@ class UnpublishRemindersTest extends ExistingSiteBase {
       'moderation_state' => 'published',
     ]);
     // Look at upcoming transitions and enqueue the emails.
-    /** @var \Drupal\Core\CronInterface $cron */
-    $cron = \Drupal::service('cron');
-    $cron->run();
+    mass_unpublish_reminders_cron()
     // Send the emails.
     $this->runQueue('mass_unpublish_reminders_queue');
 
@@ -128,9 +126,7 @@ class UnpublishRemindersTest extends ExistingSiteBase {
     ]);
 
     // Look at upcoming transitions and enqueue the emails.
-    /** @var \Drupal\Core\CronInterface $cron */
-    $cron = \Drupal::service('cron');
-    $cron->run();
+    mass_unpublish_reminders_cron();
     // Send the emails.
     $this->runQueue('mass_unpublish_reminders_queue');
 

--- a/docroot/modules/custom/mass_utility/src/Plugin/QueueWorker/RevisionCleanupQueue.php
+++ b/docroot/modules/custom/mass_utility/src/Plugin/QueueWorker/RevisionCleanupQueue.php
@@ -12,7 +12,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @QueueWorker(
  *   id = "mass_utility_revisions_cleanup",
- *   title = @Translation("Cleanup revisions queued for deletion.")
+ *   title = @Translation("Cleanup revisions queued for deletion."),
+ *   cron = {"time" = 180}
  * )
  */
 class RevisionCleanupQueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {

--- a/docroot/modules/custom/mass_utility/src/Plugin/QueueWorker/RevisionCleanupQueue.php
+++ b/docroot/modules/custom/mass_utility/src/Plugin/QueueWorker/RevisionCleanupQueue.php
@@ -12,8 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @QueueWorker(
  *   id = "mass_utility_revisions_cleanup",
- *   title = @Translation("Cleanup revisions queued for deletion."),
- *   cron = {"time" = 180}
+ *   title = @Translation("Cleanup revisions queued for deletion.")
  * )
  */
 class RevisionCleanupQueue extends QueueWorkerBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
**Description:**
- Use settings override to use test_mail_collector mailsystem sender during test
- Run cron hook in same process during the test. Faster, and easier to debug.
- Use dedicated cron job instead of general cron. Stop using cron for for processing the `mass_flagging_email_queue` queue since we already have a cron job for that.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19338


**To Test:**
- [ ] If its green its good.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
