### PR TITLE
Dp 20172 promo button text size

### DIFF
--- a/changelogs/DP-20172.yml
+++ b/changelogs/DP-20172.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Key message button link text maximum characters increased to 50.
+    issue: DP-20172

--- a/conf/drupal/config/core.entity_form_display.paragraph.key_message.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.key_message.default.yml
@@ -115,7 +115,7 @@ content:
       placeholder_title: ''
     third_party_settings:
       maxlength:
-        maxlength_js: 35
+        maxlength_js: 50
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
       mass_validation:
         internal_link_content_type_blacklist: {  }

--- a/conf/drupal/config/core.entity_form_display.paragraph.key_message_section.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.key_message_section.default.yml
@@ -39,7 +39,7 @@ content:
       placeholder_title: ''
     third_party_settings:
       maxlength:
-        maxlength_js: 35
+        maxlength_js: 50
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
       mass_validation:
         internal_link_content_type_blacklist: {  }

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -467,7 +467,7 @@ function mass_utility_field_widget_form_alter(&$element, FormStateInterface $for
     elseif ($field_name == 'field_button') {
       // Set link field description for the button on campaign landing pages.
       $element['uri']['#description'] = t('Start typing to choose an existing page on Mass.gov, or enter a complete URL to another site. If you want to add an external link, it must begin with "https://" or "http://".');
-      $element['title']['#description'] = t('A short call to action or invitation to read more. Should begin with a verb. If this is not filled out, the button will not render on the page. 20-character limit.');
+      $element['title']['#description'] = t('A short call to action or invitation to read more. Should begin with a verb. If this is not filled out, the button will not render on the page. 50-character limit.');
       $element['title']['#title'] = t('Button text');
     }
     else {


### PR DESCRIPTION
**Description:**
Increase the button text size to 50 characters for promo page key message (header and section).


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20172


**To Test:**
- [ ] add a key message header and key message section to a promo page. Verify that you can have button text up to 50 characters and the countdown and help text are correct.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
