### PR TITLE
DP-22301 sitemap settings tweak

### DIFF
--- a/changelogs/DP-22301.yml
+++ b/changelogs/DP-22301.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Changed the google sitemap setting to 3000 per page.
+    issue: DP-22301

--- a/conf/drupal/config/simple_sitemap.settings.yml
+++ b/conf/drupal/config/simple_sitemap.settings.yml
@@ -1,4 +1,4 @@
-max_links: 10000
+max_links: 3000
 cron_generate: true
 cron_generate_interval: 3
 remove_duplicates: false


### PR DESCRIPTION
**Description:**
The Google sitemap was configured for 10000 links per page, that was too many. This reduced it to 3000.

**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22301


**To Test:**
- [ ] Rebuild sitemap, and confirm links per sitemap page.

