### PR TITLE
DP-20203 Missing alert overlay in info details page

### DIFF
--- a/changelogs/DP-20203.yml
+++ b/changelogs/DP-20203.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Add a container for alert overlay to mass_theme/templates/layout/page--node--without-main.html.twig.
+    issue: DP-20203

--- a/docroot/themes/custom/mass_theme/templates/layout/page--node--without-main.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/layout/page--node--without-main.html.twig
@@ -49,6 +49,7 @@
  */
 #}
 {{ page.emergency_alert }}
+<div class="alert-overlay"></div>
 {{ page.flag_links }}
 
 {% set header_class = "" %}


### PR DESCRIPTION
**Description:**
Missing container for alert overlay in /themes/custom/mass_theme/templates/layout/page--node--without-main.html.twig was causing not showing the alert overlay in info details page. The container was added.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20203


**To Test:**
- [ ] Build the site with MF `patternlab/DP-17200-add-horizontal-nav-code-branch`.

- [ ] Go to any info details page(ex:  /info-details/covid-19-updates-and-information), and open the menu.

- [ ] Find the alert has an overlay.

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
