### PR TITLE
Add iframe_resizer_iframe.js

### DIFF
--- a/changelogs/DP-20892.yml
+++ b/changelogs/DP-20892.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Host iframe responsive height JS at docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js.
+    issue: DP-20892

--- a/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
+++ b/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
@@ -1,0 +1,101 @@
+/* Instructions
+**
+** Mass.gov CDN: https://mass.gov/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
+** Add this script into the iframe source code before the closing body tag:
+** <script type="text/javascript" src="https://mass.gov/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js"></script>
+** This code monitors the iframe page for changes in dimensions. When change is detected, it sends send the latest dimensions to the parent page using postMessage
+*/
+
+/*
+
+MIT License
+
+Copyright (c) 2019 Jacob Filipp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+
+// determine height of content on this page
+function getMyHeight() {
+  'use strict';
+
+  // https://stackoverflow.com/a/11864824
+  return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);
+}
+
+
+// send the latest page dimensions to the parent page on which this iframe is embedded
+function sendDimensionsToParent(iframeDimensions_Old) {
+  'use strict';
+
+  var iframeDimensions_New = {
+    width: window.innerWidth, // supported from IE9 onwards
+    height: getMyHeight()
+  };
+
+  // if old width is not equal new width, or old height is not equal new height, then...
+  if ((iframeDimensions_New.width !== iframeDimensions_Old.width) || (iframeDimensions_New.height !== iframeDimensions_Old.height)) {
+    window.parent.postMessage(iframeDimensions_New, '*');
+    iframeDimensions_Old = iframeDimensions_New;
+  }
+
+}
+
+
+// on load - send the page dimensions. (we do this on load because then all images have loaded...)
+window.addEventListener('load', function () {
+  'use strict';
+
+  // For debugging purposes
+  // eslint-disable-next-line no-console
+  console.log('loaded iframe JS: ' + document.URL);
+
+  var iframeDimensions_Old = {
+    width: window.innerWidth, // supported from IE9 onwards
+    height: getMyHeight()
+  };
+
+  window.parent.postMessage(iframeDimensions_Old, '*'); // send our dimensions once, initially - so the iFrame is initialized to the correct size
+
+  // if mutationobserver is supported by this browser
+  if (window.MutationObserver) {
+    // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+
+    var observer = new MutationObserver(sendDimensionsToParent);
+    var config = {
+      attributes: true,
+      attributeOldValue: false,
+      characterData: true,
+      characterDataOldValue: false,
+      childList: true,
+      subtree: true
+    };
+
+    observer.observe(document.body, config);
+
+  }
+  // if mutationobserver is NOT supported
+  else {
+    // check for changes on a timed interval, every 1/3 of a second
+    window.setInterval(sendDimensionsToParent, 300);
+  }
+
+
+}); // end of window.onload


### PR DESCRIPTION
**Description:**
Merge this PR before #605 so that the iframe_resizer_iframe.js exist in github or mass.gov (if we want to use mass.gov we need to wait for a production release) to be used as CDN

Github URL after merge --> https://raw.githubusercontent.com/massgov/openmass/develop/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js

Mass.gov URL after release --> https://mass.gov/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js

This file is only added to referenced in external iframe apps. There's no impact on mass.gov

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-20892
