### PR TITLE
Add script to allow easily turning xdebug off.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -67,3 +67,7 @@ commands:
   nightcrawler:
     usage: Run NightcrawlerJS fatal error tests.
     cmd: ahoy -f ${MASS_DEV_ENV:=docker}.ahoy.yml nightcrawler $@
+
+  xdebug:
+    usage: Turn xdebug "on" or "off"
+    cmd: ahoy exec scripts/xdebug "$@"

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ MASS_CDN_TOKEN=
 
 # XDebug defaults to Off in the drupal container (IDEKEY=PHPSTORM, Port 9000).
 #
-# Uncomment to enable XDebug.
+# Uncomment to enable XDebug (Currently not working, always enabled in image).
 # XDEBUG_ENABLE=1
 #
 # Specify a remote_host (only needed for Windows & Linux hosts).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ See the [Table of Contents](/docs/README.md) for additional documentation relate
     1. **Mac/Linux:** `/etc/hosts`
     1. **Windows:** `c:\windows\system32\drivers\etc\hosts`
 
+1. Run `docker-compose up` from project root.
+
+1. Xdebug can slow down local environment. If not actively using it, you can
+   disable it.
+   - To disable: `ahoy xdebug off`
+   - To enable: `ahoy xdebug on`
+
 ### Native (optional)
 If the Docker section above is unappealing, its easy to run mass.gov natively on any OS. You need to provide your own PHP, web server and DB server (and optional memcache). On OSX, [these install instructions](https://getgrav.org/blog/macos-bigsur-apache-multiple-php-versions) are good (stop at the section called _PHP Switcher Script_), along with this [mysql section](https://getgrav.org/blog/macos-bigsur-apache-mysql-vhost-apc). Point your web server at the /docroot directory.
 
@@ -37,7 +44,7 @@ If the Docker section above is unappealing, its easy to run mass.gov natively on
     ```bash
     sudo wget -q https://github.com/devinci-code/ahoy/releases/download/2.0.0/ahoy-bin-darwin-amd64 -O /usr/local/bin/ahoy && sudo chown $USER /usr/local/bin/ahoy && chmod +x /usr/local/bin/ahoy
     ```
-1. The Ahoy aliases also work for native development environments. Set an environment variable: `MASS_DEV_ENV=native`   
+1. The Ahoy aliases also work for native development environments. Set an environment variable: `MASS_DEV_ENV=native`
 1. Run `ahoy up` to start the Docker containers (n.b. takes about 30 minutes to pull down the latest database).
 1. Run `ahoy comi` to fetch all dependencies.
 

--- a/composer.json
+++ b/composer.json
@@ -115,6 +115,7 @@
         "drupal/config_log": "^2",
         "drupal/core-composer-scaffold": "~8.9.8",
         "drupal/core-recommended": "~8.9.8",
+        "drupal/csv_field": "^1.0@alpha",
         "drupal/csv_serialization": "^1.4",
         "drupal/datalayer": "^1",
         "drupal/devel": "^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e501431296b0740cc44b144f310e033b",
+    "content-hash": "4e16f34eb6c934dc820068eee904dee5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4115,6 +4115,53 @@
             }
         },
         {
+            "name": "drupal/csv_field",
+            "version": "1.0.0-alpha5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/csv_field.git",
+                "reference": "1.0.0-alpha5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/csv_field-1.0.0-alpha5.zip",
+                "reference": "1.0.0-alpha5",
+                "shasum": "85d7f98572150ff1f8b0a8001767f9bb014b3622"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/datatables_cdn": "^1.0",
+                "drupal/papaparse": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha5",
+                    "datestamp": "1623367023",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                }
+            ],
+            "description": "Provides a CSV text field that displays data as a table.",
+            "homepage": "https://www.drupal.org/project/csv_field",
+            "support": {
+                "source": "https://git.drupalcode.org/project/csv_field",
+                "issues": "https://www.drupal.org/project/issues/csv_field"
+            }
+        },
+        {
             "name": "drupal/csv_serialization",
             "version": "1.5.0",
             "source": {
@@ -4320,6 +4367,50 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/datalayer",
                 "issues": "https://www.drupal.org/project/issues/datalayer"
+            }
+        },
+        {
+            "name": "drupal/datatables_cdn",
+            "version": "1.0.0-alpha2",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/datatables_cdn.git",
+                "reference": "1.0.0-alpha2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/datatables_cdn-1.0.0-alpha2.zip",
+                "reference": "1.0.0-alpha2",
+                "shasum": "f0512fb443b1b4e7acc35c613ed11944e37ce9cb"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha2",
+                    "datestamp": "1623260093",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                }
+            ],
+            "description": "Provides javascript library for Datatables plugin.",
+            "homepage": "https://www.drupal.org/project/datatables_cdn",
+            "support": {
+                "source": "https://git.drupalcode.org/project/datatables_cdn"
             }
         },
         {
@@ -7435,6 +7526,50 @@
                 "source": "http://cgit.drupalcode.org/office_hours",
                 "issues": "http://drupal.org/project/office_hours",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/papaparse",
+            "version": "1.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/papaparse.git",
+                "reference": "1.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/papaparse-1.0.0-alpha1.zip",
+                "reference": "1.0.0-alpha1",
+                "shasum": "a552152cec75217b6ebc398f4926ee718ffe81db"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha1",
+                    "datestamp": "1622594388",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                }
+            ],
+            "description": "Provides Drupal library for the Papaparse javascript library.",
+            "homepage": "https://www.drupal.org/project/papaparse",
+            "support": {
+                "source": "https://git.drupalcode.org/project/papaparse"
             }
         },
         {
@@ -18877,6 +19012,7 @@
         "drupal/cloudflare": 15,
         "drupal/conditional_fields": 15,
         "drupal/config_ignore": 20,
+        "drupal/csv_field": 15,
         "drupal/diff": 20,
         "drupal/field_tokens": 10,
         "drupal/focal_point": 10,
@@ -18904,5 +19040,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/scripts/xdebug
+++ b/scripts/xdebug
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [[ "$1" = "on" ]] ; then
+  echo "Enabling xdebug";
+  # Uncomment out the extension include.
+  sed -i 's/^; \(zend_extension=.*xdebug\)$/\1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  /etc/init.d/apache2 reload
+elif [[ "$1" = "off" ]] ; then
+  echo "Disabling xdebug";
+  # Comment out the extension include.
+  sed -i 's/^\(zend_extension=.*xdebug\)$/; \1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  /etc/init.d/apache2 reload
+fi


### PR DESCRIPTION
**Description:**
I noticed the docker is very slow, and that xdebug is enabled by default in the image.  It ignores the XDEBUG_ENABLE environment variable.  Xdebug slows down PHP, but it is very useful.  Based on a concept from the ddev command `ddev xdebug on` and `ddev xdebug off`, I added a script and ahoy command to turn xdebug on and off.

Moche recently helped me fix this underlying issue, so now  XDEBUG_ENABLE is disabled by default.  But even so, this provides a useful tool when Xdebug is enabled.  By commenting out the plugin and restarting apache, you can turn it on and off quickly.


**To Test:**
- [ ] run docker-compose up
- [ ] run `ahoy xdebug off`
- [ ] notice page speeds are faster and running `php -i | grep xdebug` from within the drupal docker container shows xdebug is not enabled within PHP.
- [ ] run `ahoy xdebug on`
- [ ] notice that xdebug is enabled.


[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
