### PR TITLE
Exclude menu_link_content from sanitization - DP-21067

### DIFF
--- a/changelogs/DP-21067.yml
+++ b/changelogs/DP-21067.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Removed menu link content from database sanitization.
+    issue: DP-21067

--- a/drush/Commands/SanitizationCommands.php
+++ b/drush/Commands/SanitizationCommands.php
@@ -49,23 +49,25 @@ class SanitizationCommands extends DrushCommands {
       return;
     }
     $types = array_keys($this->entityTypeManager->getDefinitions());
+
+    // Deleting menu link content sometimes results in rendering issues with
+    // super-sanitized databases, so excluding it from sanitization.
+    $idx = array_search('menu_link_content', $types);
+    if ($idx !== -1) {
+      unset($types[$idx]);
+    }
+
+    // This is a bit of a hack, but content moderation needs to go dead last
+    // so it can clean up after all the other stuff has been deleted.
+    $idx = array_search('content_moderation_state', $types);
+    if ($idx !== -1) {
+      unset($types[$idx]);
+      $types[] = 'content_moderation_state';
+    }
+
     foreach ($types as $idx => $type) {
-
-      // Deleting menu link content sometimes results in rendering issues with
-      // super-sanitized databases, so excluding it from sanitization.
-      if ($type == 'menu_link_content') {
-        unset($types[$idx]);
-      }
-
-      // This is a bit of a hack, but content moderation needs to go dead last
-      // so it can clean up after all the other stuff has been deleted.
-      if ($type == 'content_moderation_state') {
-        unset($types[$idx]);
-        $types[] = 'content_moderation_state';
-      }
-
       if ($sanitizer = $this->getEntitySanitizer($type)) {
-        $sanitizer->sanitize();;
+        $sanitizer->sanitize();
       }
     }
   }

--- a/drush/Commands/SanitizationCommands.php
+++ b/drush/Commands/SanitizationCommands.php
@@ -65,7 +65,7 @@ class SanitizationCommands extends DrushCommands {
       $types[] = 'content_moderation_state';
     }
 
-    foreach ($types as $idx => $type) {
+    foreach ($types as $type) {
       if ($sanitizer = $this->getEntitySanitizer($type)) {
         $sanitizer->sanitize();
       }

--- a/drush/Commands/SanitizationCommands.php
+++ b/drush/Commands/SanitizationCommands.php
@@ -49,15 +49,21 @@ class SanitizationCommands extends DrushCommands {
       return;
     }
     $types = array_keys($this->entityTypeManager->getDefinitions());
-    // This is a bit of a hack, but content moderation needs to go dead last
-    // so it can clean up after all the other stuff has been deleted.
-    $idx = array_search('content_moderation_state', $types);
-    if ($idx !== -1) {
-      unset($types[$idx]);
-      $types[] = 'content_moderation_state';
-    }
+    foreach ($types as $idx => $type) {
 
-    foreach ($types as $type) {
+      // Deleting menu link content sometimes results in rendering issues with
+      // super-sanitized databases, so excluding it from sanitization.
+      if ($type == 'menu_link_content') {
+        unset($types[$idx]);
+      }
+
+      // This is a bit of a hack, but content moderation needs to go dead last
+      // so it can clean up after all the other stuff has been deleted.
+      if ($type == 'content_moderation_state') {
+        unset($types[$idx]);
+        $types[] = 'content_moderation_state';
+      }
+
       if ($sanitizer = $this->getEntitySanitizer($type)) {
         $sanitizer->sanitize();;
       }


### PR DESCRIPTION
**Description:**
While working on DP-20281, we noticed that some pages, especially edit pages, did not load when the Language module was enabled and menu link content was sanitized from the database.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21067


**To Test:**
- [ ] Locally, run `ahoy drush sql-sanitize --sanitize-entities` against the less sanitized database. 
- [ ] Enable the Language module. Try editing a node. Page should load.
- [ ] For comparison, enable the Language module using the super sanitized database. Try editing a node. The page will likely not load.

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
