### PR TITLE
DP-22483 adding a new  paragraph and content group for paragraph content

### DIFF
--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -1,0 +1,3 @@
+Added:
+  - description: Added a flexible content section to organizations and a 'Featured Topics' paragraph.
+    issue: DP-22263

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -33,6 +33,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -85,6 +86,7 @@ third_party_settings:
         - group_news
         - group_boards
         - group_feedback
+        - group_content
         - group_other
       parent_name: ''
       weight: 1
@@ -106,7 +108,7 @@ third_party_settings:
         - field_organizations
         - field_reusable_label
       parent_name: group_node_edit_form
-      weight: 20
+      weight: 22
       format_type: tab
       format_settings:
         formatter: closed
@@ -121,7 +123,7 @@ third_party_settings:
         - field_links_actions_3
         - field_ref_actions_6
       parent_name: group_node_edit_form
-      weight: 24
+      weight: 26
       format_type: tab
       format_settings:
         formatter: closed
@@ -146,10 +148,9 @@ third_party_settings:
         - field_event_quantity
         - field_billing_organization
       parent_name: group_node_edit_form
-      weight: 30
+      weight: 32
       format_type: tab
       format_settings:
-        label: More
         formatter: closed
         description: ''
         required_fields: true
@@ -166,7 +167,7 @@ third_party_settings:
         - field_social_links
         - field_intended_audience
       parent_name: group_node_edit_form
-      weight: 21
+      weight: 23
       format_type: tab
       format_settings:
         id: ''
@@ -205,7 +206,7 @@ third_party_settings:
         - field_location_button_short_desc
         - field_related_organization_type
       parent_name: group_node_edit_form
-      weight: 25
+      weight: 27
       format_type: tab
       format_settings:
         id: ''
@@ -222,7 +223,7 @@ third_party_settings:
         - field_org_show_news_images
         - field_get_updates_links
       parent_name: group_node_edit_form
-      weight: 27
+      weight: 28
       format_type: tab
       format_settings:
         id: ''
@@ -237,10 +238,9 @@ third_party_settings:
         - field_org_featured_message
         - field_org_featured_items
       parent_name: group_node_edit_form
-      weight: 22
+      weight: 24
       format_type: tab
       format_settings:
-        label: Featured
         formatter: closed
         description: ''
         required_fields: true
@@ -253,10 +253,9 @@ third_party_settings:
         - field_short_name
         - group_about_summary
       parent_name: group_node_edit_form
-      weight: 23
+      weight: 25
       format_type: tab
       format_settings:
-        label: 'About / Details'
         formatter: closed
         description: ''
         id: about-details-tab
@@ -268,7 +267,7 @@ third_party_settings:
       children:
         - field_about
       parent_name: group_about_details
-      weight: 37
+      weight: 84
       format_type: details
       format_settings:
         id: ''
@@ -281,10 +280,9 @@ third_party_settings:
       children:
         - field_boards
       parent_name: group_node_edit_form
-      weight: 28
+      weight: 29
       format_type: tab
       format_settings:
-        label: Boards
         formatter: closed
         description: ''
         required_fields: true
@@ -302,10 +300,9 @@ third_party_settings:
         - field_urgent_warning
         - field_org_sentence_phrasing
       parent_name: group_node_edit_form
-      weight: 29
+      weight: 30
       format_type: tab
       format_settings:
-        label: 'Setup Feedback'
         formatter: closed
         description: ''
         required_fields: true
@@ -313,6 +310,21 @@ third_party_settings:
         classes: ''
       label: 'Setup Feedback'
       region: content
+    group_content:
+      children:
+        - field_org_page_content
+        - field_topics
+      parent_name: group_node_edit_form
+      weight: 31
+      format_type: tab
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        description: ''
+        formatter: closed
+        required_fields: true
+      label: Content
 id: node.org_page.default
 targetEntityType: node
 bundle: org_page
