### PR TITLE
Mayflower/dp 22060 mayflower version 11.5.0

### DIFF
--- a/changelogs/DP-22060.yml
+++ b/changelogs/DP-22060.yml
@@ -1,0 +1,9 @@
+Changed:
+  - description:  |-
+        Updated Mayflower version to 11.5.0.
+          - DP-21554: Added MapLeaflet molecule and variants. (MF)
+          - DP-21554: Switch out interactive and static google maps with leaflet maps in LocationBanners and MappedLocations, on location pages and orgs and services pages. (MF)
+          - DP-21816: Remove h2 from utility nav panel title. (MF)
+          - DP-21763: Extended the GeneralTeaser component to render tags, icon in eyebrow, and upperRight content. (MF)
+          - DP-21883: Added a query string with a version to -VF.woff2 fonts for caching. (MF)
+    issue: DP-22060

--- a/composer.json
+++ b/composer.json
@@ -192,7 +192,7 @@
         "drush/drush": "^10.4",
         "enyo/dropzone": "5.7.2",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-20949-google-map-swap-poc",
+        "massgov/mayflower-artifacts": "11.5.0",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8217cd4bec4748b9d6583ce11d9fb9bf",
+    "content-hash": "223a07e93c9c1f111f00e8052a3dc4e3",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aea817051501839861c230f842c53532",
+    "content-hash": "8217cd4bec4748b9d6583ce11d9fb9bf",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10718,16 +10718,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-20949-google-map-swap-poc",
+            "version": "11.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "f94379fc065af1bb0a9319371d4b59b4d6aa4d86"
+                "reference": "118e61082730e9d5e40837839e2f72a886362727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f94379fc065af1bb0a9319371d4b59b4d6aa4d86",
-                "reference": "f94379fc065af1bb0a9319371d4b59b4d6aa4d86",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/118e61082730e9d5e40837839e2f72a886362727",
+                "reference": "118e61082730e9d5e40837839e2f72a886362727",
                 "shasum": ""
             },
             "require": {
@@ -10747,9 +10747,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-20949-google-map-swap-poc"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.5.0"
             },
-            "time": "2021-05-14T16:06:38+00:00"
+            "time": "2021-05-17T20:10:13+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -18391,7 +18391,6 @@
         "drupal/scheduler_content_moderation_integration": 15,
         "drupal/security_review": 20,
         "drupal/stage_file_proxy": 15,
-        "massgov/mayflower-artifacts": 20,
         "mikeyp/google_tag": 20,
         "behat/mink-selenium2-driver": 20,
         "weitzman/logintrait": 20


### PR DESCRIPTION
Changed:
  - description:  |-
        Updated Mayflower version to 11.5.0.
          - DP-21554: Added MapLeaflet molecule and variants. (MF)
          - DP-21554: Switch out interactive and static google maps with leaflet maps in LocationBanners and MappedLocations, on location pages and orgs and services pages. (MF)
          - DP-21816: Remove h2 from utility nav panel title. (MF)
          - DP-21763: Extended the GeneralTeaser component to render tags, icon in eyebrow, and upperRight content. (MF)
          - DP-21883: Added a query string with a version to -VF.woff2 fonts for caching. (MF)
    issue: DP-22060