### PR TITLE
Disable ClamAV at Acquia.

### DIFF
--- a/changelogs/DP-19008.yml
+++ b/changelogs/DP-19008.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: ClamAV disabled at Acquia
+    issue: DP-19008

--- a/docroot/sites/default/settings.acquia.php
+++ b/docroot/sites/default/settings.acquia.php
@@ -51,6 +51,10 @@ if (!$cli && ($is_prod || $is_mass_gov)) {
  */
 $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.acquia.yml';
 
+/**
+ * Temporarily disable ClamAV. See https://jira.mass.gov/browse/DP-19008.
+ */
+$config['clamav.settings']['enabled'] = 0;
 
 /**
  * Configure file directory paths.


### PR DESCRIPTION
**Description:**
Disable ClamAV at Acquia to improve image upload robustness


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20129


**To Test:**
- [ ] Try to upload a file in an Acquia environment.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
