### PR TITLE
Mayflower/dp 20749 mayflower version 11.0.0

### DIFF
--- a/changelogs/DP-20749.yml
+++ b/changelogs/DP-20749.yml
@@ -1,0 +1,49 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 11.0.0.
+          - DP-19530: Added the new MVP core storybook documentation site. (MF)
+          - DP-20659: Set up a template for Caspio as a figure variation template. (MF)
+          - DP-20321: Refactored header.scss build assets to use header mixed styles. (MF)
+          - DP-20321: Modified menu-overlay to work with top set to zero. Updated ma__header__hamburger__nav z-index. (MF)
+          - DP-20659: Adjust the optional title and its visibility in all figure variation templates. (MF)
+          - Sync FooterLinks markup between React and Patternlab, consolidate styles in assets. (MF)
+          - Fix Noto Sans loading on IE. (MF)
+    issue: DP-20749

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "10.4.1",
+        "massgov/mayflower-artifacts": "11.0.0",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0d610c8d06cf9d72047fa58ee99c388",
+    "content-hash": "57b536dccf39871ebaa91a718f3a9b72",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10554,16 +10554,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "10.4.1",
+            "version": "11.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "e46fc1d88f097891f5ba02b41e417c00db9121f1"
+                "reference": "b91fd1a92b8a106749f3c8c98a8f9578482a6c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e46fc1d88f097891f5ba02b41e417c00db9121f1",
-                "reference": "e46fc1d88f097891f5ba02b41e417c00db9121f1",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/b91fd1a92b8a106749f3c8c98a8f9578482a6c27",
+                "reference": "b91fd1a92b8a106749f3c8c98a8f9578482a6c27",
                 "shasum": ""
             },
             "require": {
@@ -10581,7 +10581,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-12-15T20:20:28+00:00"
+            "time": "2020-12-22T00:56:05+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 11.0.0.
          - DP-19530: Added the new MVP core storybook documentation site. (MF)
          - DP-20659: Set up a template for Caspio as a figure variation template. (MF)
          - DP-20321: Refactored header.scss build assets to use header mixed styles. (MF)
          - DP-20321: Modified menu-overlay to work with top set to zero. Updated ma__header__hamburger__nav z-index. (MF)
          - DP-20659: Adjust the optional title and its visibility in all figure variation templates. (MF)
          - Sync FooterLinks markup between React and Patternlab, consolidate styles in assets. (MF)
          - Fix Noto Sans loading on IE. (MF)
    issue: DP-20749
