### PR TITLE
DP-19974: Remove form submit in button click to stop double formstack submissions

### DIFF
--- a/changelogs/DP-19974.yml
+++ b/changelogs/DP-19974.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Remove form submit in button click to stop double formstack submissions
+    issue: DP-19974

--- a/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
+++ b/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
@@ -68,8 +68,8 @@
           else {
             // This is to stop a double click submitting the form twice
             var $submitBtn = $('input[type="submit"]', $form);
-            $submitBtn.click(function () {
-              $(this).prop('disabled', true);
+            $form.submit(function () {
+              $submitBtn.prop('disabled', true);
             });
 
             $form.ajaxForm({

--- a/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
+++ b/docroot/modules/custom/mass_feedback_form/js/mass-feedback-form.behaviors.js
@@ -70,7 +70,6 @@
             var $submitBtn = $('input[type="submit"]', $form);
             $submitBtn.click(function () {
               $(this).prop('disabled', true);
-              $form.submit();
             });
 
             $form.ajaxForm({

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -280,13 +280,13 @@
           {
             "id": "field58154059",
             "name": "field58154059",
-            "value": "entityId",
+            "value": "entityIdentifier",
             "class": "fsField data-layer-substitute"
           },
           {
             "id": "field57432673",
             "name": "field57432673",
-            "value": "entityId",
+            "value": "entityIdentifier",
             "class": "fsField data-layer-substitute"
           },
           {


### PR DESCRIPTION
**Description:**
This PR removes a form submit call inside the submit button click event. This avoids the form submitting twice to formstack with identical information.

The double submit was not always happening. I noticed it consistently on Firefox browser, but not always with Brave browser.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19974


**To Test:**
- [ ] Fill out the feedback form and submit. Then login to formstack and see the entry, only once. NOTE: Formstack will show the integration as failed since you are submitting from your local environment, changing the referring url. This is expected.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
