### PR TITLE
DP-21733: Attach workflow to external data resource content type

### DIFF
--- a/changelogs/DP-21733.yml
+++ b/changelogs/DP-21733.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Exposed the Moderation State field in the External Data Resource node form so nodes can be published.
+    issue: DP-21733

--- a/conf/drupal/config/core.entity_form_display.node.external_data_resource.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.external_data_resource.default.yml
@@ -11,7 +11,9 @@ dependencies:
     - field.field.node.external_data_resource.field_externaldata_url
     - field.field.node.external_data_resource.field_organizations
     - node.type.external_data_resource
+    - workflows.workflow.editorial
   module:
+    - content_moderation
     - field_group
     - link
     - scheduler
@@ -39,7 +41,6 @@ third_party_settings:
         - field_data_resource_type
         - field_data_format
         - field_data_topic
-        - field_data_sub_topic
       parent_name: group_externaldata_edit_form
       weight: 0
       format_type: tab
@@ -136,15 +137,21 @@ content:
     settings:
       include_locked: true
     third_party_settings: {  }
+  moderation_state:
+    type: moderation_state_default
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 2
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: options_select
-    weight: 4
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -173,19 +180,18 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 3
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: options_select
-    weight: 5
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }
 hidden:
   created: true
-  moderation_state: true
   path: true
   promote: true
   status: true

--- a/conf/drupal/config/node.type.external_data_resource.yml
+++ b/conf/drupal/config/node.type.external_data_resource.yml
@@ -16,12 +16,12 @@ third_party_settings:
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab
-    publish_enable: false
+    publish_enable: true
     publish_past_date: error
     publish_required: false
     publish_revision: true
     publish_touch: false
-    unpublish_enable: false
+    unpublish_enable: true
     unpublish_required: false
     unpublish_revision: true
   mass_admin_pages:


### PR DESCRIPTION
**Description:**
Exposed the Moderation State field in the External Data Resource node form so nodes can be published.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21733


**To Test:**
- [ ] Login and go to /node/add/external_data_resource.
- [ ] Verify there is a Save As field with states to select.
- [ ] Complete required fields and save a published node.
- [ ] Verify that you cannot view the node page as an anonymous user.


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
