### PR TITLE
DP-19156: Exclude footer, feedback and sitewide alerts from page snippets in Google

### DIFF
--- a/changelogs/DP-19156.yml
+++ b/changelogs/DP-19156.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Exclude footer, feedback and sitewide alerts from page snippets in Google.
+    issue: DP-19156

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -71,7 +71,7 @@
  <span aria-hidden="true"> * </span><span class="visually-hidden">required</span>
 {% endset %}
 
-<div class="feedback-steps">
+<div class="feedback-steps" data-nosnippet="true">
   <span id="feedback"></span>
   <div id="feedback-step-1" class="feedback-step" data-feedback-next="feedback-step-2">
     <div class="ma__mass-feedback-form">


### PR DESCRIPTION
**Description:**
Feedback form is rendered in Drupal, so I had to add data-nosnippet attribute in Drupal as well.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19156