### PR TITLE
DP-21034: Edit log in error message with wrong styles

### DIFF
--- a/changelogs/DP-21034.yml
+++ b/changelogs/DP-21034.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed log in error message appearing with wrong styles.
+    issue: DP-21034

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -894,7 +894,7 @@ function mass_utility_remove_login_validation(array &$form, FormStateInterface $
   if (isset($errors['name'])) {
     $error = $errors['name'];
     // Rebuild translated error message for displaying link.
-    \Drupal::messenger()->addStatus($error);
+    \Drupal::messenger()->addError($error);
   }
 }
 


### PR DESCRIPTION
**Description:**
Fixed the method called on custom validation function.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21034


**To Test:**
- [ ] Try to login with wrong credentials


**Screenshots/GIFs:**
<img width="800" alt="Screen Shot 2021-05-10 at 15 20 05" src="https://user-images.githubusercontent.com/62405127/117651625-34e2da80-b1a3-11eb-8fcd-878e22edd277.png">

