### PR TITLE
DP-21792 Move language field from between the data fields.

### DIFF
--- a/changelogs/DP-21792.yml
+++ b/changelogs/DP-21792.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changed the field order on the node form, keeping language out of the "data" fields.
+    issue: DP-21792

--- a/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
@@ -55,12 +55,12 @@ third_party_settings:
         - field_curatedlist_lede
         - field_curatedlist_overview
         - field_organizations
-        - langcode
-        - field_english_version
         - field_data_flag
+        - field_data_topic
         - field_list_data_type
         - field_data_format
-        - field_data_topic
+        - langcode
+        - field_english_version
         - field_intended_audience
         - field_reusable_label
       parent_name: group_curated_list_edit_form
@@ -173,13 +173,13 @@ content:
     type: text_textarea
     region: content
   field_data_flag:
-    weight: 10
+    weight: 8
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_data_format:
-    weight: 12
+    weight: 11
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -203,7 +203,7 @@ content:
     type: options_buttons
     region: content
   field_data_topic:
-    weight: 11
+    weight: 9
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -227,7 +227,7 @@ content:
     type: options_buttons
     region: content
   field_english_version:
-    weight: 9
+    weight: 13
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -255,13 +255,13 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_intended_audience:
-    weight: 13
+    weight: 14
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_list_data_type:
-    weight: 11
+    weight: 10
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -339,7 +339,7 @@ content:
     type: link_default
     region: content
   field_reusable_label:
-    weight: 14
+    weight: 15
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -360,7 +360,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 8
+    weight: 12
     region: content
     settings:
       include_locked: false

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -71,13 +71,13 @@ third_party_settings:
         - field_info_details_last_updated
         - field_page_template
         - field_organizations
-        - langcode
-        - field_english_version
         - field_data_flag
         - field_details_data_type
         - field_data_resource_type
         - field_data_format
         - field_data_topic
+        - langcode
+        - field_english_version
         - field_intended_audience
         - field_reusable_label
       parent_name: group_information_details_edit_f
@@ -281,7 +281,7 @@ content:
     type: boolean_checkbox
     region: content
   field_english_version:
-    weight: 13
+    weight: 17
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -389,7 +389,7 @@ content:
     type: metatag_firehose
     region: content
   field_intended_audience:
-    weight: 17
+    weight: 18
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -412,7 +412,7 @@ content:
     region: content
   field_reusable_label:
     type: entity_reference_autocomplete
-    weight: 18
+    weight: 19
     region: content
     settings:
       match_operator: CONTAINS
@@ -440,7 +440,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 12
+    weight: 16
     region: content
     settings:
       include_locked: false

--- a/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.service_details.default.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.service_details.field_service_detail_sections
     - field.field.node.service_details.field_state_organization_tax
     - node.type.service_details
+    - workflows.workflow.editorial
   module:
     - content_moderation
     - field_group
@@ -52,21 +53,19 @@ third_party_settings:
         - field_service_detail_lede
         - field_service_detail_overview
         - field_organizations
+        - field_data_flag
+        - field_data_format
+        - field_details_data_type
+        - field_data_topic
+        - field_data_resource_type
         - langcode
         - field_english_version
-        - field_data_flag
-        - field_details_data_type
-        - field_data_resource_type
-        - field_data_format
-        - field_data_topic
-        - field_data_sub_topic
         - field_intended_audience
         - field_reusable_label
       parent_name: group_node_edit_form
       weight: 20
       format_type: tab
       format_settings:
-        label: Overview
         formatter: open
         description: 'Service Detail pages offer information about the service they’re linked to. A Service Detail page should be linked to a Service page – make sure that you have a Service page in mind before you start. Keep the title as short as possible and use plain language. <a href="https://massgovdigital.gitbook.io/knowledge-base/content-types-1/services-and-info/service-detail" target="_blank">Learn about authoring Service Detail pages.</a>'
         required_fields: true
@@ -81,7 +80,6 @@ third_party_settings:
       weight: 21
       format_type: tab
       format_settings:
-        label: Sections
         formatter: closed
         description: 'A Service Detail page is made up of one or more sections. Sections can contain text (with a header and, optionally, additional resources for that section), or a section can be a video. We recommend limiting a Service Detail page to no more than 8 sections.'
         required_fields: true
@@ -97,7 +95,6 @@ third_party_settings:
       weight: 22
       format_type: tab
       format_settings:
-        label: Related
         formatter: closed
         description: 'Use this area to add related content.'
         required_fields: true
@@ -117,13 +114,13 @@ content:
     third_party_settings: {  }
     region: content
   field_data_flag:
-    weight: 28
+    weight: 26
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_data_format:
-    weight: 29
+    weight: 27
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -147,7 +144,7 @@ content:
     type: options_buttons
     region: content
   field_data_resource_type:
-    weight: 31
+    weight: 30
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -171,7 +168,7 @@ content:
     type: options_buttons
     region: content
   field_data_topic:
-    weight: 30
+    weight: 29
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -195,7 +192,7 @@ content:
     type: options_buttons
     region: content
   field_details_data_type:
-    weight: 29
+    weight: 28
     settings: {  }
     third_party_settings:
       conditional_fields:
@@ -219,7 +216,7 @@ content:
     type: options_buttons
     region: content
   field_english_version:
-    weight: 27
+    weight: 32
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -247,7 +244,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_intended_audience:
-    weight: 32
+    weight: 33
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -263,7 +260,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_reusable_label:
-    weight: 33
+    weight: 34
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -342,7 +339,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 26
+    weight: 31
     region: content
     settings:
       include_locked: false


### PR DESCRIPTION
**Description:**
The language field on info details pages is too high.  Move it to the bottom.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21792


**To Test:**
- [ ] View an information details node form and confirm the langage field is on the bottom.
- [ ] View a curated list node form and confirm the langage field is on the bottom.
- [ ] View a service details node form and confirm the langage field is on the bottom.
