### PR TITLE
DP-20111 Add mp4 to downloads

### DIFF
--- a/changelogs/DP-20111.yml
+++ b/changelogs/DP-20111.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Added:
-  - description: Add mp4 as an allowed file extention to the Select field in the Doument media type.
+  - description: Add mp4 as an allowed file extension to the Select field in the Document media type.
     issue: DP-20111

--- a/changelogs/DP-20111.yml
+++ b/changelogs/DP-20111.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Added:
-  - description: Add mp4 as allowed file extention to the Select the fiel field in the Doument media type.
+  - description: Add mp4 as an allowed file extention to the Select field in the Doument media type.
     issue: DP-20111

--- a/changelogs/DP-20111.yml
+++ b/changelogs/DP-20111.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add mp4 as allowed file extention to the Select the fiel field in the Doument media type.
+    issue: DP-20111

--- a/conf/drupal/config/field.field.media.document.field_upload_file.yml
+++ b/conf/drupal/config/field.field.media.document.field_upload_file.yml
@@ -19,7 +19,7 @@ default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: 'documents/[date:custom:Y]/[date:custom:m]/[date:custom:d]'
-  file_extensions: 'csv doc docm docx dot dotx dwg geojson gif json jpg kml kmz mp3 mpp msg odf ods odt pdf png pps ppsx potx ppt pptm pptx ppsm prx pub rdf rfa rte rtf tiff tsv txt xls xlsb xlsm xlsx xml zip'
+  file_extensions: 'csv doc docm docx dot dotx dwg geojson gif json jpg kml kmz mp3 mp4 mpp msg odf ods odt pdf png pps ppsx potx ppt pptm pptx ppsm prx pub rdf rfa rte rtf tiff tsv txt xls xlsb xlsm xlsx xml zip'
   max_filesize: '100 MB'
   description_field: false
   handler: 'default:file'


### PR DESCRIPTION
**Description:**
Add mp4 as an allowed file extension to the Select field in the Document media type.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20111


**To Test:**
- [ ] Go to http://mass.local/admin/structure/media/manage/document/fields/media.document.field_upload_file.  Find **mp4** is in the _Allowed file extensions_.
<img width="901" alt="mp4-config" src="https://user-images.githubusercontent.com/9633303/99722439-a9ec1780-2a7e-11eb-86e0-d69d8c1065cd.png">

- [ ] Go to any content edit page with _Additional Resources_ such as Information Details.

- [ ] In _Downloads_, click **Add new media item** button and add a mp4 file.

- [ ] Save the change and review the generated page to see the mp4 link is there.
<img width="239" alt="mp4" src="https://user-images.githubusercontent.com/9633303/99722861-5201e080-2a7f-11eb-8892-6d77a2bdbec9.png">


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
