### PR TITLE
Improves Feedback form submission data quality in feedback manager and stops errant submissions

### DIFF
--- a/changelogs/DP-19192.yml
+++ b/changelogs/DP-19192.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Stops bots submitting feedback forms. Stops double form submission. Uses formstack ID as uniqueID for survey.
+    issue: DP-19192

--- a/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
+++ b/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
@@ -23,6 +23,10 @@
       var PHONE = 'field70611804';
       var SURVEY_EMAIL = 'field68557501';
       var PLEASE_TELL_US = 'field47054414';
+
+      // This field is used by the feedback manager to join the survey (second) with the first submission
+      var MG_FEEDBACK_ID = 'field68557708';
+
       // For certain form inputs, use a value from the data layer.
       $('.data-layer-substitute', context).each(function (index) {
         var $this = $(this);
@@ -45,7 +49,6 @@
       $('.feedback-steps', context).each(function (index) {
         var $self = $(this);
         var feedback = $self.find('#feedback')[0];
-        var id = Date.now() + Math.floor(Math.random() * 1000);
         var $steps = $self.find('.feedback-step');
         // Loop for each step.
         $steps.each(function (index) {
@@ -63,10 +66,11 @@
           }
           // Setup steps that submit to formstack via ajax (using jquery form).
           else {
-            $step.find('.unique-id-substitute').each(function (index) {
-              var $this = $(this);
-              $this.val(id);
-              $this.removeClass('unique-id-substitute');
+            // This is to stop a double click submitting the form twice
+            var $submitBtn = $('input[type="submit"]', $form);
+            $submitBtn.click(function () {
+              $(this).prop('disabled', true);
+              $form.submit();
             });
 
             $form.ajaxForm({
@@ -76,6 +80,13 @@
             });
             window['form' + $form.attr('id')] = {
               onPostSubmit: function (message) {
+                // If MG_FEEDBACK_ID is 'uniqueId', then we are submitting the first (feedback) form
+                // so we now need to set the MG_FEEDBACK_ID value with the ID returned from formstack.
+                var submissionId = message.submission;
+                if ($('#' + MG_FEEDBACK_ID).val() === 'uniqueId') {
+                  $('#' + MG_FEEDBACK_ID).val(submissionId);
+                }
+
                 $step.addClass('hidden');
                 $self.find('#' + nextId).removeClass('hidden');
                 feedback.scrollIntoView();
@@ -130,6 +141,7 @@
       function validateForm(data, $form) {
         var validates = true;
         var message = '<p class="error">Please go back and fill in any required fields (marked with an *)</p>';
+
         // Switch validation based on presence of "Did you find ...".
         var $didYouFind = $form.find('[name="' + DID_YOU_FIND + '"]');
         if ($didYouFind.length > 0) {
@@ -168,8 +180,27 @@
           }
         }
 
+        // Checks to avoid bots submitting the form
+        //
+        // On the first form, the Feedback manager lambda will populate this field,
+        // so a populated field was a bot, we honey potted him/her/they
+        if ($form.find('#field68798989').length && $('#field68798989').val()) {
+          // We don't need to show the bot anything
+          return false;
+        }
+
+        // On the second form, the value will be assigned the formstack ID on submission
+        // so a default value of 'uniqueId' is not acceptable since we always want the survey
+        // to be tied to the first form
+        if ($form.find('#' + MG_FEEDBACK_ID).length && $('#' + MG_FEEDBACK_ID).val() === 'uniqueId') {
+          // We don't need to show the bot anything
+          return false;
+        }
+
         if (!validates) {
           getMessaging($form).html(message);
+          var $submitBtn = $('input[type="submit"]', $form);
+          $submitBtn.prop('disabled', false);
         }
 
         return validates;

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -613,6 +613,12 @@
             "class": "fsField unique-id-substitute"
           },
           {
+            "id": "fieldXXXX---TO-BE-REPLACED-WHEN-WE-ADD-FORMSTACK-FIELD",
+            "name": "fieldXXXX",
+            "value": "9999",
+            "class": "fsField"
+          },
+          {
             "id": "form3184363",
             "name": "form",
             "value": "3184363"

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -296,6 +296,12 @@
             "class": "fsField unique-id-substitute"
           },
           {
+            "id": "field97986104",
+            "name": "field97986104",
+            "value": "9999",
+            "class": "fsField"
+          },
+          {
             "id": "form2521317",
             "name": "form",
             "value": "2521317"
@@ -611,12 +617,6 @@
             "name": "field68557708",
             "value": "uniqueId",
             "class": "fsField unique-id-substitute"
-          },
-          {
-            "id": "field97985245",
-            "name": "field97985245",
-            "value": "9999",
-            "class": "fsField"
           },
           {
             "id": "form3184363",

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -292,7 +292,7 @@
           {
             "id": "field68798989",
             "name": "field68798989",
-            "value": "uniqueId",
+            "value": "",
             "class": "fsField unique-id-substitute"
           },
           {

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -613,8 +613,8 @@
             "class": "fsField unique-id-substitute"
           },
           {
-            "id": "fieldXXXX---TO-BE-REPLACED-WHEN-WE-ADD-FORMSTACK-FIELD",
-            "name": "fieldXXXX",
+            "id": "field97985245",
+            "name": "field97985245",
             "value": "9999",
             "class": "fsField"
           },


### PR DESCRIPTION
**Description:**
The mg_feedback_id field is used to join the survey to the first feedback form. The "unique" id is currently using a timestamp and an added number to it. I think the original intention was to append a random number to it. But previously it left open the chance to join two wrong entires. Now it will use the formstack unique ID returned from the first form to populate it in the second form.

The feedback manager ETL will take care of the mg_feedback_id field on the first form when it executes the formstack webhook.

Currently you can double click the feedback form submission buttons and submit multiple submissions to formstack. In the case of the survey I was able to submit 5 submissions by clicking quickly.

Added some validation checks that should stop a robot submitting forms.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19192


**To Test:**
- [ ] You should be able to submit feedback for both forms
- [ ] If you manually reveal the second form and submit it, it should not submit, emulating a bot.
- [ ] If you  manually provide a value for the field `#field68798989` through the console and try to submit the first form, it should not submit, emulating a bot that attempts to fill out all fields and then submit.
- [ ] On both feedback forms, you should only see one form submission even when you rapidly click the submit
- [ ] The submissions in formstack for the survey should have an mg_feedback_id field of the `uniqueId` from the first feedback form.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
