### PR TITLE
Added deployment for unpublished header media items - DP-21704

### DIFF
--- a/changelogs/DP-21704.yml
+++ b/changelogs/DP-21704.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Migrate unpublished header media image fields to use image wrapping field defaults.
+    issue: DP-21704

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -262,11 +262,11 @@ function mass_content_deploy_image_section_fields_followup(&$sandbox) {
 /**
  * Migrate followup for Header Media image fields.
  */
-function mass_content_deploy_header_media_images_followup(&$sandbox) {
+function mass_content_deploy_header_media_images_followup(&$sandbox, $status = 1) {
   $_ENV['MASS_FLAGGING_BYPASS'] = TRUE;
 
   $query = \Drupal::entityQuery('node')
-    ->condition('status', 1)
+    ->condition('status', $status)
     ->condition('type', 'info_details')
     ->condition('field_info_details_header_media.entity:paragraph.field_image.target_id', "", "!=");
 
@@ -316,4 +316,11 @@ function mass_content_deploy_header_media_images_followup(&$sandbox) {
   if ($sandbox['#finished'] >= 1) {
     return t('All Header Media image caption fields migrated.');
   }
+}
+
+/**
+ * Migrate unpublished Header Media image wrapping fields.
+ */
+function mass_content_deploy_header_media_images_unpublished(&$sandbox) {
+  mass_content_deploy_header_media_images_followup($sandbox, 0);
 }

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -262,11 +262,10 @@ function mass_content_deploy_image_section_fields_followup(&$sandbox) {
 /**
  * Migrate followup for Header Media image fields.
  */
-function mass_content_deploy_header_media_images_followup(&$sandbox, $status = 1) {
+function mass_content_deploy_header_media_images_followup(&$sandbox) {
   $_ENV['MASS_FLAGGING_BYPASS'] = TRUE;
 
   $query = \Drupal::entityQuery('node')
-    ->condition('status', $status)
     ->condition('type', 'info_details')
     ->condition('field_info_details_header_media.entity:paragraph.field_image.target_id', "", "!=");
 
@@ -322,5 +321,5 @@ function mass_content_deploy_header_media_images_followup(&$sandbox, $status = 1
  * Migrate unpublished Header Media image wrapping fields.
  */
 function mass_content_deploy_header_media_images_unpublished(&$sandbox) {
-  mass_content_deploy_header_media_images_followup($sandbox, 0);
+  mass_content_deploy_header_media_images_followup($sandbox);
 }

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -318,8 +318,8 @@ function mass_content_deploy_header_media_images_followup(&$sandbox) {
 }
 
 /**
- * Migrate unpublished Header Media image wrapping fields.
+ * Migrate both published and unpublished Header Media image wrapping fields.
  */
-function mass_content_deploy_header_media_images_unpublished(&$sandbox) {
+function mass_content_deploy_header_media_images_all(&$sandbox) {
   mass_content_deploy_header_media_images_followup($sandbox);
 }


### PR DESCRIPTION
**Description:**
The migration of header media image wrapping fields missed migrating unpublished nodes. These fields are not editable by authors, so these fields should match the defaults for both published and unpublished content.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21704


**To Test:**
- [ ] Pull down a fresh database. Do not run ahoy updatedb yet.
- [ ] Log in and go to to http://mass.local/info-details/summary-of-the-methodology-for-the-investigation-of-the-drug-laboratory-at-the-william-a-hinton-state-laboratory-investigative-process---unpublished?auHash=Pxu_czkyEaOaZ6hw0g6DkZXbF7Vc_Mm1YVYWP0SzqYM. Note that the header image does not extend the full width of the content area.
- [ ] Run ahoy updatedb.
- [ ] Check the page linked above again. Verify that the header image extends the full width of the content area.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
