### PR TITLE
DP-21745 - Address memory limit issues with language_terms migration

### DIFF
--- a/changelogs/DP-21745.yml
+++ b/changelogs/DP-21745.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Addressed memory issues with Media translations migration.
+    issue: DP-21745

--- a/docroot/modules/custom/mass_translations/mass_translations.deploy.php
+++ b/docroot/modules/custom/mass_translations/mass_translations.deploy.php
@@ -28,12 +28,14 @@ function mass_translations_deploy_language_terms(&$sandbox) {
     $sandbox['max'] = $count->count()->execute();
   }
 
-  $batch_size = 1000;
+  $batch_size = 100;
 
   $mids = $query->condition('mid', $sandbox['current'], '>')
     ->sort('mid')
     ->range(0, $batch_size)
     ->execute();
+
+  $memory_cache = \Drupal::service('entity.memory_cache');
 
   $media_storage = \Drupal::entityTypeManager()->getStorage('media');
 
@@ -76,6 +78,8 @@ function mass_translations_deploy_language_terms(&$sandbox) {
 
     $sandbox['progress']++;
   }
+
+  $memory_cache->deleteAll();
 
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
   if ($sandbox['#finished'] >= 1) {

--- a/docroot/modules/custom/mass_translations/mass_translations.deploy.php
+++ b/docroot/modules/custom/mass_translations/mass_translations.deploy.php
@@ -18,7 +18,7 @@ function mass_translations_deploy_language_terms(&$sandbox) {
 
   $query = \Drupal::entityQuery('media')
     ->condition('bundle', 'document')
-    ->condition('field_language.target_id', $english_target_id, "!=")
+    ->condition('field_language.target_id', $english_target_id, '!=')
     ->condition('field_upload_file.target_id', '', '!=');
 
   if (empty($sandbox)) {


### PR DESCRIPTION
**Description:**
This PR addresses memory leaking issues the language_terms migration. I would expect with a Batch API implementation that each batch would run as its own process and release resources with each process, but I'm unsure if that's actually happening, since memory usage gradually increases as the migration runs. This change addresses the issue by running `memory_cache->deleteAll();` with each run. I also decreased the batch size, but that shouldn't really impact overall memory usage much either way.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21745


**To Test:**
- [ ] Run locally. Monitor drupal container memory usage at portainer.mass.local. Memory should not exceed 500MB.

**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
