### PR TITLE
DP-20578 - Fix Behat XSS error related to iframe caption field

### DIFF
--- a/changelogs/DP-20578.yml
+++ b/changelogs/DP-20578.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes Behat XSS errors related to new rich text iframe caption field
+    issue: DP-20578

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--iframe.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--iframe.html.twig
@@ -36,6 +36,12 @@
  * @ingroup themeable
  */
 #}
+{% set caption = {
+  '#type':   'processed_text',
+  '#text':    paragraph.field_iframe_caption.value,
+  '#format':  paragraph.field_iframe_caption.format,
+} %}
+
 {% include "@atoms/09-media/figure--iframe.twig" with {
   "figure": {
     "align": paragraph.field_iframe_alignment.value,
@@ -46,7 +52,7 @@
       "title": paragraph.field_iframe_accessibility_title.value,
       "height": paragraph.field_height.value,
       "position": paragraph.field_iframe_display_size.value,
-      "caption": paragraph.field_iframe_caption.value
+      "caption": caption
     }
   }
 } %}


### PR DESCRIPTION
**Description:**
As a part of DP-19391, we added a rich text iframe caption field. This field value is passed from openmass to mayflower. To get the field to render properly, Mayflower was changed to output this field value as raw. The fix here ensure we are properly processing the rich text field.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20578

**To Test:**
- [ ] Run Behat and verify that there are no failures


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
