### PR TITLE
DP-22083 Upgrade Mandrill to D9 compatible version, remove patch.

### DIFF
--- a/changelogs/DP-22083.yml
+++ b/changelogs/DP-22083.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Mandrill modules update.
+    issue: DP-22083

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
         "drupal/key": "^1.10",
         "drupal/key_value_field": "1.x-dev",
         "drupal/linkit": "^6",
-        "drupal/mandrill": "1.x-dev",
+        "drupal/mandrill": "^1.2",
         "drupal/maxlength": "^1.0@RC",
         "drupal/media_entity_download": "2.x-dev",
         "drupal/memcache": "^2",
@@ -323,9 +323,6 @@
             },
             "drupal/maxlength": {
                 "Don't enforce maxlength stop, allow negative count down": "https://www.drupal.org/files/issues/2020-12-07/2916687-allow-negative-count-13.patch"
-            },
-            "drupal/mandrill": {
-                "Compatibility with Drupal 9 (https://www.drupal.org/project/mandrill/issues/3137614)": "https://www.drupal.org/files/issues/2020-12-22/3137614-11_0.patch"
             },
             "drupal/metatag": {
                 "Process tokens for arrays (https://www.drupal.org/project/metatag/issues/3162986#comment-14075815)": "https://www.drupal.org/files/issues/2021-04-28/metatag-3162986-13_0.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc17736c44b09551ce3a9ea792ae7ad7",
+    "content-hash": "55f1bff6daadbcc2c27d078b5b1bbb83",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -6776,28 +6776,31 @@
         },
         {
             "name": "drupal/mandrill",
-            "version": "dev-1.x",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/mandrill.git",
-                "reference": "d85b40572c21b0f970b228718f4c7bcdab473823"
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/mandrill-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "59d20d40061590f6220c9e54174641796b72ad2d"
             },
             "require": {
-                "drupal/core": "~8.0",
+                "drupal/core": "^8 || ^9",
                 "drupal/mailsystem": "*",
                 "mandrill/mandrill": "1.0.55"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.1+4-dev",
-                    "datestamp": "1603147971",
+                    "version": "8.x-1.2",
+                    "datestamp": "1624489386",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -6815,16 +6818,12 @@
                     "homepage": "https://www.drupal.org/user/1682976"
                 },
                 {
-                    "name": "julia.leah.ford",
-                    "homepage": "https://www.drupal.org/user/3590443"
-                },
-                {
                     "name": "levelos",
                     "homepage": "https://www.drupal.org/user/54135"
                 },
                 {
-                    "name": "samuel.mortenson",
-                    "homepage": "https://www.drupal.org/user/2582268"
+                    "name": "mariacha1",
+                    "homepage": "https://www.drupal.org/user/2210776"
                 },
                 {
                     "name": "tauno",
@@ -14623,7 +14622,6 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -18982,7 +18980,6 @@
         "drupal/focal_point": 10,
         "drupal/inline_entity_form": 20,
         "drupal/key_value_field": 20,
-        "drupal/mandrill": 20,
         "drupal/maxlength": 5,
         "drupal/media_entity_download": 20,
         "drupal/monolog": 10,


### PR DESCRIPTION
**Description:**
A new release was put out with the patch for Mandrill.  Updating to that version, and removing patch.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22083


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
