### PR TITLE
Fix dashboard iFrame URLs.

### DIFF
--- a/changelogs/DP-19935.yml
+++ b/changelogs/DP-19935.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
+    issue: DP-****

--- a/changelogs/DP-19935.yml
+++ b/changelogs/DP-19935.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
-  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
-    issue: DP-****
+Changed:
+  - description: Fixes the iFrame URLs for our web analytics Superset dashboards.
+    issue: DP-19935

--- a/conf/drupal/config/route_iframes.route_iframe_config_entity.basic_dashboard.yml
+++ b/conf/drupal/config/route_iframes.route_iframe_config_entity.basic_dashboard.yml
@@ -8,5 +8,5 @@ tab: dashboards
 scope_type: bundle
 weight: null
 scope: 'advisory,decision,event,executive_order,form_page,news,regulation,rules'
-config: '/superset/dashboard/basic-pages/?preselect_filters=%7B%221793%22%3A%20%7B%22node_id%22%3A%20%5B52691%5D%7D%2C%20%22[node:nid]%22%3A%20%7B%22__time_range%22%3A%20%22Last%20month%22%7D%7D'
+config: '/superset/dashboard/basic-pages/?preselect_filters=%7B%221823%22%3A%20%7B%22node_id%22%3A%20%5B52691%5D%7D%2C%20%22[node:nid]%22%3A%20%7B%22__time_range%22%3A%20%22Last%20month%22%7D%7D'
 iframe_height: '2200'

--- a/conf/drupal/config/route_iframes.route_iframe_config_entity.parent_pages_dashboard.yml
+++ b/conf/drupal/config/route_iframes.route_iframe_config_entity.parent_pages_dashboard.yml
@@ -8,5 +8,5 @@ tab: dashboards
 scope_type: bundle
 weight: null
 scope: 'binder,curated_list,org_page,service_page,topic_page'
-config: '/superset/dashboard/parent-page/?preselect_filters=%7B%221436%22%3A%20%7B%22node_id%22%3A%20%5B%22[node:nid]%22%5D%7D%2C%20%221542%22%3A%20%7B%22__time_range%22%3A%20%22Last%204%20months%22%7D%2C%20%221807%22%3A%20%7B%22content_type%22%3A%20%5B%22[node:content-type:machine-name]%22%5D%7D%7D'
+config: '/superset/dashboard/parent-page/?preselect_filters=%7B%221823%22%3A%20%7B%22node_id%22%3A%20%5B%22[node:nid]%22%5D%7D%2C%20%221542%22%3A%20%7B%22__time_range%22%3A%20%22Last%204%20months%22%7D%2C%20%221807%22%3A%20%7B%22content_type%22%3A%20%5B%22[node:content-type:machine-name]%22%5D%7D%7D'
 iframe_height: '2200'

--- a/conf/drupal/config/route_iframes.route_iframe_config_entity.promo_page_dashboards.yml
+++ b/conf/drupal/config/route_iframes.route_iframe_config_entity.promo_page_dashboards.yml
@@ -8,5 +8,5 @@ tab: dashboards
 scope_type: bundle
 weight: null
 scope: campaign_landing
-config: '/superset/dashboard/promo-page/?preselect_filters=%7B%221436%22%3A%7B%22node_id%22%3A%5B"[node:nid]"%5D%7D%2C%221542%22%3A%7B%22__time_range%22%3A%22Last%20quarter%22%7D%7D'
+config: '/superset/dashboard/promo-page/?preselect_filters=%7B%221823%22%3A%7B%22node_id%22%3A%5B"[node:nid]"%5D%7D%2C%221542%22%3A%7B%22__time_range%22%3A%22Last%20quarter%22%7D%7D'
 iframe_height: '2200'


### PR DESCRIPTION
**Description:**
Fixes the iFrame URLs for our web analytics Superset dashboards. Previously, the URLs included an incorrect filter ID, so the dashboards were not being correctly filtered.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19935


**To Test:**
_Parent page dashboards:_
* Open any service, organization, topic, binder, or curated list
* Click the "analytics" tab
* The data in this tab should 1. be there (i.e. there aren't a bunch of blank charts) and 2. be only about _this_ page, not _all_ service, org, topic, binder, or curated lists. You can check Google Analytics to be super sure, but the "Previous URLs" chart should be a good indication. 

_Promo page dashboard_
* Same as above but with promotional pages

_Basic dashboard_
* Same as above but with a law library content type

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
