### PR TITLE
Dp 21249 re add cache bust querystring param to css js

### DIFF
--- a/changelogs/DP-21249.yml
+++ b/changelogs/DP-21249.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Overriding CSSCollectionRenderer and JsCollectionRenderer services to re-add cache bust querystring parameter to aggregated CSS and JS.
+    issue: DP-21249

--- a/docroot/modules/custom/mass_caching/src/MassCachingCSSCollectionRenderer.php
+++ b/docroot/modules/custom/mass_caching/src/MassCachingCSSCollectionRenderer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\mass_caching;
+
+use Drupal\Core\Asset\AssetCollectionRendererInterface;
+use Drupal\Core\Asset\CssCollectionRenderer;
+
+/**
+ * Renders CSS assets.
+ */
+class MassCachingCSSCollectionRenderer extends CssCollectionRenderer implements AssetCollectionRendererInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(array $css_assets) {
+    $elements = [];
+
+    // A dummy query-string is added to filenames, to gain control over
+    // browser-caching. The string changes on every update or full cache
+    // flush, forcing browsers to load a new copy of the files, as the
+    // URL changed.
+    $query_string = $this->state->get('system.css_js_query_string', '0');
+
+    // Defaults for LINK and STYLE elements.
+    $link_element_defaults = [
+      '#type' => 'html_tag',
+      '#tag' => 'link',
+      '#attributes' => [
+        'rel' => 'stylesheet',
+      ],
+    ];
+
+    foreach ($css_assets as $css_asset) {
+      $element = $link_element_defaults;
+      $element['#attributes']['media'] = $css_asset['media'];
+      $element['#browsers'] = $css_asset['browsers'];
+
+      switch ($css_asset['type']) {
+        // For file items, output a LINK tag for file CSS assets.
+        case 'file':
+          $query_string_separator = (strpos($css_asset['data'], '?') !== FALSE) ? '&' : '?';
+          $element['#attributes']['href'] = file_url_transform_relative(file_create_url($css_asset['data'])) . $query_string_separator . $query_string;
+          break;
+
+        case 'external':
+          $element['#attributes']['href'] = $css_asset['data'];
+          break;
+
+        default:
+          throw new \Exception('Invalid CSS asset type.');
+      }
+
+      // Merge any additional attributes.
+      if (!empty($css_asset['attributes'])) {
+        $element['#attributes'] += $css_asset['attributes'];
+      }
+
+      $elements[] = $element;
+    }
+
+    return $elements;
+  }
+
+}

--- a/docroot/modules/custom/mass_caching/src/MassCachingJSCollectionRenderer.php
+++ b/docroot/modules/custom/mass_caching/src/MassCachingJSCollectionRenderer.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\mass_caching;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Asset\AssetCollectionRendererInterface;
+use Drupal\Core\Asset\JsCollectionRenderer;
+
+/**
+ * Renders CSS assets.
+ */
+class MassCachingJSCollectionRenderer extends JSCollectionRenderer implements AssetCollectionRendererInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function render(array $js_assets) {
+    $elements = [];
+
+    // A dummy query-string is added to filenames, to gain control over
+    // browser-caching. The string changes on every update or full cache
+    // flush, forcing browsers to load a new copy of the files, as the
+    // URL changed. Files that should not be cached get REQUEST_TIME as
+    // query-string instead, to enforce reload on every page request.
+    $default_query_string = $this->state->get('system.css_js_query_string', '0');
+
+    // Defaults for each SCRIPT element.
+    $element_defaults = [
+      '#type' => 'html_tag',
+      '#tag' => 'script',
+      '#value' => '',
+    ];
+
+    // Loop through all JS assets.
+    foreach ($js_assets as $js_asset) {
+      // Element properties that do not depend on JS asset type.
+      $element = $element_defaults;
+      $element['#browsers'] = $js_asset['browsers'];
+
+      // Element properties that depend on item type.
+      switch ($js_asset['type']) {
+        case 'setting':
+          $element['#attributes'] = [
+            // This type attribute prevents this from being parsed as an
+            // inline script.
+            'type' => 'application/json',
+            'data-drupal-selector' => 'drupal-settings-json',
+          ];
+          $element['#value'] = Json::encode($js_asset['data']);
+          break;
+
+        case 'file':
+          $query_string = $js_asset['version'] == -1 ? $default_query_string : 'v=' . $js_asset['version'];
+          $query_string_separator = (strpos($js_asset['data'], '?') !== FALSE) ? '&' : '?';
+          $element['#attributes']['src'] = file_url_transform_relative(file_create_url($js_asset['data'])) . $query_string_separator . ($js_asset['cache'] ? $query_string : REQUEST_TIME);;
+          break;
+
+        case 'external':
+          $element['#attributes']['src'] = $js_asset['data'];
+          break;
+
+        default:
+          throw new \Exception('Invalid JS asset type.');
+      }
+
+      // Attributes may only be set if this script is output independently.
+      if (!empty($element['#attributes']['src']) && !empty($js_asset['attributes'])) {
+        $element['#attributes'] += $js_asset['attributes'];
+      }
+
+      $elements[] = $element;
+    }
+
+    return $elements;
+  }
+
+}

--- a/docroot/modules/custom/mass_caching/src/MassCachingServiceProvider.php
+++ b/docroot/modules/custom/mass_caching/src/MassCachingServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\mass_caching;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\Core\DependencyInjection\ServiceProviderInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Helper Class MassCachingServiceProvider.
+ *
+ * Class to override Drupal core CSSCollectionRenderer
+ * and JsCollectionRenderer services.
+ */
+class MassCachingServiceProvider extends ServiceProviderBase implements ServiceProviderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    // Override CSS collection renderer service.
+    $current_css_service_def = $container->getDefinition('asset.css.collection_renderer');
+    $current_css_service_def->setClass("Drupal\mass_caching\MassCachingCSSCollectionRenderer");
+    $current_css_service_def->addArgument(new Reference("state"));
+
+    // Override JS collection renderer service.
+    $current_js_service_def = $container->getDefinition('asset.js.collection_renderer');
+    $current_js_service_def->setClass("Drupal\mass_caching\MassCachingJSCollectionRenderer");
+    $current_js_service_def->addArgument(new Reference("state"));
+  }
+
+}


### PR DESCRIPTION
**Description:**
Overriding CSSCollectionRenderer and JsCollectionRenderer services to re-add cache bust querystring parameter to aggregated CSS and JS.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21249