### PR TITLE
DP-19699: Allow role changes and other account changes without password change

### DIFF
--- a/changelogs/DP-19699.yml
+++ b/changelogs/DP-19699.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Allow role changes and other account changes without password change.
+    issue: DP-19699

--- a/composer.json
+++ b/composer.json
@@ -313,6 +313,9 @@
                 "Dynamic routes like image styles break under pathologic (https://www.drupal.org/project/pathologic/issues/2718473)": "https://www.drupal.org/files/issues/2018-11-14/2718473-dynamic-image-style-lookup-19.patch",
                 "Convert href to the aliased url if possible (https://www.drupal.org/project/pathologic/issues/2692641#comment-13317616)": "https://www.drupal.org/files/issues/2019-10-20/2692641-15.diff"
             },
+            "drupal/password_policy": {
+                "Can't edit user profile because password policy validates even when password unchanged": "https://www.drupal.org/files/issues/2020-03-19/password_policy-empty-password-skip-validation-2971079-37.patch"
+            },
             "drupal/purge": {
                 "Remove exception during first run in p:queue-work (https://www.drupal.org/project/purge/issues/3101392)": "https://www.drupal.org/files/issues/2019-12-16/empty.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e1d913ae130a47efcefc298b69f6fbb",
+    "content-hash": "942b37dba96270332ac28340bf93f6b9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7146,6 +7146,9 @@
                         "status": "not-covered",
                         "message": "Beta releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Can't edit user profile because password policy validates even when password unchanged": "https://www.drupal.org/files/issues/2020-03-19/password_policy-empty-password-skip-validation-2971079-37.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8489,7 +8492,7 @@
                 "shasum": "c7e3a3757282e4c94e3c1fff08d01e22155cb853"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9"
+                "drupal/core": "^8.8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
@@ -10833,6 +10836,7 @@
                 "source": "https://github.com/mikeyp/google_tag/tree/8.x-1.x",
                 "issues": "https://github.com/mikeyp/google_tag/issues"
             },
+            "abandoned": true,
             "time": "2016-10-17T15:47:26+00:00"
         },
         {
@@ -16037,6 +16041,12 @@
                 }
             ],
             "description": "A PHP SDK for Acquia CloudAPI v2",
+            "funding": [
+                {
+                    "url": "https://github.com/typhonius",
+                    "type": "github"
+                }
+            ],
             "time": "2020-06-01T19:47:03+00:00"
         },
         {

--- a/conf/drupal/config/system.action.user_add_role_action.editor.yml
+++ b/conf/drupal/config/system.action.user_add_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: 498e626a-dab7-4507-a456-bc83b96a0ca8
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_add_role_action.editor
+label: 'Add the Editor role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: editor

--- a/conf/drupal/config/system.action.user_remove_role_action.editor.yml
+++ b/conf/drupal/config/system.action.user_remove_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: f599a547-c5f2-4668-91dc-87d75f8cbaf6
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_remove_role_action.editor
+label: 'Remove the Editor role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: editor


### PR DESCRIPTION
**Description:**
Editor role added to the Bulk actions of the People page, password_policy module patched to allow role changes and other account changes without password change.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19699
