### PR TITLE
Pin web server during file uploads in the WYSIWYG editor - DP-20580

### DIFF
--- a/changelogs/DP-20580.yml
+++ b/changelogs/DP-20580.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Address issue where uploading files via the WYSIWYG editor results in an error.
+    issue: DP-20580

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -227,10 +227,22 @@ function _add_description_display_before(&$variables) {
  */
 function mass_admin_theme_preprocess_form_element(&$variables) {
   _add_description_display_before($variables);
+
+  // Remove cookie when in the admin theme to ensure that the cookie is reset.
+  setrawcookie('ah_app_server', '', REQUEST_TIME - 3600, '/');
+
   if (isset($variables['element']['#id']) &&
     ($variables['element']['#id'] === 'edit-upload')
   ) {
     $variables['prefix'] = t('Please note, only one image can be embedded at a time.');
+
+    // Set cookie to stick file uploads to one server. This cookie is intended
+    // to be set on each file upload, but expire after a day if not reset.
+    // See https://support.acquia.com/hc/en-us/articles/360004147834-Pinning-to-a-web-server-without-using-the-hosts-file#defineacookie
+    $server_name = explode('.', gethostname());
+    if (count($server_name) > 1) {
+      setrawcookie('ah_app_server', rawurlencode($server_name[0]), REQUEST_TIME + 86400, '/');
+    }
   }
 }
 

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -10,8 +10,6 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Site\Settings;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
 use Drupal\views\Views;
-use Symfony\Component\HttpFoundation\Cookie;
-use \Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -230,12 +228,8 @@ function _add_description_display_before(&$variables) {
 function mass_admin_theme_preprocess_form_element(&$variables) {
   _add_description_display_before($variables);
 
-  $response = new Response();
-
   // Remove cookie when in the admin theme to ensure that the cookie is reset.
-  $cookie = new Cookie('ah_app_server', '', REQUEST_TIME - 3600, '/');
-  $response->headers->setCookie($cookie);
-  $response->sendHeaders();
+  setrawcookie('ah_app_server', '', REQUEST_TIME - 3600, '/');
 
   if (isset($variables['element']['#id']) &&
     ($variables['element']['#id'] === 'edit-upload')
@@ -247,9 +241,7 @@ function mass_admin_theme_preprocess_form_element(&$variables) {
     // See https://support.acquia.com/hc/en-us/articles/360004147834-Pinning-to-a-web-server-without-using-the-hosts-file#defineacookie
     $server_name = explode('.', gethostname());
     if (count($server_name) > 1) {
-      $cookie = new Cookie('ah_app_server', rawurlencode($server_name[0]), REQUEST_TIME + 86400, '/');
-      $response->headers->setCookie($cookie);
-      $response->sendHeaders();
+      setrawcookie('ah_app_server', rawurlencode($server_name[0]), REQUEST_TIME + 86400, '/');
     }
   }
 }

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -11,7 +11,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
 use Drupal\views\Views;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpFoundation\Response;
+use \Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements hook_form_FORM_ID_alter().

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -237,7 +237,7 @@ function mass_admin_theme_preprocess_form_element(&$variables) {
     $variables['prefix'] = t('Please note, only one image can be embedded at a time.');
 
     // Set cookie to stick file uploads to one server. This cookie is intended
-    // to be set on each file upload, but expire after a day if not reset.
+    // to be set on each file upload but expire after a day if not reset.
     // See https://support.acquia.com/hc/en-us/articles/360004147834-Pinning-to-a-web-server-without-using-the-hosts-file#defineacookie
     $server_name = explode('.', gethostname());
     if (count($server_name) > 1) {

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -11,7 +11,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
 use Drupal\views\Views;
 use Symfony\Component\HttpFoundation\Cookie;
-use \Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements hook_form_FORM_ID_alter().

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -10,6 +10,8 @@ use Drupal\Core\Render\Element;
 use Drupal\Core\Site\Settings;
 use Drupal\views\Render\ViewsRenderPipelineMarkup;
 use Drupal\views\Views;
+use Symfony\Component\HttpFoundation\Cookie;
+use \Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -228,8 +230,12 @@ function _add_description_display_before(&$variables) {
 function mass_admin_theme_preprocess_form_element(&$variables) {
   _add_description_display_before($variables);
 
+  $response = new Response();
+
   // Remove cookie when in the admin theme to ensure that the cookie is reset.
-  setrawcookie('ah_app_server', '', REQUEST_TIME - 3600, '/');
+  $cookie = new Cookie('ah_app_server', '', REQUEST_TIME - 3600, '/');
+  $response->headers->setCookie($cookie);
+  $response->sendHeaders();
 
   if (isset($variables['element']['#id']) &&
     ($variables['element']['#id'] === 'edit-upload')
@@ -241,7 +247,9 @@ function mass_admin_theme_preprocess_form_element(&$variables) {
     // See https://support.acquia.com/hc/en-us/articles/360004147834-Pinning-to-a-web-server-without-using-the-hosts-file#defineacookie
     $server_name = explode('.', gethostname());
     if (count($server_name) > 1) {
-      setrawcookie('ah_app_server', rawurlencode($server_name[0]), REQUEST_TIME + 86400, '/');
+      $cookie = new Cookie('ah_app_server', rawurlencode($server_name[0]), REQUEST_TIME + 86400, '/');
+      $response->headers->setCookie($cookie);
+      $response->sendHeaders();
     }
   }
 }


### PR DESCRIPTION
**Description:**
See https://support.acquia.com/hc/en-us/articles/360004147834-Pinning-to-a-web-server-without-using-the-hosts-file#defineacookie


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20580


**To Test:**
- [ ] Go to add an info details node
- [ ] Inspect the page, and check that the cookie is not set
- [ ] In the Overview field, select the image upload icon
- [ ] Inspect the page again and verify that the cookie is set with a server name value (might be more validating to test in an Acquia environment in this case)
- [ ] Reload the page, and check that the cookie is no longer set


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
