### PR TITLE
DP-22002 Changes for metatags for news, forms and decision tree nodes

### DIFF
--- a/changelogs/DP-22002.yml
+++ b/changelogs/DP-22002.yml
@@ -37,5 +37,6 @@
 #    issue: DP-19843
 #
 Type:
-  - Changed: Metatag Changes for news, decision tree, and form content types.
+  Changed:
+  - description: Metatag Changes for news, decision tree, and form content types.
     issue: DP-22002

--- a/changelogs/DP-22002.yml
+++ b/changelogs/DP-22002.yml
@@ -36,7 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
-  Changed:
-  - description: Metatag Changes for news, decision tree, and form content types.
+Changed:
+  - description: Metatag changes for 3 content types.
     issue: DP-22002

--- a/changelogs/DP-22002.yml
+++ b/changelogs/DP-22002.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - Changed: Metatag Changes to form, news, and decision tree node types.
+    issue: DP-22002

--- a/changelogs/DP-22002.yml
+++ b/changelogs/DP-22002.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Type:
-  - Changed: Metatag Changes to form, news, and decision tree node types.
+  - Changed: Metatag Changes for news, decision tree, and form content types.
     issue: DP-22002

--- a/conf/drupal/config/metatag.metatag_defaults.node__decision_tree.yml
+++ b/conf/drupal/config/metatag.metatag_defaults.node__decision_tree.yml
@@ -5,5 +5,9 @@ dependencies: {  }
 id: node__decision_tree
 label: 'Content: Decision tree'
 tags:
+  description: '[node:field_description]'
   mass_metatag_organization: '[node:mass_organizations]'
   mg_stakeholder_org: '[node:field_state_organization_tax:entity:name]'
+  og_description: '[node:field_description]'
+  twitter_cards_type: summary
+  twitter_cards_description: '[node:field_description]'

--- a/conf/drupal/config/metatag.metatag_defaults.node__form_page.yml
+++ b/conf/drupal/config/metatag.metatag_defaults.node__form_page.yml
@@ -5,5 +5,9 @@ dependencies: {  }
 id: node__form_page
 label: 'Content: Form page'
 tags:
+  description: '[node:field_form_lede]'
   mass_metatag_organization: '[node:mass_organizations]'
   mg_stakeholder_org: '[node:field_state_organization_tax:entity:name]'
+  og_description: '[node:field_form_lede]'
+  twitter_cards_type: summary
+  twitter_cards_description: '[node:field_form_lede]'

--- a/conf/drupal/config/metatag.metatag_defaults.node__news.yml
+++ b/conf/drupal/config/metatag.metatag_defaults.node__news.yml
@@ -5,6 +5,8 @@ dependencies: {  }
 id: node__news
 label: 'Content: News'
 tags:
+  twitter_cards_type: summary
+  twitter_cards_description: '[node:field_news_lede]'
   mass_metatag_organization: '[node:mass_organizations]'
   mass_metatag_external_organization: '[node:mass_external_organizations]'
   mass_metatag_date: '[node:field_news_date:date:metadatadate]'
@@ -24,8 +26,6 @@ tags:
   schema_news_article_author: 'a:2:{s:5:"@type";s:12:"Organization";s:4:"name";s:53:"[node:field_news_signees:entity:field_state_org_name]";}'
   schema_news_article_content_location: '[node:field_news_location]'
   schema_news_article_id: '[node:url]#news'
-  description: '[node:field_news_body]'
+  description: '[node:field_news_lede]'
+  og_description: '[node:field_news_lede]'
   og_type: article
-  og_description: '[node:field_news_summary]'
-  twitter_cards_description: '[node:field_news_body]'
-  twitter_cards_type: summary

--- a/conf/drupal/config/metatag.settings.yml
+++ b/conf/drupal/config/metatag.settings.yml
@@ -45,6 +45,8 @@ entity_type_groups:
     decision_tree:
       basic: basic
       advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
     decision_tree_branch:
       basic: basic
       advanced: advanced
@@ -67,6 +69,8 @@ entity_type_groups:
     form_page:
       basic: basic
       advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
     guide_page:
       basic: basic
       advanced: advanced
@@ -94,6 +98,8 @@ entity_type_groups:
     news:
       basic: basic
       advanced: advanced
+      open_graph: open_graph
+      twitter_cards: twitter_cards
       schema_special_announcement: schema_special_announcement
     org_page:
       basic: basic

--- a/docroot/modules/custom/mass_metatag/tests/src/ExistingSite/NewsMetadataTest.php
+++ b/docroot/modules/custom/mass_metatag/tests/src/ExistingSite/NewsMetadataTest.php
@@ -33,7 +33,7 @@ class NewsMetadataTest extends MetadataTestCase {
       'field_news_date' => '2012-12-31T05:00:00',
       'field_state_organization_tax' => $org_term,
       'field_news_body' => 'TestDescription',
-      'field_form_lede' => 'TestDescription',
+      'field_news_lede' => 'TestDescription',
       'field_news_signees' => $signees_paragraph,
       'field_organizations' => [$org_node],
       'moderation_state' => 'published',

--- a/docroot/modules/custom/mass_metatag/tests/src/ExistingSite/NewsMetadataTest.php
+++ b/docroot/modules/custom/mass_metatag/tests/src/ExistingSite/NewsMetadataTest.php
@@ -33,6 +33,7 @@ class NewsMetadataTest extends MetadataTestCase {
       'field_news_date' => '2012-12-31T05:00:00',
       'field_state_organization_tax' => $org_term,
       'field_news_body' => 'TestDescription',
+      'field_form_lede' => 'TestDescription',
       'field_news_signees' => $signees_paragraph,
       'field_organizations' => [$org_node],
       'moderation_state' => 'published',


### PR DESCRIPTION
**Description:**
The following meta data fields are set:

description, og_description, twitter_cards_description

News content type:

Use field node.news.field_news_lede (short description)
Form content type:

Use field: field_form_lede
Decision Tree content type:

Use field: node.decision_tree.field_description


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22002

**To Test:**
- [ ] Confirm the changes in the metadata section on the form node form.
- [ ] Confirm the changes in the metadata section on the news node form.
- [ ] Confirm the changes in the metadata section on the decision tree node form.
