### PR TITLE
DP-21703: Update help text on pages linking here for pages & docs

### DIFF
--- a/changelogs/DP-21703.yml
+++ b/changelogs/DP-21703.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Updated the help text on the page and document Pages Linking Here tabs.
+    issue: DP-21703

--- a/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
@@ -77,7 +77,7 @@ class LinkingPageController extends ControllerBase {
     $output = [];
     $output['linking_nodes'] = [
       '#type' => 'table',
-      '#caption' => $this->t('The list below shows pages that include a link to this page. However, it DOES NOT include pages that link to this one through inline links in a rich text editor — it only includes links added through structured fields. @help_text', ['@help_text' => $help_text]),
+      '#caption' => $this->t('The list below shows pages that include a link to this page in structured and rich text fields. @help_text', ['@help_text' => $help_text]),
       '#header' => [
         $this->t('Title'),
         $this->t('ID'),

--- a/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
@@ -77,7 +77,7 @@ class MediaLinkingPageController extends ControllerBase {
     $output = [];
     $output['linking_nodes'] = [
       '#type' => 'table',
-      '#caption' => $this->t('The list below shows pages that include a link to this document. However, it DOES NOT include pages that that link to this document through inline links in a rich text editor — it only includes links added through structured fields. @help_text', ['@help_text' => $help_text]),
+      '#caption' => $this->t('The list below shows pages that include a link to this document in structured and rich text fields. @help_text', ['@help_text' => $help_text]),
       '#header' => [
         $this->t('Node'),
         $this->t('NID'),


### PR DESCRIPTION
**Description:**
Updated the help text on the pages and documents Pages Linking Here tab.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21703


**To Test:**
- [ ] Login and go to /service-details/fiscal-year-2022-local-consumer-program-grant/linking-page.
- [ ] Verify the following text exists: "The list below shows pages that include a link to this page in structured and rich text fields. Learn how to use Linking Pages."
- [ ] Go to /doc/flatiron-aod/linking-page.
- [ ] Verify the following text exists: "The list below shows pages that include a link to this document in structured and rich text fields. Learn how to use Linking Pages."


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
