### PR TITLE
DP-21375: Prevent default alias for documents with non english titles

### DIFF
--- a/changelogs/DP-21375.yml
+++ b/changelogs/DP-21375.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Updated Pathaut Maximum alias and component lengths to fix non-english blank alias generation issue.
+  - description: Updated Pathauto maximum alias and component lengths to fix non-English blank alias generation issue.
     issue: DP-21375

--- a/changelogs/DP-21375.yml
+++ b/changelogs/DP-21375.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Updated Pathaut Maximum alias and component lengths to fix non-english blank alias generation issue.
+    issue: DP-21375

--- a/conf/drupal/config/pathauto.settings.yml
+++ b/conf/drupal/config/pathauto.settings.yml
@@ -33,8 +33,8 @@ punctuation:
   back_slash: 0
 verbose: false
 separator: '-'
-max_length: 100
-max_component_length: 100
+max_length: 255
+max_component_length: 255
 transliterate: true
 reduce_ascii: false
 case: true
@@ -43,3 +43,4 @@ update_action: 2
 _core:
   default_config_hash: YrQtUD-tjwXmWch1oNpPqr3qb5S17-dXdlKwqhiHjNI
 enabled_entity_types: {  }
+safe_tokens: {  }


### PR DESCRIPTION
**Description:**
Updated Pathaut Maximum alias and component lengths to fix non-english blank alias generation issue.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21375


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
