### PR TITLE
DP-21983 Prevent links from appearing in the translations tab that do…

### DIFF
--- a/changelogs/DP-21983.yml
+++ b/changelogs/DP-21983.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Makes sure the english version translation field is empty if the content is already english.
+    issue: DP-21983

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -127,3 +127,14 @@ function mass_translations_process_language_select(array $element): array {
 
   return $element;
 }
+
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function mass_translations_node_presave(Drupal\Core\Entity\EntityInterface $entity) {
+  if ($entity->hasField('field_english_version') && $entity->get('langcode')->value == 'en') {
+    // If the Language is English, there isn't a seperate English version.
+    $entity->set('field_english_version', '');
+  }
+}

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -14,6 +14,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
 use Drupal\mass_translations\Controller\TranslationsController;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Implements hook_page_attachments().
@@ -128,11 +129,10 @@ function mass_translations_process_language_select(array $element): array {
   return $element;
 }
 
-
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function mass_translations_node_presave(Drupal\Core\Entity\EntityInterface $entity) {
+function mass_translations_node_presave(EntityInterface $entity) {
   if ($entity->hasField('field_english_version') && $entity->get('langcode')->value == 'en') {
     // If the Language is English, there isn't a seperate English version.
     $entity->set('field_english_version', '');


### PR DESCRIPTION
**Description:**
The English Version field gets hidden when you choose English as the language. But a hidden field still holds a value. 

This adds an entity presave hook to clear the value of the "English Version" Field, if the Language is set to English.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-21983


**To Test:**
- [ ] visit /info-details/enable-massnotify-on-your-smartphone/translations
- [ ] Click on one of the translated options,  (Spanish/Chinese/Portuguese) 
- [ ] Click edit
- [ ] Scroll Down and change the language to English
- [ ] (Leave the English Version reference alone)
- [ ] Click Save
- [ ] Refresh /info-details/enable-massnotify-on-your-smartphone/translations
- [ ] The The translation node you edited should no longer be listed.

