### PR TITLE
DP-22253 Add xdebug ahoy command.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -67,3 +67,7 @@ commands:
   nightcrawler:
     usage: Run NightcrawlerJS fatal error tests.
     cmd: ahoy -f ${MASS_DEV_ENV:=docker}.ahoy.yml nightcrawler $@
+
+  xdebug:
+    usage: Pass "on" or "off" to enable or disable Xdebug
+    cmd: ahoy exec scripts/xdebug "$@"

--- a/changelogs/DP-22253.yml
+++ b/changelogs/DP-22253.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adds ahoy command to toggle xdebug on and off.
+    issue: DP-22253

--- a/scripts/xdebug
+++ b/scripts/xdebug
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [[ "$1" = "on" ]] ; then
+  echo "Enabling xdebug";
+  # Uncomment out the extension include.
+  sed -i 's/^; \(zend_extension=.*xdebug\)$/\1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  /etc/init.d/apache2 reload
+elif [[ "$1" = "off" ]] ; then
+  echo "Disabling xdebug";
+  # Comment out the extension include.
+  sed -i 's/^\(zend_extension=.*xdebug\)$/; \1/' $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
+  /etc/init.d/apache2 reload
+fi


### PR DESCRIPTION
**Description:**
Based on a concept from the ddev command `ddev xdebug on` and `ddev xdebug off`, I added a script and ahoy command to turn xdebug on and off.

Moche recently helped me fix the underlying issue, so now  XDEBUG_ENABLE is disabled by default.  But even so, this provides a useful tool when Xdebug is enabled.  By commenting out the plugin and restarting apache, you can turn it on and off quickly.


**To Test:**
- [ ] run docker-compose up with XDEBUG_ENABLE=1 environement variable.
- [ ] run `ahoy xdebug off`
- [ ] notice page speeds are faster and running `php -i | grep xdebug` from within the drupal docker container shows xdebug is not enabled within PHP.
- [ ] run `ahoy xdebug on`
- [ ] notice that xdebug is enabled.


[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
