### PR TITLE
Remove inaccessible links in entity references

### DIFF
--- a/changelogs/DP-19228.yml
+++ b/changelogs/DP-19228.yml
@@ -1,0 +1,3 @@
+Changed:
+  - description: Link not removed when target is unpublished or deleted
+    issue: DP-19228

--- a/docroot/modules/custom/mass_content/src/Plugin/Field/FieldFormatter/DynamicLinkSeparateFormatter.php
+++ b/docroot/modules/custom/mass_content/src/Plugin/Field/FieldFormatter/DynamicLinkSeparateFormatter.php
@@ -93,8 +93,6 @@ class DynamicLinkSeparateFormatter extends LinkFormatter {
         $element[$delta]['#access'] = $access->isAllowed();
       }
 
-
-
       if (!empty($item->_attributes)) {
         // Set our RDFa attributes on the <a> element that is being built.
         $url->setOption('attributes', $item->_attributes);

--- a/docroot/modules/custom/mayflower/src/Helper.php
+++ b/docroot/modules/custom/mayflower/src/Helper.php
@@ -166,6 +166,11 @@ class Helper {
       $entities = Helper::getReferencedEntitiesFromField($entity, $field);
 
       foreach ($entities as $entity) {
+        // We've abandoned the Drupal render system so no concern about cache metadata. If the reference is inaccessible to anon, the link is removed for all.
+        if (!$entity->access()) {
+          continue;
+        }
+
         if (!empty($options['maxItems']) && ($item_count >= $options['maxItems'])) {
           break;
         }
@@ -191,10 +196,17 @@ class Helper {
       $links = $entity->get($field);
 
       foreach ($links as $link) {
+        if (0) {
+          $a = 'l';
+        }
         if (!empty($options['maxItems']) && ($item_count >= $options['maxItems'])) {
           break;
         }
-        $items[] = Helper::separatedLink($link, $options);
+        $separated = Helper::separatedLink($link, $options);
+        // Avoid inaccessible links.
+        if ($separated['title'] && $separated['href']) {
+          $items[] = $separated;
+        }
         $item_count++;
       }
     }
@@ -210,7 +222,7 @@ class Helper {
    * @param array $options
    *   An array of options.
    *
-   * @return array
+   * @return array|null
    *   Array that contains title, url and type (external, internal).
    */
   public static function separatedLink($link, array $options = []) {

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
@@ -170,7 +170,7 @@
 {% endblock %}
 
 {% if not no_sidebar %}
-  {% if (content.extra_sidebar_contact|render|trim is not empty) or (sideContent.linkList) %}
+  {% if (content.extra_sidma__link-list__containerebar_contact|render|trim is not empty) or (sideContent.linkList) %}
     {% set sidebar = true %}
   {% endif %}
 {% endif %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--node--field-related-links--curated-list.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--node--field-related-links--curated-list.html.twig
@@ -54,19 +54,21 @@
     {% set level = level + 1 %}
 
     {% for item in items %}
-      {% include "@molecules/press-teaser.twig" with {
-        "pressTeaser": {
-          "eyebrow": item.content['#extra']['type'],
-          "title": {
-            "href": item.content['#url'],
-            "text": item.content['#title'],
-            "info": "",
-            "property": "",
-          },
-          "level": level,
-          "date": item.content['#extra']['date'],
-        }
-      } %}
+      {% if item.content|render|striptags|trim %}
+        {% include "@molecules/press-teaser.twig" with {
+          "pressTeaser": {
+            "eyebrow": item.content['#extra']['type'],
+            "title": {
+              "href": item.content['#url'],
+              "text": item.content['#title'],
+              "info": "",
+              "property": "",
+            },
+            "level": level,
+            "date": item.content['#extra']['date'],
+          }
+        } %}
+      {% endif %}
     {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--node--field-service-detail-links-5.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--node--field-service-detail-links-5.html.twig
@@ -25,9 +25,11 @@
 
   {% block linkListDecorativeLink %}
     {% for decorativeLink in items %}
-      <li class="ma__link-list__item">
-        {{ decorativeLink.content }}
-      </li>
+      {% if decorativeLink.content|render|striptags|trim %}
+        <li class="ma__link-list__item">
+          {{ decorativeLink.content }}
+        </li>
+      {% endif %}
     {% endfor %}
   {% endblock %}
 {% endembed %}

--- a/docroot/themes/custom/mass_theme/templates/field/field--paragraph--field-related-content--related-content.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--paragraph--field-related-content--related-content.html.twig
@@ -38,8 +38,10 @@
 #}
 <ul class="ma__link-list__items">
     {% for item in items %}
-        <li class="ma__link-list__item">
-            {{ item.content }}
-        </li>
+      {% if item.content|render|striptags|trim %}
+          <li class="ma__link-list__item">
+              {{ item.content }}
+          </li>
+      {% endif %}
     {% endfor %}
 </ul>


### PR DESCRIPTION
**Description:**
Add #access to inaccessible links (i.e. deleted or unpublished referenced content), taking care to also add cacheability metadata. Unfortunately, this makes the links uncacheable (max-age=-1) but thats not so bad - they will process via dynamic page cache. 

The `{% if item.content|render|striptags|trim %}` in twig files is needed or else #access is not honored as the individual links are rendered in the design system, not in drupal.

Todo - The bad ref at bottom https://www.mass.gov/info-details/the-community-reinvestment-act-cra-for-banks-and-credit-unions is vexing. This one is in a LinkList and those deeply drift away from Drupal rendering starting at the mass_theme_preprocess_node_info_details() function https://github.com/massgov/openmass/blob/develop/docroot/themes/custom/mass_theme/mass_theme.theme#L1514

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19228




**To Test:**
- [ ] Try the links in the Jira ticket and see that their inaccessible content has been removed while anonymous. They are removed from editors too if the content is actually inaccessible.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