@@ -320,7 +332,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 39
+    weight: 40
     settings:
       rows: 9
       placeholder: ''
@@ -342,7 +354,7 @@ content:
     third_party_settings: {  }
     region: content
   field_application_login_links:
-    weight: 98
+    weight: 99
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -350,7 +362,7 @@ content:
     type: link_default
     region: content
   field_approver:
-    weight: 49
+    weight: 97
     settings:
       size: 40
       placeholder: ''
@@ -380,7 +392,7 @@ content:
     type: string_textfield
     region: content
   field_banner_image:
-    weight: 24
+    weight: 25
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -406,7 +418,7 @@ content:
     type: image_image
     region: content
   field_bg_narrow:
-    weight: 23
+    weight: 24
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber
@@ -432,7 +444,7 @@ content:
     type: image_image
     region: content
   field_bg_wide:
-    weight: 22
+    weight: 23
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber
@@ -458,7 +470,7 @@ content:
     type: image_image
     region: content
   field_billing_organization:
-    weight: 102
+    weight: 103
     settings: {  }
     third_party_settings: {  }
     type: dynamic_entity_reference_options_select
@@ -477,7 +489,7 @@ content:
     region: content
   field_boards:
     type: entity_reference_paragraphs
-    weight: 79
+    weight: 93
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -488,7 +500,7 @@ content:
     third_party_settings: {  }
     region: content
   field_career_opportunities:
-    weight: 97
+    weight: 98
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -496,19 +508,19 @@ content:
     type: link_default
     region: content
   field_constituent_communication:
-    weight: 47
+    weight: 95
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_event_quantity:
-    weight: 101
+    weight: 102
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_feedback_com_link:
-    weight: 50
+    weight: 98
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -542,7 +554,7 @@ content:
     type: link_default
     region: content
   field_image_credit:
-    weight: 25
+    weight: 26
     settings:
       size: 60
       placeholder: ''
@@ -550,7 +562,7 @@ content:
     type: string_textfield
     region: content
   field_intended_audience:
-    weight: 42
+    weight: 43
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -580,14 +592,14 @@ content:
     type: string_textfield
     region: content
   field_metatags:
-    weight: 2
+    weight: 3
     settings:
       sidebar: true
     third_party_settings: {  }
     type: metatag_firehose
     region: content
   field_more_about_agency_link:
-    weight: 94
+    weight: 95
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -595,7 +607,7 @@ content:
     type: link_default
     region: content
   field_more_about_leadership:
-    weight: 95
+    weight: 96
     settings:
       match_operator: CONTAINS
       size: 60
@@ -611,7 +623,7 @@ content:
     type: options_select
     region: content
   field_org_directory_page:
-    weight: 96
+    weight: 97
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -665,8 +677,20 @@ content:
     third_party_settings:
       conditional_fields: {  }
     region: content
+  field_org_page_content:
+    type: entity_reference_paragraphs
+    weight: 109
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: topics
+    third_party_settings: {  }
+    region: content
   field_org_page_thumbnail:
-    weight: 40
+    weight: 41
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -684,7 +708,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_org_sentence_phrasing:
-    weight: 53
+    weight: 101
     settings:
       size: 60
       placeholder: ''
@@ -699,7 +723,7 @@ content:
     type: boolean_checkbox
     region: content
   field_organizations:
-    weight: 26
+    weight: 27
     settings:
       match_operator: CONTAINS
       size: 60
@@ -709,7 +733,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_parent:
-    weight: 100
+    weight: 101
     settings:
       match_operator: CONTAINS
       size: 60
@@ -747,7 +771,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_public_records_link:
-    weight: 99
+    weight: 100
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -776,7 +800,7 @@ content:
     region: content
   field_ref_contact_info_1:
     type: entity_reference_autocomplete_tags
-    weight: 21
+    weight: 22
     settings:
       match_operator: CONTAINS
       size: 60
