### PR TITLE
DP-18737 Add CKEditor CSV Importer functionality.

### DIFF
--- a/changelogs/DP-18737.yml
+++ b/changelogs/DP-18737.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adds CKEditor CSV Importer functionality.
+    issue: DP-18737

--- a/composer.json
+++ b/composer.json
@@ -118,6 +118,7 @@
         "drupal/autologout": "^1",
         "drupal/better_exposed_filters": "^5.0@beta",
         "drupal/cache_metrics": "^2",
+        "drupal/ckeditor_csvtable": "^1.0@alpha",
         "drupal/cloudflare": "^1.0@alpha",
         "drupal/components": "^2.4",
         "drupal/composer_deploy": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc17736c44b09551ce3a9ea792ae7ad7",
+    "content-hash": "ca034b9e2bd5e2cfb8a4f1e312b1e608",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3241,6 +3241,52 @@
             "support": {
                 "source": "https://gitlab.com/drupalspoons/cache_metrics",
                 "issues": "https://gitlab.com/drupalspoons/cache_metrics/-/issues"
+            }
+        },
+        {
+            "name": "drupal/ckeditor_csvtable",
+            "version": "1.0.0-alpha4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/ckeditor_csvtable.git",
+                "reference": "1.0.0-alpha4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/ckeditor_csvtable-1.0.0-alpha4.zip",
+                "reference": "1.0.0-alpha4",
+                "shasum": "041b0c86df550067a9b06dde7c476d2375123257"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/papaparse": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha4",
+                    "datestamp": "1623951583",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                }
+            ],
+            "description": "Provides a CKEditor plugin button to import CSV to an HTML table",
+            "homepage": "https://www.drupal.org/project/ckeditor_csvtable",
+            "support": {
+                "source": "https://git.drupalcode.org/project/ckeditor_csvtable",
+                "issues": "https://www.drupal.org/project/issues/ckeditor_csvtable"
             }
         },
         {
@@ -7476,6 +7522,50 @@
                 "source": "http://cgit.drupalcode.org/office_hours",
                 "issues": "http://drupal.org/project/office_hours",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/papaparse",
+            "version": "1.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/papaparse.git",
+                "reference": "1.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/papaparse-1.0.0-alpha1.zip",
+                "reference": "1.0.0-alpha1",
+                "shasum": "a552152cec75217b6ebc398f4926ee718ffe81db"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0-alpha1",
+                    "datestamp": "1622594388",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Project has not opted into security advisory coverage!"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "oknate",
+                    "homepage": "https://www.drupal.org/user/471638"
+                }
+            ],
+            "description": "Provides Drupal library for the Papaparse javascript library.",
+            "homepage": "https://www.drupal.org/project/papaparse",
+            "support": {
+                "source": "https://git.drupalcode.org/project/papaparse"
             }
         },
         {
@@ -18974,6 +19064,7 @@
     "stability-flags": {
         "drupal/access_unpublished": 20,
         "drupal/better_exposed_filters": 10,
+        "drupal/ckeditor_csvtable": 15,
         "drupal/cloudflare": 15,
         "drupal/conditional_fields": 15,
         "drupal/config_ignore": 20,

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -14,6 +14,7 @@ module:
   breakpoint: 0
   cache_metrics: 0
   ckeditor: 0
+  ckeditor_csvtable: 0
   cloudflare: 0
   components: 0
   composer_deploy: 0
@@ -148,6 +149,7 @@ module:
   node_title_help_text: 0
   office_hours: 0
   options: 0
+  papaparse: 0
   paragraphs: 0
   password_policy: 0
   password_policy_characters: 0

--- a/conf/drupal/config/editor.editor.basic_html.yml
+++ b/conf/drupal/config/editor.editor.basic_html.yml
@@ -38,6 +38,7 @@ settings:
             - Blockquote
             - file_browser
             - Table
+            - csvtable
         -
           name: 'Block Formatting'
           items:

--- a/conf/drupal/config/editor.editor.full_html.yml
+++ b/conf/drupal/config/editor.editor.full_html.yml
@@ -41,6 +41,7 @@ settings:
             - Blockquote
             - file_browser
             - Table
+            - csvtable
             - HorizontalRule
         -
           name: 'Block Formatting'

--- a/conf/drupal/config/editor.editor.rules_of_court_section.yml
+++ b/conf/drupal/config/editor.editor.rules_of_court_section.yml
@@ -38,6 +38,7 @@ settings:
             - Blockquote
             - file_browser
             - Table
+            - csvtable
             - HorizontalRule
         -
           name: 'Block Formatting'


### PR DESCRIPTION
**Description:**
Adds a button to allow importing pasted CSV into CKEditor as a table.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-18737


**To Test:**
- [ ] Edit text using a rich text editor using a format that allows tables, press the "Create Table from CSV" button and paste in some CSV and submit. 
- [ ] Test editing the table using the contextual menu, it will allow you to edit the data as CSV.



**Screenshots/GIFs:**
![ckeditor_csvtable](https://user-images.githubusercontent.com/567614/121971332-805e4a80-cd46-11eb-9c26-08439d2f498d.gif)

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
