### PR TITLE
Render featured message text with its format

### DIFF
--- a/changelogs/DP-19523.yml
+++ b/changelogs/DP-19523.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Render featured message text with its format
+    issue: DP-19523

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--featured-message.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--featured-message.html.twig
@@ -53,7 +53,7 @@
         "path": "@atoms/11-text/paragraph.twig",
         "data": {
           "paragraph" : {
-            "text": content.field_featured_message_content[0]['#text']
+            "text": content.field_featured_message_content
           }
         }
       }]


### PR DESCRIPTION
Note that this issue is about getting the pencil image to show. The size of that image is a separate thing, should it be deemed a bug.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19523


**To Test:**
- [ ] Load orgs/massgis-bureau-of-geographic-information and see the pencil image




---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
