### PR TITLE
DP-21454 Added --no-tablespaces option during sql:dump

### DIFF
--- a/changelogs/DP-21454.yml
+++ b/changelogs/DP-21454.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Added --no-tablespaces option during sql:dump
+  - description: "Added --no-tablespaces option during sql:dump"
     issue: DP-21454

--- a/changelogs/DP-21454.yml
+++ b/changelogs/DP-21454.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Added --no-tablespaces option during sql:dump
+    issue: DP-21454

--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -6,6 +6,7 @@ command:
     dump:
       options:
         structure-tables-key: common
+        extra-dump: '--no-tablespaces'
   core:
     rsync:
       options:


### PR DESCRIPTION
**Description:**
Fixes a release error https://mass-digital.slack.com/archives/GCBUXFXT8/p1615941846006000 that was introduced by mysql upgrade at Acquia. Also see https://github.com/drush-ops/drush/issues/4489


**Jira:** (Skip unless you are MA staff)
DP-21454


**To Test:**
- [ ] Run `drush sql:dump`. If it doesn't immediately error its fine.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
