### PR TITLE
Fixed primary image metatag - DP-19463

### DIFF
--- a/docroot/modules/custom/mass_schema_metatag/mass_schema_collection_page/src/Plugin/metatag/Tag/SchemaCollectionPagePrimaryImageOfPage.php
+++ b/docroot/modules/custom/mass_schema_metatag/mass_schema_collection_page/src/Plugin/metatag/Tag/SchemaCollectionPagePrimaryImageOfPage.php
@@ -35,6 +35,13 @@ class SchemaCollectionPagePrimaryImageOfPage extends SchemaImageBase {
    * {@inheritdoc}
    */
   public function output() {
+    $value = SchemaMetatagManager::recomputeSerializedLength($this->value());
+    $value = unserialize($value);
+    $value = array_merge($value, [
+      '@type' => 'ImageObject',
+    ]);
+    $this->setValue(SchemaMetatagManager::serialize($value));
+
     $element = parent::output();
 
     if (!empty($element)) {

--- a/docroot/modules/custom/mass_schema_metatag/mass_schema_place/src/Plugin/metatag/Tag/SchemaPlacePhoto.php
+++ b/docroot/modules/custom/mass_schema_metatag/mass_schema_place/src/Plugin/metatag/Tag/SchemaPlacePhoto.php
@@ -39,19 +39,33 @@ class SchemaPlacePhoto extends SchemaImageBase {
    * {@inheritdoc}
    */
   public function output() {
-    if (!$element = parent::output()) {
-      return $element;
-    }
+    $value = SchemaMetatagManager::recomputeSerializedLength($this->value());
+    $value = unserialize($value);
+    $value = array_merge($value, [
+      '@type' => 'Photograph',
+    ]);
+    $this->setValue(SchemaMetatagManager::serialize($value));
 
-    $images = SchemaMetatagManager::unserialize($this->value());
-    foreach ($images as $image) {
-      // If it is null, continue;.
-      if (empty($image)) {
-        continue;
+    $element = parent::output();
+
+    if (!empty($element)) {
+      $element['#attributes']['content'] = [];
+      $images = SchemaMetatagManager::unserialize($this->value());
+
+      if (empty($images['url'])) {
+        return '';
       }
 
-      $url = json_decode($image, TRUE);
-      $element['#attributes']['content'][] = $url;
+      $images = explode(', ', $images['url']);
+
+      foreach ($images as $url) {
+        // If it is null, continue;.
+        if (empty($url)) {
+          continue;
+        }
+
+        $element['#attributes']['content'][] = json_decode($url, TRUE);
+      }
     }
 
     return $element;


### PR DESCRIPTION
**Description:**
Fixes issues with tests resulting from two key changes in the Metatag module: a check for an @type key in the value array and converting empty values from strings to empty arrays.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19463


**To Test:**
- [ ] PHPUnit tests pass


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
