### PR TITLE
DP-21786 uninstalling config_log module

### DIFF
--- a/changelogs/DP-21786.yml
+++ b/changelogs/DP-21786.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Uninstalling config_log module.
+    issue: DP-21786

--- a/conf/drupal/config/config_log.settings.yml
+++ b/conf/drupal/config/config_log.settings.yml
@@ -1,9 +1,0 @@
-log_ignored_config: {  }
-log_destination:
-  custom: custom
-  default: '0'
-  mail: '0'
-_core:
-  default_config_hash: XmAs9nbCHoc6DoEAUPbXoiDvo91WF8JHqbJQfd1sHB4
-log_email_address: ''
-ignore_config_import: true

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -20,7 +20,6 @@ module:
   config: 0
   config_filter: 0
   config_ignore: 0
-  config_log: 0
   contact: 0
   content_moderation: 0
   crop: 0


### PR DESCRIPTION
**Description:**
This uninstalls the config_log module and removes the associated configurations.

A later ticket will remove it from composer.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21786


**To Test:**
- [ ] Confirm config_log is not enabled, it shows up as the "Configuration Log" module on **/admin/modules**
