### PR TITLE
 DP-21188: Wrap long file names that have no breaking character in "all documents" view

### DIFF
--- a/changelogs/DP-21188.yml
+++ b/changelogs/DP-21188.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Wrap long file names that have no breaking character in "all documents" view.
+    issue: DP-21188

--- a/docroot/themes/custom/mass_admin_theme/css/components/views-ui.css
+++ b/docroot/themes/custom/mass_admin_theme/css/components/views-ui.css
@@ -183,3 +183,7 @@ form#view-add-form fieldset {
   padding: 1.5rem;
   margin-top: 1.5rem;
 }
+
+.view-all-documents.view-display-id-page_1 td.views-field-filename {
+  word-break: break-all;
+}


### PR DESCRIPTION
**Description:**
Fixed the issue by applying CSS rule.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21188


**To Test:**
- [ ] Visit the page here mass.local/admin/ma-dash/documents?field_title_value=caregiver&filename=&mid=&moderation_state_1=All&uid=&media_org_filter=


**Screenshots/GIFs:**
<img width="1501" alt="Screen Shot 2021-05-10 at 13 01 37" src="https://user-images.githubusercontent.com/62405127/117634355-dceea880-b18f-11eb-8a12-73e39bf3a889.png">

