### PR TITLE
DP-21677 No more comass Docker org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ executors:
     parameters:
       instance:
         type: string
-        default: comass/mysql-sanitized:latest
+        default: massgov/mysql-sanitized:latest
     working_directory: /var/www/code
     # https://circleci.com/docs/2.0/configuration-reference/#resource_class
     resource_class: xlarge
@@ -234,7 +234,7 @@ jobs:
     parameters:
       instance:
         type: string
-        default: comass/mysql-sanitized:latest
+        default: massgov/mysql-sanitized:latest
       command:
         type: enum
         enum: ['phpunit', 'behat']
@@ -968,12 +968,12 @@ workflows:
       - test:
           name: test-phpunit-super
           command: phpunit
-          instance: comass/mysql-sanitized:super
+          instance: massgov/mysql-sanitized:super
           requires: [build]
       - test:
           name: test-super-behat
           command: behat
-          instance: comass/mysql-sanitized:super
+          instance: massgov/mysql-sanitized:super
           requires: [build]
     triggers:
       - schedule:
@@ -1005,7 +1005,6 @@ workflows:
             branches:
               only:
                 - develop
-                - move-from-comass
 
   # Usually triggered by drush ma:backstop.
   backstop_ad_hoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -989,22 +989,23 @@ workflows:
     jobs:
       - build
       - populate:
-          name: populate --sanitize
+          name: massgov.populate --sanitize
           requires: [build]
           sanitizeOption: --sanitize
-          instance: comass/mysql-sanitized:latest
+          instance: massgov/mysql-sanitized:latest
       - populate:
-          name: populate --super-sanitize
+          name: massgov.populate --super-sanitize
           requires: [build]
           sanitizeOption: --super-sanitize
-          instance: comass/mysql-sanitized:super
+          instance: massgov/mysql-sanitized:super
     triggers:
       - schedule:
-          cron: "32 21 * * *"
+          cron: "42 15 * * *"
           filters:
             branches:
               only:
                 - develop
+                - move-from-comass
 
   # Usually triggered by drush ma:backstop.
   backstop_ad_hoc:

--- a/changelogs/DP-21677.yml
+++ b/changelogs/DP-21677.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Use 'massgov' Docker org instead of comass
+    issue: DP-21677

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,8 +74,8 @@ services:
     # Use the heavily sanitized version of the database by default.
     # If needed, access can be given to the less heavily sanitized db, "latest"
     # That version includes revisions, unpublished content, and other information we keep private
-    image: comass/mysql-sanitized:super
-    # image: comass/mysql-sanitized:latest
+    image: massgov/mysql-sanitized:super
+    # image: massgov/mysql-sanitized:latest
     environment:
       MYSQL_USER: circle
       MYSQL_PASSWORD: circle


### PR DESCRIPTION
**Description:**
Use `massgov` org instead


**Jira:** (Skip unless you are MA staff)
DP-21677


**To Test:**
- [ ] Confirm that the `mysql_rebuild` CircleCI job pushed 2 new images successfully - https://hub.docker.com/repository/docker/massgov/mysql-sanitized/tags
- [ ] Confirm that a reasonable list of members has been invited to the new repo so they can keep on using `ahoy pull`. https://hub.docker.com/orgs/massgov/teams/developers


**Post Merge:**
- [ ] Announce in chat - "Please pull latest develop, and merge changes from develop into your feature branches so that you get the latest sanitized database. See https://github.com/massgov/openmass/pull/731"


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
