### PR TITLE
DP-22021: Bug on how-to. Unable to add existing fee

### DIFF
--- a/changelogs/DP-22021.yml
+++ b/changelogs/DP-22021.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed error when adding an existing Fee to a How-to page.
+    issue: DP-22021

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -354,6 +354,7 @@ function mass_admin_theme_preprocess_input__submit(array &$variables) {
   // replaced by "Select Entities" button.
   if (!is_string($attr_value) && $attr_value->getUntranslatedString() == 'Add @type_singular') {
     if (!empty($attr_value->getArguments()['@type_singular']) &&
+      !is_string($attr_value->getArguments()['@type_singular']) &&
       strpos($attr_value->getArguments()['@type_singular']->getUntranslatedString(), "media") !== FALSE) {
       $needles = [
         "field-service-detail-sections",


### PR DESCRIPTION
**Description:**
Updating a condition in the mass_admin_theme to fix an AJAX error when adding an existing fee to a how-to page.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22021


**To Test:**
- Login and go to "/admin/content".
- Filter by "How-to" content type.
- Click the "Edit" button for a result.
- Click on the "Details" tab and add an existing Fee.
- [ ] Verify the autocomplete form displays.
- Click on the "Additional Info" tab and add an existing media item to the "Downloads" field.
- [ ] Verify that the view for selecting displays.
- Click the "Save" button.
- [ ] View the node to verify there are no display errors.


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
