### PR TITLE
DP-21691 main nav labels

### DIFF
--- a/changelogs/DP-21691.yml
+++ b/changelogs/DP-21691.yml
@@ -1,0 +1,44 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Replace h2 with div keeping its aria-labelledby for the main nav.
+
+Removed:
+  - description: Removed deplicated mobile version header + navigation components for the horizontal nav.
+    issue: DP-21691

--- a/changelogs/DP-21691.yml
+++ b/changelogs/DP-21691.yml
@@ -38,6 +38,7 @@
 #
 Changed:
   - description: Replace h2 with div keeping its aria-labelledby for the main nav.
+    issue: DP-21691
 
 Removed:
   - description: Removed deplicated mobile version header + navigation components for the horizontal nav.

--- a/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation-2.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation-2.html.twig
@@ -31,7 +31,10 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
-{# Mix for Home page - horizontal main nav for desktop + hamburger menu for mobile  #}
+{# Mix main navigations for Home page - horizontal main nav for desktop + hamburger menu for mobile
+Desktop horizontal main nav is added by themes/custom/mass_theme/templates/block/block--mainnavigation-2.html.twig
+in the following block to this.
+#}
 {% set ariaLabel = heading_id ?? 'main-navigation-heading' %}
 <nav class="ma__header__hamburger__nav" aria-labelledby="{{ ariaLabel }}" id="main-navigation" role="navigation">
   <div class="ma__header__hamburger-wrapper">
@@ -63,7 +66,7 @@
       {% set title_attributes = title_attributes.addClass('visually-hidden') %}
     {% endif %}
     {{ title_prefix }}
-    <h2{{ title_attributes.setAttribute('id', ariaLabel) }}>{{ configuration.label }}</h2>
+    <div{{ title_attributes.setAttribute('id', ariaLabel) }}>{{ configuration.label }}</div>
     {{ title_suffix }}
 
     <div class="ma__header__hamburger__nav-container" aria-hidden="true">

--- a/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation-3.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation-3.html.twig
@@ -63,7 +63,7 @@
       {% set title_attributes = title_attributes.addClass('visually-hidden') %}
     {% endif %}
     {{ title_prefix }}
-    <h2{{ title_attributes.setAttribute('id', ariaLabel) }}>{{ configuration.label }}</h2>
+    <div{{ title_attributes.setAttribute('id', ariaLabel) }}>{{ configuration.label }}</div>
     {{ title_suffix }}
 
     <div class="ma__header__hamburger__nav-container" aria-hidden="true">

--- a/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/block/block--mainnavigation.html.twig
@@ -31,67 +31,19 @@
  * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
  */
 #}
+{# This is the horizontal navigation component.
+   In Home page, this block is placed after
+   themes/custom/mass_theme/templates/block/block--mainnavigation-2.html.twig.
+   It should only contains the horizontal main navigation, no utlity nav, no search, no logo.
+#}
 {% set ariaLabel = heading_id ?? 'main-navigation-heading' %}
 <nav class="ma__header__nav" role="navigation" aria-labelledby="{{ ariaLabel }}" id="main-navigation">
-
-
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', ariaLabel) }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
-  <div class="ma__header__button-container js-sticky-header">
-    <button type="button" class="ma__header__back-button js-close-sub-nav"><span>Back</span></button>
-    <button type="button"
-            aria-expanded="false"
-            aria-label="Open the main menu for mass.gov"
-            class="ma__header__menu-button js-header-menu-button">
-      <span>Menu</span><span class="ma__header__menu-icon"></span>
-
-      {# Menu label with screen size greater than 620px. #}
-      {# <span class="ma__header__hamburger__menu-text ma__header__hamburger__desktop-label js-header__menu-text">Menu</span> #}
-      {# Menu label with screen size less than 620px. #}
-      {# <span class="ma__header__hamburger__menu-text ma__header__hamburger__mobile-label js-header__menu-text">Mass.gov</span> #}
-
-    </button>
-
-    {# Skip button to search. #}
-    {# <button type="button"
-            aria-expanded="false"
-            class="ma__header__hamburger__search-access-button js-header-search-access-button">
-      <span class="ma__visually-hidden">Access to search</span>
-      {{ icon('search') }}
-    </button> #}
-
-  </div>
-
-  {# 2 NARROW UTILITY NAVS? #}
-  <div class="ma__header__utility-nav ma__header__utility-nav--narrow js-utility-nav--narrow">
-    {{ render_menu('utility') }}
-  </div>
-  {#
-  <div class="ma__header__hamburger__utility-nav ma__header__hamburger__utility-nav--wide js-utility-nav--wide">
-    {{ render_menu('utility') }}
-  </div>
-  #}
-
   <div class="ma__header__nav-container">
-    <div class="ma__header__nav-search">
-      <section class="ma__header-search">
-        {% include directory ~ "/templates/includes/molecules-header-search.html.twig" with { 'searchFormId': "cse-header-search-form" } %}
-      </section>
-    </div>
     <div class="ma__header__main-nav">
       {# Main Menu aka Topic Menu #}
       {% block content %}
         {{ content }}
       {% endblock %}
-    </div>
-    <div class="ma__header__utility-nav ma__header__utility-nav--narrow js-utility-nav--narrow">
-      {{ render_menu('utility') }}
     </div>
   </div>
 </nav>


### PR DESCRIPTION
**Description:**

- Replace `<h2 class="visually-hidden" id="main-navigation-heading">Main navigation</h2>` with `aria-label` for the main navigation components (`nav.ma__header__hamburger__nav` and `nav.ma__header__nav`).
- Re-label the components with more proper labels. Replace `aria-labelledby` associated with `h2.main-navigation-heading` with `aria-label`.
- Remove the old mobile version main navigation snippets (search and utility nav) from the horizontal nav.



**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21691


**To Test:**
- [ ] Go to the home page and open inspect.
- [ ] Find `<h2 class="visually-hidden" id="main-navigation-heading">Main navigation</h2>` is now `<div class="visually-hidden" id="main-navigation-heading">Main navigation</div>`.
- [ ] In the horizontal nav component, find no search and utility nav snippets, which used to be the flyout mobile version from the right side.

- [ ] Go to any page but the home page and open inspect.
- [ ] Find `<h2 class="visually-hidden" id="main-navigation-heading">Main navigation</h2>` is now `<div class="visually-hidden" id="main-navigation-heading">Main navigation</div>`.


**Screenshots/GIFs:**






---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
