### PR TITLE
Mayflower/dp 22507 mayflower version 11.8.0

### DIFF
--- a/changelogs/DP-22507.yml
+++ b/changelogs/DP-22507.yml
@@ -1,0 +1,47 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 11.8.0.
+            - DP-21924: Changed Twig syntax for drupal-9 (MF)
+            - DP-18737: Target regular richtext table more specifically. (MF)
+            - DP-22334: Add quick action links to GeneralTeaser component. (MF)
+            - DP-22506: Reverted globally changed ul/ol elements styling targeting types, fix the listing regressions in navs. (MF)
+            - DP-22281: Fixed the google translate element for mobile. (MF)
+    issue: DP-22507

--- a/composer.json
+++ b/composer.json
@@ -229,7 +229,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.7.1",
+        "massgov/mayflower-artifacts": "11.8.0",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^7",
         "symfony/dom-crawler": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d07b5af9005bf276b00ffd43d34bd35",
+    "content-hash": "213f57473df409a9ff597c3b9f4e3ff6",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11443,16 +11443,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.7.1",
+            "version": "11.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "94fdc6f6b938d4fc3d8d56583ede59ec2d33b06f"
+                "reference": "64566763381a29f954042f56578d436553b0b224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/94fdc6f6b938d4fc3d8d56583ede59ec2d33b06f",
-                "reference": "94fdc6f6b938d4fc3d8d56583ede59ec2d33b06f",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/64566763381a29f954042f56578d436553b0b224",
+                "reference": "64566763381a29f954042f56578d436553b0b224",
                 "shasum": ""
             },
             "require": {
@@ -11472,9 +11472,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.7.1"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.8.0"
             },
-            "time": "2021-06-28T19:05:04+00:00"
+            "time": "2021-07-12T21:21:23+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -19120,5 +19120,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 11.8.0.
            - DP-21924: Changed Twig syntax for drupal-9 (MF)
            - DP-18737: Target regular richtext table more specifically. (MF)
            - DP-22334: Add quick action links to GeneralTeaser component. (MF)
            - DP-22506: Reverted globally changed ul/ol elements styling targeting types, fix the listing regressions in navs. (MF)
            - DP-22281: Fixed the google translate element for mobile. (MF)
    issue: DP-22507