### PR TITLE
Remove balancer in Terraform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,13 +468,13 @@ jobs:
       - when:
           condition: << parameters.auto-approve >>
           steps:
-            run:  TF_LOG=1 ./scripts/cloudflare-deploy << pipeline.parameters.target >> --auto-approve
+            run: ./scripts/cloudflare-deploy << pipeline.parameters.target >> --auto-approve
       - unless:
           # We expect to fail when this job runs *before* the hold. Keep it green by appending `|| true`.
           # See https://discuss.circleci.com/t/run-all-test-steps-even-if-one-fails/11229/12
           condition: << parameters.auto-approve >>
           steps:
-            run: TF_LOG=1 ./scripts/cloudflare-deploy << pipeline.parameters.target >> || true
+            run: ./scripts/cloudflare-deploy << pipeline.parameters.target >> || true
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,13 +468,13 @@ jobs:
       - when:
           condition: << parameters.auto-approve >>
           steps:
-            run: ./scripts/cloudflare-deploy << pipeline.parameters.target >> --auto-approve
+            run:  TF_LOG=1 ./scripts/cloudflare-deploy << pipeline.parameters.target >> --auto-approve
       - unless:
           # We expect to fail when this job runs *before* the hold. Keep it green by appending `|| true`.
           # See https://discuss.circleci.com/t/run-all-test-steps-even-if-one-fails/11229/12
           condition: << parameters.auto-approve >>
           steps:
-            run: ./scripts/cloudflare-deploy << pipeline.parameters.target >> || true
+            run: TF_LOG=1 ./scripts/cloudflare-deploy << pipeline.parameters.target >> || true
 
 workflows:
   version: 2

--- a/changelogs/DP-20115.yml
+++ b/changelogs/DP-20115.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Removed:
+  - description: Balancer address
+    issue: DP-20115

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -15,7 +15,7 @@ locals {
 resource "cloudflare_record" "edit_dns" {
   zone_id = var.zone_id
   name    = local.edit_domain
-  value   = var.BALANCER_IP
+  value   = var.balancer_ip
   type    = "A"
   proxied = true
 }
@@ -23,7 +23,7 @@ resource "cloudflare_record" "edit_dns" {
 resource "cloudflare_record" "www_dns" {
   zone_id = var.zone_id
   name    = local.www_domain
-  value   = var.BALANCER_IP
+  value   = var.balancer_ip
   type    = "A"
   proxied = true
 }

--- a/cloudflare/terraform/environment/main.tf
+++ b/cloudflare/terraform/environment/main.tf
@@ -15,7 +15,7 @@ locals {
 resource "cloudflare_record" "edit_dns" {
   zone_id = var.zone_id
   name    = local.edit_domain
-  value   = var.balancer_ip
+  value   = var.BALANCER_IP
   type    = "A"
   proxied = true
 }
@@ -23,7 +23,7 @@ resource "cloudflare_record" "edit_dns" {
 resource "cloudflare_record" "www_dns" {
   zone_id = var.zone_id
   name    = local.www_domain
-  value   = var.balancer_ip
+  value   = var.BALANCER_IP
   type    = "A"
   proxied = true
 }

--- a/cloudflare/terraform/environment/variables.tf
+++ b/cloudflare/terraform/environment/variables.tf
@@ -10,6 +10,12 @@ variable "domain" {
   type        = string
 }
 
+variable "balancer_ip" {
+  default     = "get-from-environment"
+  description = "Load balancer IP."
+  type        = string
+}
+
 variable "www_domains" {
   type = map(string)
   default = {

--- a/cloudflare/terraform/environment/variables.tf
+++ b/cloudflare/terraform/environment/variables.tf
@@ -10,12 +10,6 @@ variable "domain" {
   type        = string
 }
 
-variable "balancer_ip" {
-  default     = "52.55.144.180"
-  description = "Load balancer IP."
-  type        = string
-}
-
 variable "www_domains" {
   type = map(string)
   default = {

--- a/cloudflare/terraform/environment/variables.tf
+++ b/cloudflare/terraform/environment/variables.tf
@@ -10,7 +10,7 @@ variable "domain" {
   type        = string
 }
 
-variable "balancer_ip" {
+variable "BALANCER_IP" {
   default     = "get-from-environment"
   description = "Load balancer IP."
   type        = string


### PR DESCRIPTION
**Description:**
- Removed the IP from the codebase
- Wrote a new chamber variable called `tf_var_balancer_ip`. This is automatically saved as a terraform variable as per https://stackoverflow.com/a/62483073/265501. We are already using this technique for `tf_var_edit_bypass_condition`.

```
aws-vault exec massgov -- chamber list tf/massgov-cloudflare-deployment
Key				Version		LastModified	User
cdn_token			1		10-01 15:03:45	arn:aws:iam::748039698304:user/rob.bayliss
cloudflare_account_id		1		03-12 11:47:56	arn:aws:iam::748039698304:user/rob.bayliss
cloudflare_api_key		1		03-12 11:46:24	arn:aws:iam::748039698304:user/rob.bayliss
cloudflare_email		1		06-07 11:39:38	arn:aws:iam::748039698304:user/youssef.riahi
cloudflare_token		1		06-07 11:39:39	arn:aws:iam::748039698304:user/youssef.riahi
mass_cdn_token			1		10-24 16:43:12	arn:aws:iam::748039698304:user/youssef.riahi
tf_var_balancer_ip		1		10-05 13:21:11	arn:aws:iam::748039698304:user/moshe.weitzman
tf_var_edit_bypass_condition	1		03-12 11:56:46	arn:aws:iam::748039698304:user/rob.bayliss
```


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20115


**To Test:**
- [ ] Do a test CF deployment with `drush ma-cf-deploy cf --ci-branch=DP-20115-Move-origin-IP-address -v`. [Or just review this build](https://app.circleci.com/pipelines/github/massgov/openmass/4743/workflows/4e77402c-5077-4ed3-8af8-39f10b8002a7/jobs/19408). Notice that `terraform plan` found no changes. This indicates that the variable is being passed properly from chamber to terraform. 

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
