### PR TITLE
DP-21682: Configure links on info details pages acting as landing pages to be in descendent manager

### DIFF
--- a/changelogs/DP-21682.yml
+++ b/changelogs/DP-21682.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update the info_details config to add additional fields to descendant manager 'pages linking here' section.
+    issue: DP-21682

--- a/conf/drupal/config/node.type.info_details.yml
+++ b/conf/drupal/config/node.type.info_details.yml
@@ -38,6 +38,8 @@ third_party_settings:
       - field_info_details_sections>field_section_long_form_addition>field_links_downloads_down
       - field_contact
       - field_info_details_sections>field_section_long_form_content>field_body
+      - field_info_details_sections>field_section_long_form_content>field_card>field_card_link
+      - field_info_details_sections>field_section_long_form_content>field_link
       - field_info_details_sections>field_section_long_form_content>field_card>field_content
       - field_info_details_sections>field_section_long_form_content>field_tabl_caption
       - field_footnotes

--- a/docroot/modules/custom/mass_content_api/mass_content_api.deploy.php
+++ b/docroot/modules/custom/mass_content_api/mass_content_api.deploy.php
@@ -63,3 +63,31 @@ function mass_content_api_deploy_queue_contact_related_nodes_for_save() {
   }
   print('Queued ' . count($nids) . ' nodes for re-indexing to Descendants table.');
 }
+
+/**
+ * Queue nodes to be saved.
+ *
+ * Updating info_details content type with linking pages.
+ */
+function mass_content_api_deploy_queue_info_details_nodes_for_save() {
+  $_ENV['MASS_FLAGGING_BYPASS'] = TRUE;
+
+  $bundles = [
+    'info_details',
+  ];
+
+  $nids = \Drupal::entityQuery('node')
+    ->condition('type', $bundles, 'IN')
+    ->sort('nid')
+    ->execute();
+  /** @var Drupal\Core\Queue\QueueFactory $queue_factory */
+  $queue_factory = \Drupal::service('queue');
+  /** @var Drupal\Core\Queue\QueueInterface $queue */
+  $descendant_queue = $queue_factory->get('mass_content_api_descendant_queue');
+  // The descendant queue requires full node loads, which we'd like to batch.
+  // Queue these up in chunks of 150 so they run through faster.
+  foreach (array_chunk($nids, 150) as $chunk) {
+    $descendant_queue->createItem((object) ['ids' => $chunk]);
+  }
+  print('Queued ' . count($nids) . ' nodes for re-indexing to Descendants table.');
+}


### PR DESCRIPTION
**Description:**
Added fileds to the info_details content type config, queued nodes for re-indexing in descendent manager.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21682


**To Test:**
- [ ] ahoy drush queue:run mass_content_api_descendant_queue 


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
