### PR TITLE
DP-21464: Half-width image renders as full width in rich text with no alignment

### DIFF
--- a/changelogs/DP-21464.yml
+++ b/changelogs/DP-21464.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Rich Text images set to half-width with no alignment now have a width of 50%.
+    issue: DP-21464

--- a/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
@@ -39,6 +39,9 @@ figure figcaption {
     margin-left: .5em;
     margin-bottom: 1em;
   }
+  article.align-right {
+    margin-left: 50px;
+  }
   .align-left {
     float: left;
     margin-right: .5em;

--- a/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
@@ -31,16 +31,17 @@ figure figcaption {
 }
 
 @media (min-width: 621px) {
+  article[data-entity-embed-display-settings="embedded_half_width"] {
+    width: 50%;
+  }
   .align-right {
     float: right;
     margin-left: .5em;
     margin-bottom: 1em;
-    width: 50%;
   }
   .align-left {
     float: left;
     margin-right: .5em;
     margin-bottom: 1em;
-    width: 50%;
   }
 }


### PR DESCRIPTION
Moved the desktop width CSS from the **right-align** and **left-align** classes to **article[data-entity-embed-display-settings="embedded_half_width"]**.

**Description:**
CSS change to the mass_theme overrides CSS.


**Jira:**
https://jira.mass.gov/browse/DP-21464


**To Test:**
- [ ] Copy the Content Rich Text markup from https://massgovfeature4.prod.acquia-sites.com/info-details/what-to-do-if-you-received-a-massnotify-exposure-notification to an Info Detail node.
- [ ] Verify the image as half-width and alignment set to none is showing at 50% width.
- [ ] Verify the right-aligned and left-aligned images below are also still at 50% width.

**Screenshots/GIFs:**
Feature4:
![feature4_half-width_align-none](https://user-images.githubusercontent.com/1434979/112059084-cb930380-8b31-11eb-8023-6e8724319807.png)
Fixed:
![local_half-width_align-none](https://user-images.githubusercontent.com/1434979/112059115-d2ba1180-8b31-11eb-84a6-ae2f6ac41d9c.png)

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
