### PR TITLE
Update basic iframe URL so that node ID is correctly passed to Supers…

### DIFF
--- a/changelogs/DP-20161.yml
+++ b/changelogs/DP-20161.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
+    issue: DP-****

--- a/changelogs/DP-20161.yml
+++ b/changelogs/DP-20161.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: Updates iFrame for events, forms, news, and law library content types.
     issue: DP-0161

--- a/changelogs/DP-20161.yml
+++ b/changelogs/DP-20161.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Type:
-  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
-    issue: DP-****
+  - description: Updates iFrame for events, forms, news, and law library content types.
+    issue: DP-0161

--- a/conf/drupal/config/route_iframes.route_iframe_config_entity.basic_dashboard.yml
+++ b/conf/drupal/config/route_iframes.route_iframe_config_entity.basic_dashboard.yml
@@ -8,5 +8,5 @@ tab: dashboards
 scope_type: bundle
 weight: null
 scope: 'advisory,decision,event,executive_order,form_page,news,regulation,rules'
-config: '/superset/dashboard/basic-pages/?preselect_filters=%7B%221823%22%3A%20%7B%22node_id%22%3A%20%5B52691%5D%7D%2C%20%22[node:nid]%22%3A%20%7B%22__time_range%22%3A%20%22Last%20month%22%7D%7D'
+config: '/superset/dashboard/basic-pages/?preselect_filters=%7B%221823%22%3A%20%7B%22node_id%22%3A%20%5B%22[node:nid]%22%5D%7D%2C%20%221542%22%3A%20%7B%22__time_range%22%3A%20%22Last%20month%22%7D%7D'
 iframe_height: '2200'


### PR DESCRIPTION
…et filter.

**Description:**
This is what I believe you all refer to as a "backport config"? Anyway, I updated the route iframe configuration for "basic page dashboards" in the CMS, and this is the actual config change. 


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20161


**To Test:**
Testing this is going to be kind of a bear. You cannot test this locally--you get warnings about CSRF attacks. If you want to see it working:
* grab the basic page dashboard URL from the route iFrame config (also pasted below)
* substitute the node_id token `[node:nid]` for any node ID
* load it in your browser
* the data should be appropriate to that page (look at previous/next pages)

**Here's the iframe url (containing the drupal macro)**
dashboards.digital.mass.gov/superset/dashboard/basic-pages/?preselect_filters=%7B%221823%22%3A%20%7B%22node_id%22%3A%20%5B%22[node:nid]%22%5D%7D%2C%20%221542%22%3A%20%7B%22__time_range%22%3A%20%22Last%20month%22%7D%7D


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
