### PR TITLE
DP-6360: DEV A11y - change directions links in location listings pages to not all have same link label/title

### DIFF
--- a/changelogs/DP-6360.yml
+++ b/changelogs/DP-6360.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changed directions links in location listings pages to not all have same link label/title.
+    issue: DP-6360

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -230,6 +230,7 @@ class MapLocationFetcher {
         'href' => 'https://www.google.com/maps/place/' . $locations['imagePromos']['items'][$key]['location']['text'],
         'type' => "external",
         'info' => '',
+        'labelContext' => t('to @location', ['@location' => $locations['imagePromos']['items'][$key]['location']['text']]),
       ];
 
       if (!$node->field_ref_contact_info_1->isEmpty()) {

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -230,7 +230,7 @@ class MapLocationFetcher {
         'href' => 'https://www.google.com/maps/place/' . $locations['imagePromos']['items'][$key]['location']['text'],
         'type' => "external",
         'info' => '',
-        'labelContext' => t('to @location', ['@location' => $locations['imagePromos']['items'][$key]['location']['text']]),
+        'labelContext' => t('to @location', ['@location' => $node->getTitle()]),
       ];
 
       if (!$node->field_ref_contact_info_1->isEmpty()) {


### PR DESCRIPTION
**Description:**
Passed the labelContext variable to populate the required markup.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-6360


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
