### PR TITLE
DP-20086: Prevent bulk update of author from sending watch emails

### DIFF
--- a/changelogs/DP-20086.yml
+++ b/changelogs/DP-20086.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Prevent bulk update of author from sending watch emails.
+    issue: DP-20086

--- a/docroot/modules/custom/mass_flagging/mass_flagging.module
+++ b/docroot/modules/custom/mass_flagging/mass_flagging.module
@@ -64,7 +64,8 @@ function mass_flagging_node_insert(Node $node) {
 function mass_flagging_node_update_insert_send_notifications(Node $node) {
   // Only send notifications after a node has been published.
   // This excludes any nodes in one of multiple 'prepublished' states.
-  if (!MassModeration::isPrepublish($node)) {
+  $is_vbo = Drupal::routeMatch()->getRouteName() == 'system.batch_page.json';
+  if (!MassModeration::isPrepublish($node) && !$is_vbo) {
     $flag_service = \Drupal::service('flag');
     $watch_flag = \Drupal::entityTypeManager()
       ->getStorage('flag')


### PR DESCRIPTION
**Description:**
Added a check in the send function to prevent sending from VBO page.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20086


**To Test:**
- [ ] Run ahoy drush queue:run mass_flagging_email_queue command and make sure there are no items in the queue.
- [ ] Go to the bulk page update 50 nodes randomly
- [ ] Run ahoy drush queue:run mass_flagging_email_queue and make sure there are no watch emails in the mailhog.mass.local inbox
