### PR TITLE
DP-20992: BUG when an advisory is added under featured tasks on service page, it doesn't render right on "see all" page

### DIFF
--- a/changelogs/DP-20992.yml
+++ b/changelogs/DP-20992.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed advisory content type rendering with Title short desription view mode.
+    issue: DP-20992

--- a/conf/drupal/config/core.entity_view_display.node.advisory.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.advisory.title_short_desc.yml
@@ -1,0 +1,78 @@
+uuid: 28fac55e-df9a-4fc4-85fc-953e9cfd3b66
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.advisory.field_advisory_date
+    - field.field.node.advisory.field_advisory_download
+    - field.field.node.advisory.field_advisory_footnotes
+    - field.field.node.advisory.field_advisory_issuer
+    - field.field.node.advisory.field_advisory_links
+    - field.field.node.advisory.field_advisory_listing_desc
+    - field.field.node.advisory.field_advisory_metatags
+    - field.field.node.advisory.field_advisory_overview
+    - field.field.node.advisory.field_advisory_publish_state_tax
+    - field.field.node.advisory.field_advisory_ref_contact
+    - field.field.node.advisory.field_advisory_ref_sources
+    - field.field.node.advisory.field_advisory_section
+    - field.field.node.advisory.field_advisory_type_tax
+    - field.field.node.advisory.field_intended_audience
+    - field.field.node.advisory.field_organizations
+    - field.field.node.advisory.field_reusable_label
+    - field.field.node.advisory.field_state_organization_tax
+    - node.type.advisory
+  module:
+    - user
+id: node.advisory.title_short_desc
+targetEntityType: node
+bundle: advisory
+mode: title_short_desc
+content:
+  field_advisory_listing_desc:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  referencing_binders_page_flipper:
+    type: entity_reference_label
+    weight: 18
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_related_to: true
+  content_moderation_control: true
+  extra_node_all_actions: true
+  extra_node_pager: true
+  extra_org_feedback_form: true
+  field_advisory_date: true
+  field_advisory_download: true
+  field_advisory_footnotes: true
+  field_advisory_issuer: true
+  field_advisory_links: true
+  field_advisory_metatags: true
+  field_advisory_overview: true
+  field_advisory_publish_state_tax: true
+  field_advisory_ref_contact: true
+  field_advisory_ref_sources: true
+  field_advisory_section: true
+  field_advisory_type_tax: true
+  field_intended_audience: true
+  field_organizations: true
+  field_reusable_label: true
+  field_state_organization_tax: true
+  links: true
+  page_next: true
+  page_previous: true
+  referencing_binders: true

--- a/conf/drupal/config/core.entity_view_display.node.decision.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.decision.title_short_desc.yml
@@ -1,0 +1,81 @@
+uuid: e2f0bc54-6b52-408d-992b-49acfa2f70f6
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.decision.field_decision_date
+    - field.field.node.decision.field_decision_docket_number
+    - field.field.node.decision.field_decision_download
+    - field.field.node.decision.field_decision_footnotes
+    - field.field.node.decision.field_decision_listing_desc
+    - field.field.node.decision.field_decision_location
+    - field.field.node.decision.field_decision_metatags
+    - field.field.node.decision.field_decision_overview
+    - field.field.node.decision.field_decision_participants
+    - field.field.node.decision.field_decision_ref_contact
+    - field.field.node.decision.field_decision_ref_organization
+    - field.field.node.decision.field_decision_ref_type
+    - field.field.node.decision.field_decision_related
+    - field.field.node.decision.field_decision_section
+    - field.field.node.decision.field_decision_sources
+    - field.field.node.decision.field_intended_audience
+    - field.field.node.decision.field_organizations
+    - field.field.node.decision.field_reusable_label
+    - field.field.node.decision.field_state_organization_tax
+    - node.type.decision
+  module:
+    - user
+id: node.decision.title_short_desc
+targetEntityType: node
+bundle: decision
+mode: title_short_desc
+content:
+  field_decision_listing_desc:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  referencing_binders_page_flipper:
+    type: entity_reference_label
+    weight: 19
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_related_to: true
+  content_moderation_control: true
+  extra_node_pager: true
+  extra_org_feedback_form: true
+  field_decision_date: true
+  field_decision_docket_number: true
+  field_decision_download: true
+  field_decision_footnotes: true
+  field_decision_location: true
+  field_decision_metatags: true
+  field_decision_overview: true
+  field_decision_participants: true
+  field_decision_ref_contact: true
+  field_decision_ref_organization: true
+  field_decision_ref_type: true
+  field_decision_related: true
+  field_decision_section: true
+  field_decision_sources: true
+  field_intended_audience: true
+  field_organizations: true
+  field_reusable_label: true
+  field_state_organization_tax: true
+  links: true
+  page_next: true
+  page_previous: true
+  referencing_binders: true

