### PR TITLE
DP-19570: Check when cached and DB vids do not match

### DIFF
--- a/changelogs/DP-19570.yml
+++ b/changelogs/DP-19570.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Logging to detect node publishing issues.
+    issue: DP-19570

--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -655,7 +655,7 @@ function mass_content_node_update(EntityInterface $node) {
     Drupal::logger('content')->info('Node @nid updated to revision @vid_db in the database, but revision @vid_cache was retrieved from cache.', [
       '@nid' => $nid,
       '@vid_db' => $vid_db,
-      '@vid_cache' => $vid_cache
+      '@vid_cache' => $vid_cache,
     ]);
   }
 }

--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -629,3 +629,28 @@ function mass_content_field_widget_paragraphs_form_alter(&$element, &$form_state
     $element['subform']['field_url']['widget'][0]['title']['#description'] = t('Provide a label that describes the link destination in a specific way, such as "See more employee profiles". Avoid generic labels such as "See more".');
   }
 }
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function mass_content_node_update(EntityInterface $node) {
+  // Compare the entity cache-stored vid to the vid stored in the database.
+  // @see https://jira.mass.gov/browse/DP-19570
+  $nid = $node->id();
+
+  // Retrieve the vid value via Node::load to get the currently cached value.
+  $vid_cache = \Drupal\node\Entity\Node::load($nid)->getRevisionId();
+
+  // Query for vid.
+  $database = \Drupal::database();
+  $query = $database->select('node', 'n');
+  $vid_db = $query
+    ->fields('n', ['vid'])
+    ->condition('n.nid', $nid)
+    ->execute()
+    ->fetchField();
+
+  if ($vid_db !== $vid_cache) {
+    Drupal::logger('content')->info('Node @nid updated to revision @vid_db in the database, but revision @vid_cache was retrieved from cache.', ['@nid' => $nid, '@vid_db' => $vid_db, '@vid_cache' => $vid_cache]);
+  }
+}

--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_entity_bundle_field_info().
@@ -639,7 +640,7 @@ function mass_content_node_update(EntityInterface $node) {
   $nid = $node->id();
 
   // Retrieve the vid value via Node::load to get the currently cached value.
-  $vid_cache = \Drupal\node\Entity\Node::load($nid)->getRevisionId();
+  $vid_cache = Node::load($nid)->getRevisionId();
 
   // Query for vid.
   $database = \Drupal::database();
@@ -651,6 +652,10 @@ function mass_content_node_update(EntityInterface $node) {
     ->fetchField();
 
   if ($vid_db !== $vid_cache) {
-    Drupal::logger('content')->info('Node @nid updated to revision @vid_db in the database, but revision @vid_cache was retrieved from cache.', ['@nid' => $nid, '@vid_db' => $vid_db, '@vid_cache' => $vid_cache]);
+    Drupal::logger('content')->info('Node @nid updated to revision @vid_db in the database, but revision @vid_cache was retrieved from cache.', [
+      '@nid' => $nid,
+      '@vid_db' => $vid_db,
+      '@vid_cache' => $vid_cache
+    ]);
   }
 }


### PR DESCRIPTION


**Description:**
This is a check to determine if the vid loaded via cache after a node save matches the expected vid from the node update. This information will be logged and used to determine how widespread reports are of nodes not saving and setting the correct, latest revision. This is a difficult issue to replicate, but when replicated, a log entry will be created.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19570


**To Test:**
- [ ] Check the issue for more information on how this has been replicated. More replication steps may appear in the issue in the future.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
