### PR TITLE
Remove unused alert target_pages paragraphs before importing config.

### DIFF
--- a/changelogs/DP-19034.yml
+++ b/changelogs/DP-19034.yml
@@ -39,4 +39,3 @@
 Removed:
   - description: Remove unused paragraph from alerts
     issue: DP-19034
-

--- a/changelogs/DP-19034.yml
+++ b/changelogs/DP-19034.yml
@@ -39,3 +39,5 @@
 Removed:
   - description: Remove unused paragraph from alerts
     issue: DP-19034
+  - description: Remove unused alert paragraphs from DB
+    issue: DP-19034

--- a/changelogs/DP-20337.yml
+++ b/changelogs/DP-20337.yml
@@ -36,7 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Removed:
-  - description: Remove unused paragraph from alerts
-    issue: DP-19034
-
+Type:
+  - description: Remove unused alert paragraphs from DB.
+    issue: DP-20337

--- a/changelogs/DP-20337.yml
+++ b/changelogs/DP-20337.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Removed:
   - description: Remove unused alert paragraphs from DB.
     issue: DP-20337

--- a/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
@@ -95,4 +95,19 @@ function mass_alerts_post_update_target_pages(&$sandbox) {
     return t('Migrated the data from field_target_pages_para_ref to field_target_page for @nodes Alert nodes.', ["@nodes" => $sandbox['total']]);
   }
 
+  /**
+   * Implements hook_post_update_NAME.
+   *
+   * Empty unused paragraphs.
+   */
+  function mass_alerts_post_update_target_pages_paragraphs(&$sandbox) {
+    $entityTypeManager = Drupal::entityTypeManager();
+    $storage = $entityTypeManager->getStorage('paragraph');
+    $query = $storage->getQuery();
+    $bundleKey = $entityTypeManager->getDefinition('paragraph')->getKey('bundle');
+    $query = $query->condition($bundleKey, 'target_pages');
+    $result = $query->execute();
+    $entities = $storage->loadMultiple($result);
+    $storage->delete($entities);
+  }
 }

--- a/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
@@ -110,4 +110,5 @@ function mass_alerts_post_update_target_pages(&$sandbox) {
     $entities = $storage->loadMultiple($result);
     $storage->delete($entities);
   }
+
 }

--- a/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
@@ -94,21 +94,20 @@ function mass_alerts_post_update_target_pages(&$sandbox) {
   if ($sandbox['#finished'] >= 1) {
     return t('Migrated the data from field_target_pages_para_ref to field_target_page for @nodes Alert nodes.', ["@nodes" => $sandbox['total']]);
   }
+}
 
-  /**
-   * Implements hook_post_update_NAME.
-   *
-   * Empty unused paragraphs.
-   */
-  function mass_alerts_post_update_paragraphs_target_pages(&$sandbox) {
-    $entityTypeManager = Drupal::entityTypeManager();
-    $storage = $entityTypeManager->getStorage('paragraph');
-    $query = $storage->getQuery();
-    $bundleKey = $entityTypeManager->getDefinition('paragraph')->getKey('bundle');
-    $query = $query->condition($bundleKey, 'target_pages');
-    $result = $query->execute();
-    $entities = $storage->loadMultiple($result);
-    $storage->delete($entities);
-  }
-
+/**
+ * Implements hook_post_update_NAME.
+ *
+ * Empty unused paragraphs.
+ */
+function mass_alerts_post_update_paragraphs_target_pages(&$sandbox) {
+  $entityTypeManager = Drupal::entityTypeManager();
+  $storage = $entityTypeManager->getStorage('paragraph');
+  $query = $storage->getQuery();
+  $bundleKey = $entityTypeManager->getDefinition('paragraph')->getKey('bundle');
+  $query = $query->condition($bundleKey, 'target_pages');
+  $result = $query->execute();
+  $entities = $storage->loadMultiple($result);
+  $storage->delete($entities);
 }

--- a/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.post_update.php
@@ -100,7 +100,7 @@ function mass_alerts_post_update_target_pages(&$sandbox) {
    *
    * Empty unused paragraphs.
    */
-  function mass_alerts_post_update_target_pages_paragraphs(&$sandbox) {
+  function mass_alerts_post_update_paragraphs_target_pages(&$sandbox) {
     $entityTypeManager = Drupal::entityTypeManager();
     $storage = $entityTypeManager->getStorage('paragraph');
     $query = $storage->getQuery();


### PR DESCRIPTION
**Description:**
Fixes problem where prod keeps creating these paragraphs and repopulating our dev DB with them.


**Jira:** (Skip unless you are MA staff)
DP-19034


**To Test:**
- [ ] If its green its good

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