--- a/conf/drupal/config/core.entity_view_display.node.decision_tree.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.decision_tree.title_short_desc.yml
@@ -1,0 +1,47 @@
+uuid: fff03aac-da56-4a2c-9903-b0f79bba3062
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.decision_tree.field_bg_narrow
+    - field.field.node.decision_tree.field_bg_wide
+    - field.field.node.decision_tree.field_campaign_logo
+    - field.field.node.decision_tree.field_decision_tree_metatags
+    - field.field.node.decision_tree.field_description
+    - field.field.node.decision_tree.field_disclaimer
+    - field.field.node.decision_tree.field_organizations
+    - field.field.node.decision_tree.field_reusable_label
+    - field.field.node.decision_tree.field_service_ref_services_6
+    - field.field.node.decision_tree.field_start_button
+    - field.field.node.decision_tree.field_state_organization_tax
+    - node.type.decision_tree
+  module:
+    - user
+id: node.decision_tree.title_short_desc
+targetEntityType: node
+bundle: decision_tree
+mode: title_short_desc
+content:
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_log_in_links: true
+  computed_related_to: true
+  content_moderation_control: true
+  extra_org_feedback_form: true
+  field_bg_narrow: true
+  field_bg_wide: true
+  field_campaign_logo: true
+  field_decision_tree_metatags: true
+  field_description: true
+  field_disclaimer: true
+  field_organizations: true
+  field_reusable_label: true
+  field_service_ref_services_6: true
+  field_start_button: true
+  field_state_organization_tax: true
+  links: true

--- a/conf/drupal/config/core.entity_view_display.node.executive_order.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.executive_order.title_short_desc.yml
@@ -1,0 +1,77 @@
+uuid: c73b7845-1e6b-4f66-950e-9615d67e7f7e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.executive_order.body
+    - field.field.node.executive_order.field_exec_order_listing_desc
+    - field.field.node.executive_order.field_executive_order_adjustment
+    - field.field.node.executive_order.field_executive_order_contact
+    - field.field.node.executive_order.field_executive_order_date
+    - field.field.node.executive_order.field_executive_order_downloads
+    - field.field.node.executive_order.field_executive_order_issuer
+    - field.field.node.executive_order.field_executive_order_mass_regis
+    - field.field.node.executive_order.field_executive_order_metatags
+    - field.field.node.executive_order.field_executive_order_number
+    - field.field.node.executive_order.field_executive_order_overview
+    - field.field.node.executive_order.field_executive_order_related
+    - field.field.node.executive_order.field_executive_title
+    - field.field.node.executive_order.field_intended_audience
+    - field.field.node.executive_order.field_organizations
+    - field.field.node.executive_order.field_reusable_label
+    - field.field.node.executive_order.field_state_organization_tax
+    - node.type.executive_order
+  module:
+    - user
+id: node.executive_order.title_short_desc
+targetEntityType: node
+bundle: executive_order
+mode: title_short_desc
+content:
+  field_exec_order_listing_desc:
+    type: string
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  referencing_binders_page_flipper:
+    type: entity_reference_label
+    weight: 18
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  body: true
+  computed_related_to: true
+  content_moderation_control: true
+  extra_node_pager: true
+  extra_org_feedback_form: true
+  field_executive_order_adjustment: true
+  field_executive_order_contact: true
+  field_executive_order_date: true
+  field_executive_order_downloads: true
+  field_executive_order_issuer: true
+  field_executive_order_mass_regis: true
+  field_executive_order_metatags: true
+  field_executive_order_number: true
+  field_executive_order_overview: true
+  field_executive_order_related: true
+  field_executive_title: true
+  field_intended_audience: true
+  field_organizations: true
+  field_reusable_label: true
+  field_state_organization_tax: true
+  links: true
+  page_next: true
+  page_previous: true
+  referencing_binders: true

