### PR TITLE
DP-22247 Suppress google tag scripts on admin pages.

### DIFF
--- a/conf/drupal/config/google_tag.settings.yml
+++ b/conf/drupal/config/google_tag.settings.yml
@@ -1,6 +1,6 @@
 container_id: GTM-MPHNMQ
 path_toggle: all_except_listed
-path_list: "admin*\nbatch*\nnode/add*\nnode/*/*\nuser/*/*"
+path_list: "/admin*\r\n/batch*\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
 role_toggle: all_except_listed
 role_list:
   - null


### PR DESCRIPTION
**Description:**
There's an error in the google_tag module where the description says not to add leading forward slash.  But this has changed in Drupal since the module has created.  The forward slash should be there.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22247 


**To Test:**
- [ ] do a config import, notice the google tags are no longer loading on the admin pages


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