@@ -795,14 +819,14 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_related_organization_type:
-    weight: 101
+    weight: 83
     settings:
       display_label: false
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_response_expectations:
-    weight: 51
+    weight: 99
     settings:
       rows: 5
       placeholder: ''
@@ -834,7 +858,7 @@ content:
     type: string_textarea
     region: content
   field_reusable_label:
-    weight: 27
+    weight: 28
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -872,7 +896,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_short_name:
-    weight: 35
+    weight: 83
     settings:
       size: 60
       placeholder: ''
@@ -880,7 +904,7 @@ content:
     type: string_textfield
     region: content
   field_social_links:
-    weight: 41
+    weight: 42
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -888,7 +912,7 @@ content:
     type: link_default
     region: content
   field_state_organization_tax:
-    weight: 6
+    weight: 4
     settings:
       match_operator: CONTAINS
       size: 60
@@ -899,7 +923,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_sub_brand:
-    weight: 38
+    weight: 39
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber
@@ -930,14 +954,14 @@ content:
     type: string_textfield
     region: content
   field_urgent_warning:
-    weight: 52
+    weight: 100
     settings:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
   field_verification:
-    weight: 48
+    weight: 96
     settings:
       display_label: true
     third_party_settings:
@@ -963,7 +987,7 @@ content:
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 10
+    weight: 6
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -1019,7 +1043,7 @@ content:
     type: options_select
     region: content
   url_redirects:
-    weight: 9
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_form_display.paragraph.topics.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.topics.default.yml
@@ -1,0 +1,33 @@
+uuid: ca467193-85b6-4687-8179-4db07dc3317f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.topics.field_topic_name_only
+    - field.field.paragraph.topics.field_topic_topics
+    - paragraphs.paragraphs_type.topics
+id: paragraph.topics.default
+targetEntityType: paragraph
+bundle: topics
+mode: default
+content:
+  field_topic_name_only:
+    weight: 0
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_topic_topics:
+    weight: 1
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -153,6 +154,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.all_services.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.all_services.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -151,6 +152,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
@@ -33,6 +33,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -373,6 +374,15 @@ content:
     type: entity_reference_revisions_entity_view
     weight: 21
     label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_org_page_content:
+    type: entity_reference_revisions_entity_view
+    weight: 138
+    label: above
     settings:
       view_mode: default
       link: ''

--- a/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -162,6 +163,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_show_news_images: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -124,6 +125,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -143,6 +144,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -139,6 +140,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -130,6 +131,7 @@ hidden:
   field_org_page_about_desc: true
   field_org_page_about_image: true
   field_org_page_add_section: true
+  field_org_page_content: true
   field_org_page_short_name: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -133,6 +134,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -129,6 +130,7 @@ hidden:
   field_org_page_about_desc: true
   field_org_page_about_image: true
   field_org_page_add_section: true
+  field_org_page_content: true
   field_org_page_short_name: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
@@ -34,6 +34,7 @@ dependencies:
     - field.field.node.org_page.field_org_featured_message
     - field.field.node.org_page.field_org_featured_news_items
     - field.field.node.org_page.field_org_our_orgs
+    - field.field.node.org_page.field_org_page_content
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_ref_locations
     - field.field.node.org_page.field_org_sentence_phrasing
@@ -120,6 +121,7 @@ hidden:
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_page_content: true
   field_org_page_thumbnail: true
   field_org_ref_locations: true
   field_org_sentence_phrasing: true

