### PR TITLE
Fix missing hours on location listings

### DIFF
--- a/changelogs/DP-22061.yml
+++ b/changelogs/DP-22061.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix missing hours on location listing pages.
+    issue: DP-22061

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -249,7 +249,7 @@ class MapLocationFetcher {
         // Get hours from the referenced contact info node.
         if (!$contact_information_entity->field_ref_hours->isEmpty()) {
           $hours_paragraph = $contact_information_entity->field_ref_hours->entity;
-          if (!is_null($hours_paragraph)) {
+          if (!is_null($hours_paragraph) && !isset($hours_paragraph->field_hours_structured->entity)) {
             $hours = $hours_paragraph->field_hours_structured->view('default');
             if ($hours) {
               $hours = \Drupal::service('renderer')->render($hours);

--- a/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
+++ b/docroot/modules/custom/mass_map/src/MapLocationFetcher.php
@@ -249,7 +249,7 @@ class MapLocationFetcher {
         // Get hours from the referenced contact info node.
         if (!$contact_information_entity->field_ref_hours->isEmpty()) {
           $hours_paragraph = $contact_information_entity->field_ref_hours->entity;
-          if (!is_null($hours_paragraph) &&   !is_null($hours_paragraph->field_hours_structured->entity)) {
+          if (!is_null($hours_paragraph)) {
             $hours = $hours_paragraph->field_hours_structured->view('default');
             if ($hours) {
               $hours = \Drupal::service('renderer')->render($hours);


### PR DESCRIPTION
Maps PR introduced visual regressions on the location listing -  hours on the location teasers are no longer showing

Prod: 
https://www.mass.gov/rmv-services-at-aaa/locations?_page=1
![Screen Shot 2021-05-18 at 10 47 16 AM](https://user-images.githubusercontent.com/5789411/118673101-bc91a000-b7c6-11eb-85b3-f2dbf213254d.png)


Before:
feature2: https://massgovfeature2.prod.acquia-sites.com/rmv-services-at-aaa/locations?_page=1
![Screen Shot 2021-05-18 at 10 48 04 AM](https://user-images.githubusercontent.com/5789411/118673129-c2878100-b7c6-11eb-95a8-7a1596158d7e.png)


After:
feature5: https://massgovfeature5.prod.acquia-sites.com/rmv-services-at-aaa/locations?_page=1
![Screen Shot 2021-05-18 at 10 47 16 AM](https://user-images.githubusercontent.com/5789411/118673690-3590f780-b7c7-11eb-819e-82211afbab78.png)

