### PR TITLE
Fix 2 buglets related to Hotfix process (github tag creation and Circle automation)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -912,7 +912,6 @@ workflows:
           requires:
             - build
             - tagging_acquia
-            - deploy-tag-stage-acquia
             - hold_for_prod_maint
           target: prod
           gitRef: tags/$CIRCLE_TAG
@@ -936,7 +935,6 @@ workflows:
           requires:
             - build
             - tagging_acquia
-            - deploy-tag-stage-acquia
             - hold_for_prod_no_maint
           target: prod
           gitRef: tags/$CIRCLE_TAG

--- a/changelogs/DP-19428.yml
+++ b/changelogs/DP-19428.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Fixed:
   - description: Fix 2 buglets related to Hotfix process (github tag creation and Circle automation)
     issue: DP-19428

--- a/changelogs/DP-19428.yml
+++ b/changelogs/DP-19428.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Fix 2 buglets related to Hotfix process (github tag creation and Circle automation)
+    issue: DP-19428

--- a/scripts/tag-github.php
+++ b/scripts/tag-github.php
@@ -27,7 +27,7 @@ if(strpos($branch, "release") !== false){
   $version->incrementMinor();
 }
 // If the commit message has the word "hotfix" in it the tag will increment as patch.
-elseif (strpos($branch, "hotfix") !==false){
+elseif (strpos($branch, "hotfix") !== false){
   $version->incrementPatch();
 }
 // If none of those words are found the tag will be unable to increment correctly.


### PR DESCRIPTION
Deployments need not require a prior deployment to Stage. That’s at the discretion of release manager. Usually stage already has the proposed code and its been approved so these requirements are unneeded.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-19428


**To Test:**
- [ ] N/A

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
