### PR TITLE
Add PHP Yaml parse validation for changelog.yml files in PRs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,8 @@ jobs:
       - run: composer validate
       # Check coding standards with php code sniffer. See phpcs.xml
       - run: phpcs -v -n
+      # Make sure changelogs are parseable by PHP (since build-changelog.php requires that).
+      - run: php scripts/directory-yaml-parse.php
       # Lint javascript
       - run: yarn run eslint --debug --ignore-path '.eslintignore' 'docroot/modules/custom/**/*.js' 'docroot/themes/custom/**/*.js' 'docroot/profiles/custom/**/*.js' 2>&1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ executors:
         type: string
         default: comass/mysql-sanitized:latest
     working_directory: /var/www/code
+    # https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    resource_class: xlarge
     docker:
       - image: massgov/drupal-container:1.0.15-ci
         environment:

--- a/changelogs/DP-18527.yml
+++ b/changelogs/DP-18527.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Add PHP Yaml parse validation for changelog.yml files in PRs.
+    issue: DP-18527

--- a/changelogs/DP-18527.yml
+++ b/changelogs/DP-18527.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Added:
   - description: Add PHP Yaml parse validation for changelog.yml files in PRs.
     issue: DP-18527

--- a/scripts/build-changelog.php
+++ b/scripts/build-changelog.php
@@ -25,8 +25,9 @@ echo "";
 $holidayDates = array('01-01', '07-04', '11-14', '12-25');
 
 // Iterate over Changelog files
+$path = Path::join(dirname(__DIR__), 'changelogs');
 $finder = Finder::create()
-  ->in(__DIR__ . '/../changelogs')
+  ->in($path)
   ->name('*.yml')
   ->notName('template.yml');
 
@@ -65,8 +66,6 @@ echo "";
 
 // Update the changelog.md with the changelog files.
 $changes = [];
-$path = Path::join(dirname(__DIR__), 'changelogs');
-
 
 foreach($finder as $file) {
   $data = Yaml::parseFile($file->getPathname());

--- a/scripts/directory-yaml-parse.php
+++ b/scripts/directory-yaml-parse.php
@@ -1,0 +1,20 @@
+<?php
+
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Yaml\Yaml;
+use Webmozart\PathUtil\Path;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$path = Path::join(dirname(__DIR__), 'changelogs');
+// Iterate over Changelog files
+$finder = Finder::create()
+  ->in($path)
+  ->name('*.yml')
+  ->notName('template.yml');
+
+foreach($finder as $file) {
+  // An Exception is thrown if a file is not parseable.
+  echo "Parsing " . $file->getPathname() . "\n";
+  Yaml::parseFile($file->getPathname());
+}


### PR DESCRIPTION
See title. Also, this seems like a harmless PR to bundle in another small change ...

This PR ups our resource_class at CircleCI. Our tests are taking a very long time, and its hurting our team velocity. The default resource_class is no longer cutting it. This PR ups our class to xlarge. We have plenty of monthly credits for this change. We are halfway through the month and have used 1/10 of our credits. That makes sense since our team is much smaller now. Furthermore, our tests are running [3x faster with this PR](https://app.circleci.com/pipelines/github/massgov/openmass/3789/workflows/459e9642-c4eb-4acd-a748-54538f0c20c1/jobs/15912) so I'm not sure this will use more credits since we consume fewer minutes:

<img width="1132" alt="image" src="https://user-images.githubusercontent.com/7740/87585665-6a1abb00-c6ad-11ea-95e5-3e035b63630d.png">


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18527


**To Test:**
- [ ] Make a PR with an invalid changelog file and see that it fails.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
