### PR TITLE
Mayflower/dp 20880 mayflower version 11.1.0

### DIFF
--- a/changelogs/DP-20880.yml
+++ b/changelogs/DP-20880.yml
@@ -1,0 +1,45 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 11.1.0.
+            - DP-9450: Set bullet style for nested unordered list. (MF)
+            - DP-9450: Remove the existing bullet style for a unordered list in rich text to match _elements.scss and adjust nested lists' top margin for consistent spacing. (MF)
+            - GlobalNav: Removed the submenu first child and its hidden styles, cleanup style overrides. Target the category link in submenu using className ma__main__hamburger-nav__subitem--main instead of :last-child (MF)
+    issue: DP-20880

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "drush/drush": "^10",
         "enyo/dropzone": "4.3.0",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.0.0",
+        "massgov/mayflower-artifacts": "11.1.0",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57b536dccf39871ebaa91a718f3a9b72",
+    "content-hash": "560e0693d3243f9f186e9486ff786eda",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10554,16 +10554,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.0.0",
+            "version": "11.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "b91fd1a92b8a106749f3c8c98a8f9578482a6c27"
+                "reference": "2c9e120f43641f2a7cecda7ac3719be00bd8e946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/b91fd1a92b8a106749f3c8c98a8f9578482a6c27",
-                "reference": "b91fd1a92b8a106749f3c8c98a8f9578482a6c27",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/2c9e120f43641f2a7cecda7ac3719be00bd8e946",
+                "reference": "2c9e120f43641f2a7cecda7ac3719be00bd8e946",
                 "shasum": ""
             },
             "require": {
@@ -10581,7 +10581,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2020-12-22T00:56:05+00:00"
+            "time": "2021-01-08T22:51:37+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 11.1.0.
            - DP-9450: Set bullet style for nested unordered list. (MF)
            - DP-9450: Remove the existing bullet style for a unordered list in rich text to match _elements.scss and adjust nested lists' top margin for consistent spacing. (MF)
            - GlobalNav: Removed the submenu first child and its hidden styles, cleanup style overrides. Target the category link in submenu using className ma__main__hamburger-nav__subitem--main instead of :last-child (MF)
    issue: DP-20880