### PR TITLE
DP-21457: Fix htmlspecialchars errors on iframe templates

### DIFF
--- a/changelogs/DP-21457.yml
+++ b/changelogs/DP-21457.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed the htmlspecialchars() PHP warning for iframe paragraph captions.
+    issue: DP-21457

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--iframe.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--iframe.html.twig
@@ -38,8 +38,8 @@
 #}
 {% set caption = {
   '#type':   'processed_text',
-  '#text':    paragraph.field_iframe_caption.value,
-  '#format':  paragraph.field_iframe_caption.format,
+  '#text':    paragraph.field_iframe_caption.value ?: '',
+  '#format':  paragraph.field_iframe_caption.format ?: 'basic_html',
 } %}
 
 {% include "@atoms/09-media/figure--iframe.twig" with {


### PR DESCRIPTION
**Description:**
Added some fallback values for field_iframe_caption in the iframe paragraph theme template to fix the htmlspecialchars() PHP warning.


**Jira:**
https://jira.mass.gov/browse/DP-21457


**To Test:**
- [ ] Visit a page with an iframe paragraph. Example: /info-details/example-in-lieu-fee-program-projects
Verify there is no htmlspecialchars() warning message.
- [ ] Visit a page with an iframe with captions set. Example: /info-details/about-covid-19-federal-funds
Verify the captions display and there is no warning message.


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
