### PR TITLE
Dp22487 add languages albanian polish

### DIFF
--- a/changelogs/DP-22487.yml
+++ b/changelogs/DP-22487.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adding Albanian and Polish as available languages for pages and documents.
+    issue: DP-22487

--- a/conf/drupal/config/language.entity.pl.yml
+++ b/conf/drupal/config/language.entity.pl.yml
@@ -1,0 +1,9 @@
+uuid: 65bdee68-81c8-437e-948e-0b8019cc79db
+langcode: en
+status: true
+dependencies: {  }
+id: pl
+label: Polish
+direction: ltr
+weight: 20
+locked: false

--- a/conf/drupal/config/language.entity.sq.yml
+++ b/conf/drupal/config/language.entity.sq.yml
@@ -1,0 +1,9 @@
+uuid: a32be8f6-4762-48bd-bfb0-a168a50e3afb
+langcode: en
+status: true
+dependencies: {  }
+id: sq
+label: Albanian
+direction: ltr
+weight: 19
+locked: false

--- a/conf/drupal/config/language.entity.und.yml
+++ b/conf/drupal/config/language.entity.und.yml
@@ -7,5 +7,5 @@ _core:
 id: und
 label: 'Not specified'
 direction: ltr
-weight: 19
+weight: 21
 locked: true

--- a/conf/drupal/config/language.entity.zxx.yml
+++ b/conf/drupal/config/language.entity.zxx.yml
@@ -7,5 +7,5 @@ _core:
 id: zxx
 label: 'Not applicable'
 direction: ltr
-weight: 20
+weight: 22
 locked: true

--- a/conf/drupal/config/language.negotiation.yml
+++ b/conf/drupal/config/language.negotiation.yml
@@ -22,6 +22,8 @@ url:
     pt-br: pt-br
     hi: hi
     ne: ne
+    sq: sq
+    pl: pl
   domains:
     en: ''
     es: ''
@@ -42,6 +44,8 @@ url:
     pt-br: ''
     hi: ''
     ne: ''
+    sq: ''
+    pl: ''
 selected_langcode: site_default
 _core:
   default_config_hash: uEePITI9tV6WqzmsTb7MfPCi5yPWXSxAN1xeLcYFQbM


### PR DESCRIPTION
**Description:**
Allow languages Polish and Albanian as options for documents and pages.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22487


**To Test:**
- [ ] Add a document. Make sure you can choose languages Polish and Albanian.
- [ ] Add an info detail page. Make sure you can choose languages Polish and Albanian.


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
