### PR TITLE
DP-21034 login error message type

### DIFF
--- a/changelogs/DP-21034.yml
+++ b/changelogs/DP-21034.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
+    issue: DP-****

--- a/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
@@ -24,8 +24,6 @@
 {{ attach_library('classy/messages') }}
 {% block messages %}
 {% for type, messages in message_list %}
-
-<h2>{{ type }}</h2>
   {# Override 'type' for the "Unrecognized username or password" message to 'error.' #}
   {% if 'Unrecognized username' in messages|first|striptags %}
     {% set type = 'error' %}

--- a/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
@@ -24,6 +24,12 @@
 {{ attach_library('classy/messages') }}
 {% block messages %}
 {% for type, messages in message_list %}
+
+<h2>{{ type }}</h2>
+  {# Override 'type' for the "Unrecognized username or password" message to 'error.' #}
+  {% if 'Unrecognized username' in messages|first|striptags %}
+    {% set type = 'error' %}
+  {% endif %}
   {%
     set classes = [
       'messages',


### PR DESCRIPTION
**Description:**
Override the message type "status" with "error" for the message "Unrecognized username or password."
The messages are configured in core.  Instead of touching core, override the type for the particular message.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21034


**To Test:**
- [ ] Go to the login page and type in incorrect user name and password to cause the login error.
- [ ] Find the error message is in a red box for _error_ instead of green for _status_.


**Screenshots/GIFs:**
<img width="736" alt="error-style" src="https://user-images.githubusercontent.com/9633303/114460070-4be7da00-9baf-11eb-9f4e-d583b4985f3c.png">


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
