### PR TITLE
Mayflower/dp 22130 mayflower version 11.5.1

### DIFF
--- a/changelogs/DP-22130.yml
+++ b/changelogs/DP-22130.yml
@@ -38,7 +38,7 @@
 #
 Changed:
   - description: |-
-      Updated Mayflower version to 11.5.1.
-        - DP-21660: Fix bullets and list numbers overwrapped with left floated elements in IE11. (MF)
-        - DP-22079: Fixed location listing pagination error, and fixed auto complete. (MF)
+        Updated Mayflower version to 11.5.1.
+          - DP-21660: Fix bullets and list numbers overwrapped with left floated elements in IE11. (MF)
+          - DP-22079: Fixed location listing pagination error, and fixed auto complete. (MF)
     issue: DP-22130

--- a/changelogs/DP-22130.yml
+++ b/changelogs/DP-22130.yml
@@ -1,0 +1,44 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+      Updated Mayflower version to 11.5.1.
+        - DP-21660: Fix bullets and list numbers overwrapped with left floated elements in IE11. (MF)
+        - DP-22079: Fixed location listing pagination error, and fixed auto complete. (MF)
+    issue: DP-22130

--- a/composer.json
+++ b/composer.json
@@ -192,7 +192,7 @@
         "drush/drush": "^10.4",
         "enyo/dropzone": "5.7.2",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.5.0",
+        "massgov/mayflower-artifacts": "11.5.1",
         "mikeyp/google_tag": "dev-8.x-1.x#3caa4f0b7f008576936ab7501d483bfcf58a4764",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "223a07e93c9c1f111f00e8052a3dc4e3",
+    "content-hash": "e080387c02dfad091bf9b36a35429a24",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -10721,16 +10721,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.5.0",
+            "version": "11.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "118e61082730e9d5e40837839e2f72a886362727"
+                "reference": "a7147c462a7d4d4eb9628ab8f04bd5a2448beff7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/118e61082730e9d5e40837839e2f72a886362727",
-                "reference": "118e61082730e9d5e40837839e2f72a886362727",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a7147c462a7d4d4eb9628ab8f04bd5a2448beff7",
+                "reference": "a7147c462a7d4d4eb9628ab8f04bd5a2448beff7",
                 "shasum": ""
             },
             "require": {
@@ -10750,9 +10750,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.5.0"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.5.1"
             },
-            "time": "2021-05-17T20:10:13+00:00"
+            "time": "2021-05-24T18:51:06+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Changed:
  - description: |-
      Updated Mayflower version to 11.5.1.
        - DP-21660: Fix bullets and list numbers overwrapped with left floated elements in IE11. (MF)
        - DP-22079: Fixed location listing pagination error, and fixed auto complete. (MF)
    issue: DP-22130