### PR TITLE
DP-21662: Adjust format of how labels come over from metadata API

### DIFF
--- a/changelogs/DP-21662.yml
+++ b/changelogs/DP-21662.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Adjust format of how labels come over from metadata API
+    issue: DP-21662

--- a/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
+++ b/docroot/modules/custom/mass_content_api/src/Plugin/rest/resource/ContentMetadataResource.php
@@ -141,11 +141,10 @@ class ContentMetadataResource extends ResourceBase implements ContainerFactoryPl
         $l_refs = $item->field_reusable_label->referencedEntities();
         if (!empty($l_refs)) {
           foreach ($l_refs as $l_ref) {
-            $label = (object) [
+            $labels[] = [
               'id' => $l_ref->id(),
               'name' => $l_ref->label(),
             ];
-            $labels[] = JSON::encode($label);
           }
         }
       }


### PR DESCRIPTION
**Description:**
The labels in the content metadata API were a JSON encoded string. Instead, they should be an array of objects.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21662


**To Test:**
- Log into an environment
- Go to /api/v1/content-metadata?content_types=org_page&published=1&depth=0
- Ctrl+F for labels":["
- If there are results, it means it's a JSON encoded string and is therefore wrong.
- Ctrl+F for labels":[{
- If there are results, this means it's correctly encoded.

Alternatively, you could use a command like 

```
curl 'http://edit.mass.gov/api/v1/content-metadata?content_types=org_page&published=1&depth=0' \
   -H 'Cookie: your_logged_in_cookie_value' | jq '.data[] | select(.labels | length > 0) | .labels'
```

The correct output would be something in the following format:

```
[
  {
    "id": "82971",
    "name": "HRD-CSU-ANALYTICS"
  }
]

```

**Screenshots/GIFs:**
n/a

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