--- a/conf/drupal/config/core.entity_view_display.node.topic_page.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic_page.link_only.yml
@@ -1,0 +1,58 @@
+uuid: 62c749d4-8f37-4538-ac1f-ba44b4b12252
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.link_only
+    - field.field.node.topic_page.field_image_credit
+    - field.field.node.topic_page.field_intended_audience
+    - field.field.node.topic_page.field_organizations
+    - field.field.node.topic_page.field_reusable_label
+    - field.field.node.topic_page.field_state_organization_tax
+    - field.field.node.topic_page.field_topic_bg_narrow
+    - field.field.node.topic_page.field_topic_bg_wide
+    - field.field.node.topic_page.field_topic_content_cards
+    - field.field.node.topic_page.field_topic_display_links
+    - field.field.node.topic_page.field_topic_lede
+    - field.field.node.topic_page.field_topic_metatags
+    - field.field.node.topic_page.field_topic_ref_icon
+    - field.field.node.topic_page.field_topic_ref_related_topics
+    - field.field.node.topic_page.field_topic_section_bg_narrow
+    - field.field.node.topic_page.field_topic_section_bg_wide
+    - field.field.node.topic_page.field_topic_type
+    - node.type.topic_page
+  module:
+    - user
+id: node.topic_page.link_only
+targetEntityType: node
+bundle: topic_page
+mode: link_only
+content:
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  computed_card_links: true
+  content_moderation_control: true
+  extra_org_feedback_form: true
+  field_image_credit: true
+  field_intended_audience: true
+  field_organizations: true
+  field_reusable_label: true
+  field_state_organization_tax: true
+  field_topic_bg_narrow: true
+  field_topic_bg_wide: true
+  field_topic_content_cards: true
+  field_topic_display_links: true
+  field_topic_lede: true
+  field_topic_metatags: true
+  field_topic_ref_content_cards: true
+  field_topic_ref_icon: true
+  field_topic_ref_related_topics: true
+  field_topic_section_bg_narrow: true
+  field_topic_section_bg_wide: true
+  field_topic_type: true
+  langcode: true
+  links: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.topics.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.topics.default.yml
@@ -1,0 +1,33 @@
+uuid: 3524b2f6-3a00-4487-92cf-3ac0b9eafa4a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.topics.field_topic_name_only
+    - field.field.paragraph.topics.field_topic_topics
+    - paragraphs.paragraphs_type.topics
+id: paragraph.topics.default
+targetEntityType: paragraph
+bundle: topics
+mode: default
+content:
+  field_topic_name_only:
+    type: boolean
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+  field_topic_topics:
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: card
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/conf/drupal/config/core.entity_view_mode.node.card_compact.yml
+++ b/conf/drupal/config/core.entity_view_mode.node.card_compact.yml
@@ -1,0 +1,10 @@
+uuid: dd9bea07-8d9e-4e37-8e77-eb82405f3014
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.card_compact
+label: 'Card Compact'
+targetEntityType: node
+cache: true

