### PR TITLE
DP-22066 DP-22075 English version picker bugfix

### DIFF
--- a/changelogs/DP-22066.yml
+++ b/changelogs/DP-22066.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes options in the English Version field autocomplete picker.
+    issue: DP-22066

--- a/conf/drupal/config/views.view.english_versions_media.yml
+++ b/conf/drupal/config/views.view.english_versions_media.yml
@@ -7,9 +7,7 @@ dependencies:
     - media.type.document
   module:
     - media
-    - taxonomy
     - user
-    - views_autocomplete_filters
 id: english_versions_media
 label: 'English Versions (Media)'
 module: views
@@ -223,15 +221,16 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
-        name:
-          id: name
-          table: taxonomy_term_field_data
-          field: name
-          relationship: field_language
+        langcode:
+          id: langcode
+          table: media_field_data
+          field: langcode
+          relationship: none
           group_type: group
           admin_label: ''
-          operator: '='
-          value: English
+          operator: in
+          value:
+            en: en
           group: 1
           exposed: false
           expose:
@@ -248,14 +247,7 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
-            autocomplete_filter: 0
-            autocomplete_min_chars: '0'
-            autocomplete_items: '10'
-            autocomplete_field: ''
-            autocomplete_raw_suggestion: 1
-            autocomplete_raw_dropdown: 1
-            autocomplete_dependent: 0
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -268,9 +260,9 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: views_autocomplete_filters_string
+          entity_type: media
+          entity_field: langcode
+          plugin_id: language
       sorts:
         name:
           id: name
@@ -289,16 +281,7 @@ display:
       header: {  }
       footer: {  }
       empty: {  }
-      relationships:
-        field_language:
-          id: field_language
-          table: media__field_language
-          field: field_language
-          relationship: none
-          group_type: group
-          admin_label: 'field_language: Taxonomy term'
-          required: true
-          plugin_id: standard
+      relationships: {  }
       arguments: {  }
       display_extenders: {  }
     cache_metadata:

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -83,6 +83,15 @@ function mass_translations_field_widget_multivalue_form_alter(array &$elements, 
       $elements[0]['target_id']['#title'] = '';
     }
   }
+  // Fixes the "English Version" field help text.
+  if (isset($elements['#field_name']) && $elements['#field_name'] == 'field_media_english_version') {
+    $elements['#media_help']['#media_list_help'] = 'Start typing the document title or filename.';
+    $overview_url = Url::fromUri('internal:/admin/ma-dash/documents');
+    if ($overview_url->access()) {
+      $elements['#media_help']['#media_list_link'] = t('See the <a href=":list_url" target="_blank">document list</a> (opens a new window) to help locate media.', [':list_url' => $overview_url->toString()]);
+    }
+    $elements['#media_help']['#allowed_types_help'] = '';
+  }
 }
 
 /**
@@ -136,5 +145,19 @@ function mass_translations_node_presave(EntityInterface $entity) {
   if ($entity->hasField('field_english_version') && $entity->get('langcode')->value == 'en') {
     // If the Language is English, there isn't a seperate English version.
     $entity->set('field_english_version', '');
+  }
+}
+
+/**
+ * Implements hook_module_implements_alter().
+ */
+function mass_translations_module_implements_alter(&$implementations, $hook) {
+  switch ($hook) {
+    // Our hook_field_widget_multivalue_form_alter() to execute last.
+    case 'field_widget_multivalue_form_alter':
+      $group = $implementations['mass_translations'];
+      unset($implementations['mass_translations']);
+      $implementations['mass_translations'] = $group;
+      break;
   }
 }


### PR DESCRIPTION
**Description:**
This changes the entity reference autocomplete picker view to use the langcode on the node to filter the options instead of the old field_langage on document media entities. 

There are also tweaks to the helptext per the ticket.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22066
https://jira.mass.gov/browse/DP-22075


**To Test:**
- [ ] Edit Document ID 2290646
- [ ] Try to set document ID 2250581 (Defendant's Waiver of Jury Trial and Consent to Bench Trial) as the English Version, it should show up in the autocomplete list.