--- a/conf/drupal/config/core.entity_view_display.node.regulation.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.regulation.title_short_desc.yml
@@ -1,0 +1,81 @@
+uuid: d25d5470-0292-4e72-bb2c-a8a48091691e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.regulation.field_intended_audience
+    - field.field.node.regulation.field_organizations
+    - field.field.node.regulation.field_regluation_official_ver
+    - field.field.node.regulation.field_regulation_agency_cmr
+    - field.field.node.regulation.field_regulation_cmr_chapter
+    - field.field.node.regulation.field_regulation_contact
+    - field.field.node.regulation.field_regulation_download
+    - field.field.node.regulation.field_regulation_last_updated
+    - field.field.node.regulation.field_regulation_link_org
+    - field.field.node.regulation.field_regulation_listing_desc
+    - field.field.node.regulation.field_regulation_metatags
+    - field.field.node.regulation.field_regulation_ref_state_tax
+    - field.field.node.regulation.field_regulation_reg_authority
+    - field.field.node.regulation.field_regulation_related
+    - field.field.node.regulation.field_regulation_section
+    - field.field.node.regulation.field_regulation_short_descr
+    - field.field.node.regulation.field_regulation_title
+    - field.field.node.regulation.field_reusable_label
+    - field.field.node.regulation.field_state_organization_tax
+    - node.type.regulation
+  module:
+    - user
+id: node.regulation.title_short_desc
+targetEntityType: node
+bundle: regulation
+mode: title_short_desc
+content:
+  field_regulation_listing_desc:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  referencing_binders_page_flipper:
+    type: entity_reference_label
+    weight: 22
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_related_to: true
+  content_moderation_control: true
+  extra_node_pager: true
+  extra_org_feedback_form: true
+  field_intended_audience: true
+  field_organizations: true
+  field_regluation_official_ver: true
+  field_regulation_agency_cmr: true
+  field_regulation_cmr_chapter: true
+  field_regulation_contact: true
+  field_regulation_download: true
+  field_regulation_last_updated: true
+  field_regulation_link_org: true
+  field_regulation_metatags: true
+  field_regulation_ref_state_tax: true
+  field_regulation_reg_authority: true
+  field_regulation_related: true
+  field_regulation_section: true
+  field_regulation_short_descr: true
+  field_regulation_title: true
+  field_reusable_label: true
+  field_state_organization_tax: true
+  links: true
+  page_next: true
+  page_previous: true
+  referencing_binders: true

--- a/conf/drupal/config/core.entity_view_display.node.rules.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.rules.title_short_desc.yml
@@ -1,0 +1,87 @@
+uuid: 06d09ddd-60b5-4ba2-abc2-2d3ce6e846ae
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.title_short_desc
+    - field.field.node.rules.field_intended_audience
+    - field.field.node.rules.field_organizations
+    - field.field.node.rules.field_reusable_label
+    - field.field.node.rules.field_rules_adopted_date
+    - field.field.node.rules.field_rules_courts
+    - field.field.node.rules.field_rules_download
+    - field.field.node.rules.field_rules_effective_date
+    - field.field.node.rules.field_rules_footnotes
+    - field.field.node.rules.field_rules_listing_desc
+    - field.field.node.rules.field_rules_metatags
+    - field.field.node.rules.field_rules_overview
+    - field.field.node.rules.field_rules_ref_contact
+    - field.field.node.rules.field_rules_referenced_sources
+    - field.field.node.rules.field_rules_related
+    - field.field.node.rules.field_rules_related_collections
+    - field.field.node.rules.field_rules_section
+    - field.field.node.rules.field_rules_standing
+    - field.field.node.rules.field_rules_status
+    - field.field.node.rules.field_rules_subheading
+    - field.field.node.rules.field_rules_type
+    - field.field.node.rules.field_rules_updates
+    - field.field.node.rules.field_state_organization_tax
+    - node.type.rules
+  module:
+    - user
+id: node.rules.title_short_desc
+targetEntityType: node
+bundle: rules
+mode: title_short_desc
+content:
+  field_rules_listing_desc:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  referencing_binders_page_flipper:
+    type: entity_reference_label
+    weight: 22
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_related_to: true
+  content_moderation_control: true
+  extra_node_pager: true
+  extra_org_feedback_form: true
+  field_intended_audience: true
+  field_organizations: true
+  field_reusable_label: true
+  field_rules_adopted_date: true
+  field_rules_courts: true
+  field_rules_download: true
+  field_rules_effective_date: true
+  field_rules_footnotes: true
+  field_rules_metatags: true
+  field_rules_overview: true
+  field_rules_ref_contact: true
+  field_rules_referenced_sources: true
+  field_rules_related: true
+  field_rules_related_collections: true
+  field_rules_section: true
+  field_rules_standing: true
+  field_rules_status: true
+  field_rules_subheading: true
+  field_rules_type: true
+  field_rules_updates: true
+  field_state_organization_tax: true
+  links: true
+  page_next: true
+  page_previous: true
+  referencing_binders: true

--- a/docroot/themes/custom/mass_theme/templates/content/node--advisory--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--advisory--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--decision--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--decision--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--decision-tree--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--decision-tree--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--executive-order--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--executive-order--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--regulation--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--regulation--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--rules--title-short-desc.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--rules--title-short-desc.html.twig
@@ -1,0 +1,87 @@
+{#
+/**
+ * @file
+ * Theme override to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status.d Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ */
+#}
+{% include "@molecules/image-promo.twig" with {
+  "imagePromo": {
+    "title": {
+      "text": node.title.value,
+      "href": url,
+      "info": ""
+    },
+    "description": {
+      "rteElements": [{
+        "path": "@atoms/11-text/paragraph.twig",
+        "data": {
+          "paragraph" : {
+            "text": content|render
+          }
+        }
+      }]
+    },
+  }
+} %}


### PR DESCRIPTION
**Description:**
Added title short description view mode and configured for advisory content type.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20992


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
