### PR TITLE
DP-21949: Add missing pages to Drupal Backstop

### DIFF
--- a/backstop/all.json
+++ b/backstop/all.json
@@ -43,13 +43,17 @@
   {"label": "OrgsUpcomingEvents", "url": "/orgs/qag-digital-services/events?_page=1"},
   {"label": "OrgsPastEvents", "url": "/orgs/qag-digital-services/events/past?_page=1"},
   {"label": "OrgsServices", "url": "/orgs/qag-executive-office-of-technology-services-and-security/services"},
-  {"label": "OrgsLocationDetails", "url": "/orgs/qag-executive-office-of-technology-services-and-security/locations?page=1"},
+  {"label": "OrgsLocationDetails", "url": "/orgs/qag-executive-office-of-technology-services-and-security/locations?_page=1"},
   {"label": "PersonBoardMember", "url": "/person/qag-person-boardmember-role"},
   {"label": "PersonBoardElected", "url": "/person/qag-jane-test-here-is-janes-title"},
   {"label": "RegulationDraft", "url": "/regulations/900-CMR-3-qag-regulation-title-ultricies-tristique-nulla-aliquet-enim-tortor-at-auctor"},
   {"label": "RegulationEffectiveDate", "url": "/regulations/900-CMR-2-qag-regulation-title"},
   {"label": "RulesOfCourt", "url": "/trial-court-rules/qag-rulesofcourt"},
   {"label": "ServiceDetails", "url": "/service-details/qag-servicedetails"},
+  {"label": "ServiceDetailsResources", "url": "/service-details/qag-servicedetails/resources"},
+  {"label": "ServiceTasks", "url": "/qag-service4/tasks"},
+  {"label": "ServiceNeedToKnow", "url": "/qag-service4/need-to-know"},
+  {"label": "ServiceResources", "url": "/qag-service4/resources"},
   {"label": "Service1", "url": "/qag-service1"},
   {"label": "Service2", "url": "/qag-service2"},
   {"label": "Service3", "url": "/qag-service3"},
@@ -64,6 +68,6 @@
   {"label": "InfoDetailsImageWrapLeft", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-text-wrap"},
   {"label": "InfoDetailsImageWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-wrap"},
   {"label": "InfoDetailsImageNoWrapLeft", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-no-text-wrap"},
-  {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"}
+  {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"},
 
 ]

--- a/backstop/all.json
+++ b/backstop/all.json
@@ -68,6 +68,6 @@
   {"label": "InfoDetailsImageWrapLeft", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-text-wrap"},
   {"label": "InfoDetailsImageWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-wrap"},
   {"label": "InfoDetailsImageNoWrapLeft", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-no-text-wrap"},
-  {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"},
+  {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"}
 
 ]

--- a/changelogs/DP-21949.yml
+++ b/changelogs/DP-21949.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add missing pages to Drupal Backstop.
+    issue: DP-21949


### PR DESCRIPTION
**Description:**
Added pages to the backstop all.json file.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21949


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
