### PR TITLE
[Hotfix/0.281.1] DP-21948: Fix broken overflow pages in Drupal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 
 
+## [0.281.1] - May 6, 2021
+
+### Changed
+- DP-21948: Fixed overflow pages.
+  
+
+
 ## [0.281.0] - May 4, 2021
 
 ### Changed

--- a/docroot/modules/custom/mass_more_lists/src/Service/MassMoreListsListBuilder.php
+++ b/docroot/modules/custom/mass_more_lists/src/Service/MassMoreListsListBuilder.php
@@ -159,7 +159,7 @@ class MassMoreListsListBuilder {
     $num_download_links = count($form_downloads['downloadLinks']);
 
     // Creates pager, which also returns current page value.
-    $page = $this->pagerManager->createPager($num_download_links, $this->pageLimit);
+    $page = $this->pagerManager->createPager($num_download_links, $this->pageLimit)->getCurrentPage();
     // Calculates pager offset.
     // @see https://api.drupal.org/api/drupal/core%21includes%21pager.inc/function/pager_default_initialize/8.5.x
     $offset = $this->pageLimit * $page;


### PR DESCRIPTION
**Description:**
Added an additional method call to complete the deprecation fix in the more list functionality.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21948


**To Test:**
- [ ] Go to /public-records-and-training-record-transcript-requests/resources
- [ ] Verify there are items displayed and the result count is accurate.


**Screenshots/GIFs:**
![| Mass gov 2021-05-06 16-59-44](https://user-images.githubusercontent.com/1434979/117364894-7e25e800-ae8c-11eb-9ddf-0bccc0d379fa.png)
---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
