### PR TITLE
More robust Unpublish Reminder queue worker

### DIFF
--- a/changelogs/DP-19494.yml
+++ b/changelogs/DP-19494.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Harden unpublish reminder queue worker
+    issue: DP-19494

--- a/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
@@ -71,7 +71,6 @@ class UnpublishReminderQueue extends QueueWorkerBase {
         ]
       );
 
-
       // Log the email so we don't resend. We log first, because we really don't want
       // to re-send these emails. Its better if they never get sent.
       try {
@@ -81,7 +80,8 @@ class UnpublishReminderQueue extends QueueWorkerBase {
           'nid' => $nid,
           'reminder_sent' => \Drupal::time()->getRequestTime(),
         ])->execute();
-      } catch (\Exception $e) {
+      }
+      catch (\Exception $e) {
         // It shouldn't happen, but we are seeing an already existing nid being
         // reprocessed. Rather than rewrite_mass_unpublish_reminders_cron_helper(),
         // lets mark this item as processed, and keep processing the queue. See


### PR DESCRIPTION
**Description:**
Keep processing items if the insert into reminder table fails.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19494


**To Test:**
- [ ] See original feature test plan

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
