### PR TITLE
Speed up local development when using latest docker for mac.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,8 @@ MASS_CDN_TOKEN=
 
 # Set a docker caching specification for the code mount.
 #
-# File access in hosted volumes can be very slow on Mac due to issues with the
-# filesystem.  Using cached or delegated here can really speed things up, but
-# this isn't a cross-platform feature.
 # See https://docs.docker.com/compose/compose-file/#caching-options-for-volume-mounts-docker-for-mac
-# VOLUME_FLAGS=cached
+# VOLUME_FLAGS=delegated
 
 # Specify the path and filename of your Acquia SSH key (defaults to id_rsa).
 # PRIVATE_KEY=-~/.ssh/id_rsa

--- a/changelogs/Dp-15708.yml
+++ b/changelogs/Dp-15708.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Speed up local development environment for latest Docker for Mac
+    issue: DP-15708

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,8 @@ services:
     image: "massgov/drupal-container:1.0.15-dev"
     hostname: mass.local
     volumes:
-      # Non OSX users may want to set VOLUME_FLAGS via the .env file.
-      - .:/var/www/mass.local:${VOLUME_FLAGS-cached}
+      - .:/var/www/mass.local:${VOLUME_FLAGS-delegated}
       # Configures SSH
-      - .docker/config:/root/.ssh/config:${VOLUME_FLAGS-cached}
       - .docker/.bashrc:/root/.bashrc
     # Get Acquia SSH keys into container.
     secrets:


### PR DESCRIPTION
**Description:**
To get the benefit today, switch your Docker for Mac(DFM)  to use [Edge releases](https://docs.docker.com/docker-for-mac/edge-release-notes/). See DFM preferences.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/15708


**To Test:**
- [ ] Switch to Edge and try out the web site locally. Perharps a drush command as well.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
