### PR TITLE
DP-20418: Media bundle is missing file for media entity: XYZ

### DIFF
--- a/changelogs/DP-20418.yml
+++ b/changelogs/DP-20418.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Bypass "Media bundle is missing file for media entity" error message on all environments except production.
+    issue: DP-20418

--- a/changelogs/DP-20418.yml
+++ b/changelogs/DP-20418.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Bypass "Media bundle is missing file for media entity" error message on all environments except production.
+  - description: Changed "Media bundle is missing file for media entity" error message to report only to logs.
     issue: DP-20418

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6292,14 +6292,11 @@ function mass_theme_preprocess_media_document(array &$variables) {
     $list_table_rows = [];
 
     // Get the attached file from the media entity.
-    try {
+    if ($media_file_changed_time = media_file_changed_time($media, 'field_upload_file')) {
       $list_table_rows[] = [
         'label' => 'Last Updated:',
-        'text' => media_file_changed_time($media, 'field_upload_file'),
+        'text' => $media_file_changed_time,
       ];
-    }
-    catch (FileNotFoundException $e) {
-      \Drupal::logger('media.documents')->error($e->getMessage());
     }
 
     $creator = $media->field_creator->entity;
@@ -6355,15 +6352,15 @@ function mass_theme_preprocess_media_document(array &$variables) {
  *
  * @return string
  *   Date formatted Y-m-d for the file last changed date.
- *
- * @throws \FileNotFoundException
  */
 function media_file_changed_time(MediaInterface $entity, $field_name) {
   $file = $entity->{$field_name}->entity;
   if (!$file instanceof File) {
-    if ((!isset($_ENV['AH_SITE_ENVIRONMENT']) || $_ENV['AH_SITE_ENVIRONMENT'] == 'prod')) {
-      throw new FileNotFoundException('Media bundle is missing file for media entity: ' . $entity->label() . "(" . $entity->id() . ")");
-    }
+    \Drupal::logger('media.documents')->error('Media bundle is missing file for media entity: @entity_label (@entity_id)', [
+      '@entity_label' => $entity->label(),
+      '@entity_id' => $entity->id(),
+    ]);
+    return '';
   }
   return DrupalDateTime::createFromTimestamp($entity->{$field_name}->entity->getChangedTime())->format('Y-m-d');
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6361,7 +6361,9 @@ function mass_theme_preprocess_media_document(array &$variables) {
 function media_file_changed_time(MediaInterface $entity, $field_name) {
   $file = $entity->{$field_name}->entity;
   if (!$file instanceof File) {
-    throw new FileNotFoundException('Media bundle is missing file for media entity: ' . $entity->label() . "(" . $entity->id() . ")");
+    if ((!isset($_ENV['AH_SITE_ENVIRONMENT']) || $_ENV['AH_SITE_ENVIRONMENT'] == 'prod')) {
+      throw new FileNotFoundException('Media bundle is missing file for media entity: ' . $entity->label() . "(" . $entity->id() . ")");
+    }
   }
   return DrupalDateTime::createFromTimestamp($entity->{$field_name}->entity->getChangedTime())->format('Y-m-d');
 }


### PR DESCRIPTION
**Description:**
Changed error message from both throwing and reporting to watchdog to just reporting the error to watchdog.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20418

**To Test:**
- [ ] Check that the error exists by loading a media entity page that does not have a file (I used media/1518421) and check that the error shows up in Portainer. Also verify that the media entity page itself still loads without error.
- [ ] Add a file to the media entity and save. Verify that you no longer see an error in Portainer, that the media entity page itself still loads without error, and that you can also see the "Last Updated" info about the file along with other expected fields, such as the link to download the file.
---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)