--- a/conf/drupal/config/field.field.node.org_page.field_org_page_content.yml
+++ b/conf/drupal/config/field.field.node.org_page.field_org_page_content.yml
@@ -1,0 +1,373 @@
+uuid: 4d9873e3-d490-4eaf-bf1d-1830af377fe3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_org_page_content
+    - node.type.org_page
+    - paragraphs.paragraphs_type.topics
+  module:
+    - entity_reference_revisions
+id: node.org_page.field_org_page_content
+field_name: field_org_page_content
+entity_type: node
+bundle: org_page
+label: Content
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      topics: topics
+    target_bundles_drag_drop:
+      1up_stacked_band:
+        weight: 116
+        enabled: false
+      2up_stacked_band:
+        weight: 117
+        enabled: false
+      3_up_content:
+        weight: 118
+        enabled: false
+      3_up_text:
+        weight: 119
+        enabled: false
+      about:
+        weight: 120
+        enabled: false
+      action_address:
+        weight: 121
+        enabled: false
+      action_address_info:
+        weight: 122
+        enabled: false
+      action_area:
+        weight: 123
+        enabled: false
+      action_set:
+        weight: 124
+        enabled: false
+      action_step:
+        weight: 125
+        enabled: false
+      action_step_numbered:
+        weight: 126
+        enabled: false
+      action_step_numbered_list:
+        weight: 127
+        enabled: false
+      activities:
+        weight: 128
+        enabled: false
+      activity:
+        weight: 129
+        enabled: false
+      address:
+        weight: 130
+        enabled: false
+      adjustment_type:
+        weight: 131
+        enabled: false
+      advisory_issuer:
+        weight: 132
+        enabled: false
+      advisory_section:
+        weight: 133
+        enabled: false
+      board_member:
+        weight: 134
+        enabled: false
+      callout_alert:
+        weight: 135
+        enabled: false
+      callout_button:
+        weight: 136
+        enabled: false
+      callout_link:
+        weight: 137
+        enabled: false
+      campaign_features:
+        weight: 138
+        enabled: false
+      card:
+        weight: 139
+        enabled: false
+      caspio_embed:
+        weight: 140
+        enabled: false
+      completion_time:
+        weight: 141
+        enabled: false
+      contact:
+        weight: 142
+        enabled: false
+      contact_group:
+        weight: 143
+        enabled: false
+      contact_info:
+        weight: 144
+        enabled: false
+      content_card_group:
+        weight: 145
+        enabled: false
+      custom_html:
+        weight: 146
+        enabled: false
+      decision_participants:
+        weight: 147
+        enabled: false
+      decision_section:
+        weight: 148
+        enabled: false
+      emergency_alert:
+        weight: 149
+        enabled: false
+      event_agenda_section:
+        weight: 150
+        enabled: false
+      event_minutes_section:
+        weight: 151
+        enabled: false
+      external_organization:
+        weight: 152
+        enabled: false
+      fax_number:
+        weight: 153
+        enabled: false
+      featured_content_2up_item:
+        weight: 154
+        enabled: false
+      featured_content_single_item:
+        weight: 155
+        enabled: false
+      featured_item:
+        weight: 156
+        enabled: false
+      featured_item_mosaic:
+        weight: 157
+        enabled: false
+      featured_message:
+        weight: 158
+        enabled: false
+      file_download:
+        weight: 159
+        enabled: false
+      file_download_single:
+        weight: 160
+        enabled: false
+      footnotes:
+        weight: 161
+        enabled: false
+      full_bleed:
+        weight: 162
+        enabled: false
+      guide_section:
+        weight: 163
+        enabled: false
+      guide_section_3up:
+        weight: 164
+        enabled: false
+      homepage_background_images:
+        weight: 165
+        enabled: false
+      hours:
+        weight: 166
+        enabled: false
+      icon:
+        weight: 167
+        enabled: false
+      icon_link:
+        weight: 168
+        enabled: false
+      icon_links:
+        weight: 169
+        enabled: false
+      iframe:
+        weight: 170
+        enabled: false
+      image:
+        weight: 171
+        enabled: false
+      image_credit:
+        weight: 172
+        enabled: false
+      info_details_card_group:
+        weight: 173
+        enabled: false
+      issuer:
+        weight: 174
+        enabled: false
+      key_message:
+        weight: 175
+        enabled: false
+      key_message_section:
+        weight: 176
+        enabled: false
+      link_group:
+        weight: 177
+        enabled: false
+      link_group_document:
+        weight: 178
+        enabled: false
+      link_group_link:
+        weight: 179
+        enabled: false
+      links:
+        weight: 180
+        enabled: false
+      links_downloads:
+        weight: 181
+        enabled: false
+      list_board_members:
+        weight: 182
+        enabled: false
+      list_dynamic:
+        weight: 183
+        enabled: false
+      list_item_contact:
+        weight: 184
+        enabled: false
+      list_item_document:
+        weight: 185
+        enabled: false
+      list_item_link:
+        weight: 186
+        enabled: false
+      list_item_person:
+        weight: 187
+        enabled: false
+      list_manual_directory:
+        weight: 188
+        enabled: false
+      list_static:
+        weight: 189
+        enabled: false
+      location_information:
+        weight: 190
+        enabled: false
+      manage_account_link:
+        weight: 191
+        enabled: false
+      map:
+        weight: 192
+        enabled: false
+      map_row:
+        weight: 193
+        enabled: false
+      media_contact:
+        weight: 194
+        enabled: false
+      method:
+        weight: 195
+        enabled: false
+      more_info:
+        weight: 196
+        enabled: false
+      multiple_answers:
+        weight: 197
+        enabled: false
+      next_step:
+        weight: 198
+        enabled: false
+      online_email:
+        weight: 199
+        enabled: false
+      organization_grid:
+        weight: 200
+        enabled: false
+      page:
+        weight: 201
+        enabled: false
+      page_group:
+        weight: 202
+        enabled: false
+      phone_number:
+        weight: 203
+        enabled: false
+      pull_quote:
+        weight: 204
+        enabled: false
+      quick_action:
+        weight: 205
+        enabled: false
+      recommended_activity:
+        weight: 206
+        enabled: false
+      regulation_section:
+        weight: 207
+        enabled: false
+      related_content:
+        weight: 208
+        enabled: false
+      related_link:
+        weight: 209
+        enabled: false
+      rich_text:
+        weight: 210
+        enabled: false
+      rules_section:
+        weight: 211
+        enabled: false
+      rules_updates:
+        weight: 212
+        enabled: false
+      search_band:
+        weight: 213
+        enabled: false
+      search_banner:
+        weight: 214
+        enabled: false
+      section:
+        weight: 215
+        enabled: false
+      section_board_members:
+        weight: 216
+        enabled: false
+      section_heading_text:
+        weight: 217
+        enabled: false
+      section_long_form:
+        weight: 218
+        enabled: false
+      section_with_heading:
+        weight: 219
+        enabled: false
+      slideshow:
+        weight: 220
+        enabled: false
+      stacked_band:
+        weight: 221
+        enabled: false
+      start_button:
+        weight: 222
+        enabled: false
+      stat:
+        weight: 223
+        enabled: false
+      state_organization:
+        weight: 224
+        enabled: false
+      subhead:
+        weight: 225
+        enabled: false
+      tableau_embed:
+        weight: 226
+        enabled: false
+      topics:
+        enabled: true
+        weight: 227
+      video:
+        weight: 228
+        enabled: false
+      video_with_header:
+        weight: 229
+        enabled: false
+      video_with_section:
+        weight: 230
+        enabled: false
+field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.paragraph.topics.field_topic_name_only.yml
+++ b/conf/drupal/config/field.field.paragraph.topics.field_topic_name_only.yml
@@ -1,0 +1,23 @@
+uuid: 80740866-baf7-46b7-9c81-8a1b686cbd9b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_topic_name_only
+    - paragraphs.paragraphs_type.topics
+id: paragraph.topics.field_topic_name_only
+field_name: field_topic_name_only
+entity_type: paragraph
+bundle: topics
+label: 'Show topic name only without child links.'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.topics.field_topic_topics.yml
+++ b/conf/drupal/config/field.field.paragraph.topics.field_topic_topics.yml
@@ -1,0 +1,28 @@
+uuid: 43daca9b-f685-4a82-9e8f-41357e5cb291
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_topic_topics
+    - node.type.topic_page
+    - paragraphs.paragraphs_type.topics
+id: paragraph.topics.field_topic_topics
+field_name: field_topic_topics
+entity_type: paragraph
+bundle: topics
+label: Topics
+description: 'You can use this area to include up to 15 topics that are relevant. You can look at the site''s main navigation to explore the topics that exist.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      topic_page: topic_page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.storage.node.field_org_page_content.yml
+++ b/conf/drupal/config/field.storage.node.field_org_page_content.yml
@@ -1,0 +1,21 @@
+uuid: 7ae215f3-d488-4d82-9d0e-439215ef977f
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_org_page_content
+field_name: field_org_page_content
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.paragraph.field_topic_name_only.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_topic_name_only.yml
@@ -1,0 +1,18 @@
+uuid: d7305202-e5ce-4e00-84b0-86883efffa28
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_topic_name_only
+field_name: field_topic_name_only
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.paragraph.field_topic_topics.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_topic_topics.yml
@@ -1,0 +1,20 @@
+uuid: 859195be-95da-4354-8771-2fbedb45fa42
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_topic_topics
+field_name: field_topic_topics
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: 15
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/paragraphs.paragraphs_type.topics.yml
+++ b/conf/drupal/config/paragraphs.paragraphs_type.topics.yml
@@ -1,0 +1,10 @@
+uuid: 4f431f64-1b97-405d-b9ff-a5d512cede2f
+langcode: en
+status: true
+dependencies: {  }
+id: topics
+label: 'Featured Topics'
+icon_uuid: null
+icon_default: null
+description: 'Include topics into the content, either just the title or including the child topics.'
+behavior_plugins: {  }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6756,3 +6756,21 @@ function mass_theme_preprocess_paragraph__featured_content_single_item(&$variabl
   mass_theme_campaign_landing_paragraph_set_header_level($variables);
   mass_theme_featured_content_cards($variables);
 }
