### PR TITLE
DP-21792 Language field in the way on info details pages

### DIFF
--- a/changelogs/DP-21792.yml
+++ b/changelogs/DP-21792.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Dropping the language field to the bottom of the node form when the data_flag field is on a content type.
+    issue: DP-21792

--- a/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
@@ -55,12 +55,11 @@ third_party_settings:
         - field_curatedlist_lede
         - field_curatedlist_overview
         - field_organizations
-        - langcode
         - field_english_version
         - field_data_flag
+        - field_data_topic
         - field_list_data_type
         - field_data_format
-        - field_data_topic
         - field_intended_audience
         - field_reusable_label
       parent_name: group_curated_list_edit_form
@@ -360,26 +359,26 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 8
+    weight: 11
     region: content
     settings:
       include_locked: false
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 10
     settings: {  }
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 8
+    weight: 7
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -414,12 +413,12 @@ content:
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -71,11 +71,10 @@ third_party_settings:
         - field_info_details_last_updated
         - field_page_template
         - field_organizations
-        - langcode
-        - field_english_version
         - field_data_flag
         - field_details_data_type
         - field_data_resource_type
+        - field_english_version
         - field_data_format
         - field_data_topic
         - field_intended_audience
@@ -440,14 +439,14 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 12
+    weight: 11
     region: content
     settings:
       include_locked: false
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 9
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -499,7 +498,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 11
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.service_details.field_service_detail_sections
     - field.field.node.service_details.field_state_organization_tax
     - node.type.service_details
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - field_group
@@ -52,21 +53,18 @@ third_party_settings:
         - field_service_detail_lede
         - field_service_detail_overview
         - field_organizations
-        - langcode
         - field_english_version
         - field_data_flag
-        - field_details_data_type
-        - field_data_resource_type
         - field_data_format
+        - field_details_data_type
         - field_data_topic
-        - field_data_sub_topic
+        - field_data_resource_type
         - field_intended_audience
         - field_reusable_label
       parent_name: group_node_edit_form
       weight: 20
       format_type: tab
       format_settings:
-        label: Overview
         formatter: open
         description: 'Service Detail pages offer information about the service they’re linked to. A Service Detail page should be linked to a Service page – make sure that you have a Service page in mind before you start. Keep the title as short as possible and use plain language. <a href="https://massgovdigital.gitbook.io/knowledge-base/content-types-1/services-and-info/service-detail" target="_blank">Learn about authoring Service Detail pages.</a>'
         required_fields: true
@@ -81,7 +79,6 @@ third_party_settings:
       weight: 21
       format_type: tab
       format_settings:
-        label: Sections
         formatter: closed
         description: 'A Service Detail page is made up of one or more sections. Sections can contain text (with a header and, optionally, additional resources for that section), or a section can be a video. We recommend limiting a Service Detail page to no more than 8 sections.'
         required_fields: true
@@ -97,7 +94,6 @@ third_party_settings:
       weight: 22
       format_type: tab
       format_settings:
-        label: Related
         formatter: closed
         description: 'Use this area to add related content.'
         required_fields: true
@@ -112,7 +108,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 3
+    weight: 2
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -304,7 +300,7 @@ content:
     type: link_default
     region: content
   field_service_detail_metatags:
-    weight: 7
+    weight: 6
     settings:
       sidebar: true
     third_party_settings: {  }
@@ -331,7 +327,7 @@ content:
     third_party_settings: {  }
     region: content
   field_state_organization_tax:
-    weight: 8
+    weight: 7
     settings:
       match_operator: CONTAINS
       size: 60
@@ -342,31 +338,31 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 26
+    weight: 12
     region: content
     settings:
       include_locked: false
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 11
+    weight: 10
     settings: {  }
     region: content
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 5
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
   publish_state:
     type: scheduler_moderation
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 4
+    weight: 3
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -380,7 +376,7 @@ content:
     region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 2
+    weight: 1
     settings:
       match_operator: CONTAINS
       size: 60
@@ -390,18 +386,18 @@ content:
     region: content
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 6
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   unpublish_state:
     type: scheduler_moderation
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
**Description:**
The language field on info details pages is too high.  Move it to the bottom.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21792


**To Test:**
- [ ] View an information details node form and confirm the langage field is on the bottom.
- [ ] View a curated list node form and confirm the langage field is on the bottom.
- [ ] View a service details node form and confirm the langage field is on the bottom.


