### PR TITLE
Enable New Relic measument of CLI PHP commands.

### DIFF
--- a/changelogs/DP-13674.yml
+++ b/changelogs/DP-13674.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Enable New Relic metrics for CLI PHP commands.
+    issue: DP-13674

--- a/drush/Commands/NewRelicCommands.php
+++ b/drush/Commands/NewRelicCommands.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drush\Commands;
+
+use Consolidation\AnnotatedCommand\CommandData;
+use Drush\Commands\DrushCommands;
+
+class NewRelicCommands extends DrushCommands
+{
+
+  /**
+   * @hook option *
+   *
+   * @option nr-name New Relic transaction name.
+   */
+  public function optionsetNrName($options = ['nrname' => self::REQ])
+  {
+  }
+
+  /**
+   * Set NR name
+   *
+   * @hook post-command *
+   */
+  public function name($result, CommandData $commandData)
+  {
+    if (!extension_loaded('newrelic')) {
+      return;
+    }
+    $annotationData = $commandData->annotationData();
+    $commandName = $annotationData['command'];
+    $name = $commandData->input()->getOption('nrname') ?: $commandName;
+    newrelic_name_transaction("cli.drush.$name");
+  }
+}

--- a/drush/Commands/NewRelicCommands.php
+++ b/drush/Commands/NewRelicCommands.php
@@ -11,7 +11,7 @@ class NewRelicCommands extends DrushCommands
   /**
    * @hook option *
    *
-   * @option nr-name New Relic transaction name.
+   * @option nrname New Relic transaction name.
    */
   public function optionsetNrName($options = ['nrname' => self::REQ])
   {


### PR DESCRIPTION
Once this goes out, I will visit most of the scheduled jobs and add: 

- ` PHP_INI_SCAN_DIR=~` to the fron of the command, thus loading the newrelic php extension
- Optionally set `--nrname=foo` to clarify what job name shows up at New Relic

**Jira:** (Skip unless you are MA staff)

DP-13674
---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