+
+/**
+ * Display cards or compact cards depending on the settings.
+ */
+function mass_theme_preprocess_paragraph__topics(&$variables) {
+  $paragraph = $variables['paragraph'];
+  if($paragraph->field_topic_name_only->value == true) {
+    $field_topics = $variables['content']['field_topic_topics'];
+    $count = $field_topics['#items']->count();
+    if ($count) {
+      for ($i = 0; $i < $count; $i++) {
+        $field_topics[$i]['#view_mode'] = 'card_compact';
+        unset($field_topics[$i]['#cache']['keys']);
+      }
+    }
+    $variables['content']['field_topic_topics'] = $field_topics;
+  }
+}

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6762,7 +6762,7 @@ function mass_theme_preprocess_paragraph__featured_content_single_item(&$variabl
  */
 function mass_theme_preprocess_paragraph__topics(&$variables) {
   $paragraph = $variables['paragraph'];
-  if($paragraph->field_topic_name_only->value == true) {
+  if ($paragraph->field_topic_name_only->value == TRUE) {
     $field_topics = $variables['content']['field_topic_topics'];
     $count = $field_topics['#items']->count();
     if ($count) {

--- a/docroot/themes/custom/mass_theme/templates/content/node--card-compact.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--card-compact.html.twig
@@ -1,0 +1,95 @@
+{#
+/**
+ * @file
+ * Theme override to display a topic page node in the card display mode.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ *
+ */
+#}
+
+{# Set top heading level for the page. #}
+{% set level = 2 %}
+{% if elements['#level'] is not empty %}
+  {% set level = elements['#level'] %}
+{% endif %}
+{# TODO: Implement 'compact' variable in the pl component. #}
+{% embed "@molecules/section-links.twig" with {
+  "sectionLinks": {
+    "id": node.id,
+    "title": {
+      "href": url,
+      "text": node.title.value,
+      "info": ""
+    },
+    "level": level,
+    "description": "",
+    "compact": true
+  }
+} %}
+
+{% endembed %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page.html.twig
@@ -543,6 +543,24 @@
         {% endif %}
       {% endblock %}
 
+      {# Content paragraph #}
+      {% block orgContent %}
+        {% if node.field_org_page_content is not empty %}
+
+          {% embed "@organisms/by-author/stacked-row-section.twig" with {
+            "stackedRowSection": {
+              "title":"",
+              "id":""
+            }
+          } %}
+            {% block stackedRowContentOverride %}
+              {{ content.field_org_page_content }}
+            {% endblock %}
+          {% endembed %}
+
+        {% endif %}
+      {% endblock %}
+
       {# Recent news & announcements #}
       {% block recentNews %}
         {% if news %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--topic-page--card-compact.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--topic-page--card-compact.html.twig
@@ -77,7 +77,7 @@
 {% if elements['#level'] is not empty %}
   {% set level = elements['#level'] %}
 {% endif %}
-
+{# TODO: Implement 'compact' variable in the pl component. #}
 {% embed "@molecules/section-links.twig" with {
   "sectionLinks": {
     "id": node.id,
@@ -87,7 +87,8 @@
       "info": ""
     },
     "level": level,
-    "description": ""
+    "description": "",
+    "compact": true
   }
 } %}
 

--- a/docroot/themes/custom/mass_theme/templates/content/node--topic-page--card-compact.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--topic-page--card-compact.html.twig
@@ -1,0 +1,94 @@
+{#
+/**
+ * @file
+ * Theme override to display a topic page node in the card display mode.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ *
+ */
+#}
+
+{# Set top heading level for the page. #}
+{% set level = 2 %}
+{% if elements['#level'] is not empty %}
+  {% set level = elements['#level'] %}
+{% endif %}
+
+{% embed "@molecules/section-links.twig" with {
+  "sectionLinks": {
+    "id": node.id,
+    "title": {
+      "href": url,
+      "text": node.title.value,
+      "info": ""
+    },
+    "level": level,
+    "description": ""
+  }
+} %}
+
+{% endembed %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--topics.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--topics.html.twig
@@ -1,0 +1,68 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * If we are using the default paragraph, we only want it to print the content.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+
+ {% embed "@organisms/by-author/stacked-row-section.twig" with {
+   "stackedRowSection": {
+     "title":"",
+     "id":""
+   }
+ } %}
+   {% block stackedRowContentOverride %}
+     {% embed "@organisms/by-author/sections-three-up.twig" with {
+       "sectionThreeUp": {
+         "compHeading": {
+           "title": "Featured Topics",
+           "sub": "",
+           "color": "",
+           "id": "",
+           "centered": ""
+         }
+       }
+     } %}
+       {% block sectionLinks %}
+         {{ content.field_topic_topics|merge({'#level': level + 1 }) }}
+       {% endblock %}
+     {% endembed %}
+   {% endblock %}
+ {% endembed %}


### PR DESCRIPTION
**Description:**
There is a new paragraph called "Featured Topics" with a checkbox and a topics reference field (limited to 15 items).
Then I added a new form tab for Organizations called "Content", this tab contains a field called "Content" as well which is a  paragraph reference field of unlimited values, for now it only supports "featured topics" paragraphs.

Finally, I created a new view mode called "Card Compact" and it's switching the display mode for the paragraph entities from mass.theme using a preprocessing function.


**Jira:** (Skip unless you are MA staff)
https://jira.mass.gov/browse/DP-22483


**To Test:**
- [ ] Edit an Organization, go to the content tab and add a new featured content paragraph.


**Screenshots/GIFs:**
<img width="1538" alt="Captura de Pantalla 2021-07-12 a la(s) 16 12 01" src="https://user-images.githubusercontent.com/141685/125343420-6c4d3f00-e32c-11eb-9edf-74c059a486d4.png">

<img width="1531" alt="Captura de Pantalla 2021-07-12 a la(s) 16 16 47" src="https://user-images.githubusercontent.com/141685/125343552-943ca280-e32c-11eb-8343-a07554af0634.png">


In the case of mobile, it's still showing the expanding "plus" and when clicked it has just a "Read more" link which is probably not needed, this needs an update to Mayflower PL component, which is a different pull request, let me know if I should do this change too.

<img width="369" alt="Captura de Pantalla 2021-07-12 a la(s) 16 16 22" src="https://user-images.githubusercontent.com/141685/125343781-d7971100-e32c-11eb-84c9-224b36238f5e.png">

Let me know if you'll prefer a different tab / field name or if I should place it on an existing one instead.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
