### PR TITLE
DP-21124 Fix issue with header hamburger menu overlapping certain elements

### DIFF
--- a/changelogs/DP-21124.yml
+++ b/changelogs/DP-21124.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Changed:
+Fixed:
   - description: Adjust z-index for the admin tool bar to prevent the Mass.gov heading bar to overwrap.
     issue: DP-21124

--- a/changelogs/DP-21124.yml
+++ b/changelogs/DP-21124.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adjust z-index for the admin tool bar to prevent the Mass.gov heading bar to overwrap.
+    issue: DP-21124

--- a/docroot/modules/custom/mass_admin_toolbar/css/toolbar.theme.css
+++ b/docroot/modules/custom/mass_admin_toolbar/css/toolbar.theme.css
@@ -22,6 +22,7 @@
 .toolbar .toolbar-bar {
   background-color: #a1cab7;
   color: #141414;
+  z-index: 9010;
 }
 .toolbar .toolbar-bar .toolbar-item {
   color: #141414;


### PR DESCRIPTION
**Description:**
Adjust z-index for the admin tool bar to prevent the Mass.gov heading bar to overwrap.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21124


**To Test:**
- [ ] In the admin area, preview any page except for error pages.
- [ ] Scroll up the page toward the admin tool bar and find the Mass.gov heading bar (blue bar) doesn't go on the top of the admin bar.

<img width="990" alt="Statement_of_the_Supreme_Judicial_Court_and_Introduction___Mass_gov_and_toolbar_theme_css_—_openmass" src="https://user-images.githubusercontent.com/9633303/109528843-1a91cf80-7a83-11eb-950e-1f645d9230f5.png">

<img width="661" alt="Statement_of_the_Supreme_Judicial_Court_and_Introduction___Mass_gov" src="https://user-images.githubusercontent.com/9633303/109528859-1d8cc000-7a83-11eb-98ed-dac3fa6bbde9.png">



**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
