### PR TITLE
DP-22280 Show user who created the schedule transition in revision history

### DIFF
--- a/changelogs/DP-22280.yml
+++ b/changelogs/DP-22280.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Show user who created the schedule transition in revision history.
+    issue: DP-22280

--- a/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
+++ b/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Drupal\mass_scheduled_transitions\EventSubscriber;
+
+
+use Drupal\scheduled_transitions\Event\ScheduledTransitionsNewRevisionEvent;
+use Drupal\scheduled_transitions\EventSubscriber\ScheduledTransitionsNewRevision;
+
+class MassScheduledTransitionsNewRevision extends ScheduledTransitionsNewRevision {
+
+  /**
+   * Set revision owner to be same as the Transition owner. DP-22082.
+   *
+   * @param \Drupal\scheduled_transitions\Event\ScheduledTransitionsNewRevisionEvent $event
+   */
+  public function latestRevision(ScheduledTransitionsNewRevisionEvent $event): void {
+    parent::latestRevision($event);
+    $transition = $event->getScheduledTransition();
+    /** @var \Drupal\Core\Entity\RevisionableInterface $revision */
+    $revision = $event->getNewRevision();
+    $revision->setRevisionUser($transition->getAuthor());
+    $event->setNewRevision($revision);
+  }
+
+}

--- a/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
+++ b/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
@@ -1,18 +1,22 @@
 <?php
 
-
 namespace Drupal\mass_scheduled_transitions\EventSubscriber;
-
 
 use Drupal\scheduled_transitions\Event\ScheduledTransitionsNewRevisionEvent;
 use Drupal\scheduled_transitions\EventSubscriber\ScheduledTransitionsNewRevision;
 
+/**
+ * MassScheduledTransitionsNewRevision
+ *
+ * @package Drupal\mass_scheduled_transitions\EventSubscriber
+ */
 class MassScheduledTransitionsNewRevision extends ScheduledTransitionsNewRevision {
 
   /**
    * Set revision owner to be same as the Transition owner. DP-22082.
    *
    * @param \Drupal\scheduled_transitions\Event\ScheduledTransitionsNewRevisionEvent $event
+   *   An event.
    */
   public function latestRevision(ScheduledTransitionsNewRevisionEvent $event): void {
     parent::latestRevision($event);

--- a/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
+++ b/docroot/modules/custom/mass_scheduled_transitions/src/EventSubscriber/MassScheduledTransitionsNewRevision.php
@@ -6,7 +6,7 @@ use Drupal\scheduled_transitions\Event\ScheduledTransitionsNewRevisionEvent;
 use Drupal\scheduled_transitions\EventSubscriber\ScheduledTransitionsNewRevision;
 
 /**
- * MassScheduledTransitionsNewRevision
+ * MassScheduledTransitionsNewRevision.
  *
  * @package Drupal\mass_scheduled_transitions\EventSubscriber
  */

--- a/docroot/modules/custom/mass_scheduled_transitions/src/MassScheduledTransitionsServiceProvider.php
+++ b/docroot/modules/custom/mass_scheduled_transitions/src/MassScheduledTransitionsServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\mass_scheduled_transitions;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\scheduled_transitions\EventSubscriber\ScheduledTransitionsNewRevision;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Defines a service provider for the Mass Scheduled Transitions module.
+ */
+class MassScheduledTransitionsServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    // Overrides ScheduledTransitionsNewRevision event subscriber.
+    $definition = $container->getDefinition('scheduled_transitions.new_revision');
+    $definition->setClass('\Drupal\mass_scheduled_transitions\EventSubscriber\MassScheduledTransitionsNewRevision');
+  }
+
+}


### PR DESCRIPTION
**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22280

**To Test:**
- [ ] Create an upcoming transition for the next minute or two.
- [ ] Run `drush scheduled-transitions:queue-jobs && drush queue:run scheduled_transition_job`
- [ ] Assure that your name is owner of latest revision (see Revisions tab).


<img width="1118" alt="image" src="https://user-images.githubusercontent.com/7740/122421343-4d8ca000-cf5a-11eb-87dd-599acde19b90.png">


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
