### PR TITLE
Mayflower/dp 20563 mayflower version 10.3.0

### DIFF
--- a/changelogs/DP-20563.yml
+++ b/changelogs/DP-20563.yml
@@ -1,0 +1,49 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 10.3.0.
+              - DP-19520: Specify the link color for the second unit. (MF)
+              - DP-20499: Align stikcy nav to the top of the page with screen width 780px and less. (MF)
+              - Added PNG and SVG formats for all official state seal variations stateseal.[png|svg], stateseal-color.[png|svg], stateseal-black.[png|svg], stateseal-white.[png|svg]. (MF)
+              - Changed global.scss path for static assets to point to unpkg CDN url. (MF)
+              - Changed main nav js for window resize to use addEventListener instead of undefined addEventHandler. (MF)
+              - Renamed variable names to be unique for each module file, allowing those files to be combined without conflicts for static js generation. (MF)
+              - Optimize and standardize existing state seals PNGs in assets to reduce file sizes for web usage without sacrificing qualities. (MF)
+    issue: DP-20563

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "10.2.0",
+        "massgov/mayflower-artifacts": "10.3.0",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0642ad89174fd2f781611a56dd0e976f",
+    "content-hash": "8978947359c0d697f6b66514ab2839f8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10071,12 +10071,6 @@
                 "laminas",
                 "zf"
             ],
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
             "time": "2020-09-14T14:23:00+00:00"
         },
         {
@@ -10313,16 +10307,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "10.2.0",
+            "version": "10.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "b26c31b4f146a081562b313c8e99dcddbe61b720"
+                "reference": "68af27d14c5bdd7457ecd51c13af1016e1dc8063"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/b26c31b4f146a081562b313c8e99dcddbe61b720",
-                "reference": "b26c31b4f146a081562b313c8e99dcddbe61b720",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/68af27d14c5bdd7457ecd51c13af1016e1dc8063",
+                "reference": "68af27d14c5bdd7457ecd51c13af1016e1dc8063",
                 "shasum": ""
             },
             "require": {
@@ -10340,7 +10334,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-11-16T19:34:48+00:00"
+            "time": "2020-11-23T21:29:15+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -10531,16 +10525,6 @@
                 }
             ],
             "description": "Drupal extension and rules for PHPStan",
-            "funding": [
-                {
-                    "url": "https://github.com/mglaman",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/mglaman",
-                    "type": "liberapay"
-                }
-            ],
             "time": "2020-06-10T21:05:10+00:00"
         },
         {
@@ -10566,8 +10550,7 @@
                 "source": "https://github.com/mikeyp/google_tag/tree/8.x-1.x",
                 "issues": "https://github.com/mikeyp/google_tag/issues"
             },
-            "abandoned": true,
-            "time": "2016-10-17T15:47:26+00:00"
+            "time": "2016-10-17T16:52:31+00:00"
         },
         {
             "name": "mkalkbrenner/php-htmldiff-advanced",
@@ -12095,20 +12078,6 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-06-14T14:10:59+00:00"
         },
         {
@@ -14184,20 +14153,6 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-08-31T05:53:42+00:00"
         },
         {
@@ -15375,12 +15330,6 @@
                 }
             ],
             "description": "A PHP SDK for Acquia CloudAPI v2",
-            "funding": [
-                {
-                    "url": "https://github.com/typhonius",
-                    "type": "github"
-                }
-            ],
             "time": "2020-06-01T19:47:03+00:00"
         },
         {
@@ -17541,6 +17490,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.3"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 10.3.0.
              - DP-19520: Specify the link color for the second unit. (MF)
              - DP-20499: Align stikcy nav to the top of the page with screen width 780px and less. (MF)
              - Added PNG and SVG formats for all official state seal variations stateseal.[png|svg], stateseal-color.[png|svg], stateseal-black.[png|svg], stateseal-white.[png|svg]. (MF)
              - Changed global.scss path for static assets to point to unpkg CDN url. (MF)
              - Changed main nav js for window resize to use addEventListener instead of undefined addEventHandler. (MF)
              - Renamed variable names to be unique for each module file, allowing those files to be combined without conflicts for static js generation. (MF)
              - Optimize and standardize existing state seals PNGs in assets to reduce file sizes for web usage without sacrificing qualities. (MF)
    issue: DP-20563