### PR TITLE
DP-21692: Remove support message upon saving content in Drupal

### DIFF
--- a/changelogs/DP-21692.yml
+++ b/changelogs/DP-21692.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed empty support status message rendering upon saving content in Drupal.
+    issue: DP-21692

--- a/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
+++ b/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
@@ -49,7 +49,9 @@ function mass_feedback_form_theme() {
  */
 function mass_feedback_form_node_update(EntityInterface $node) {
   $notification = \Drupal::state()->get('mass_feedback_form.notification', '');
-  \Drupal::messenger()->addStatus(Markup::create($notification));
+  if (!empty($notification)) {
+    \Drupal::messenger()->addStatus(Markup::create($notification));
+  }
 }
 
 /**
@@ -57,7 +59,9 @@ function mass_feedback_form_node_update(EntityInterface $node) {
  */
 function mass_feedback_form_node_insert(EntityInterface $node) {
   $notification = \Drupal::state()->get('mass_feedback_form.notification', '');
-  \Drupal::messenger()->addStatus(Markup::create($notification));
+  if (!empty($notification)) {
+    \Drupal::messenger()->addStatus(Markup::create($notification));
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Added checks in 2 places to avoid rendering empty message.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21692


**To Test:**
- [ ] Edit and save a Service node


**Screenshots/GIFs:**
<img width="387" alt="Screen Shot 2021-05-10 at 12 30 24" src="https://user-images.githubusercontent.com/62405127/117629710-80898a00-b18b-11eb-91d0-3970ccb10557.png">
