### PR TITLE
Fix tag invalidation for alerts page responses.

### DIFF
--- a/changelogs/DP-22571.yml
+++ b/changelogs/DP-22571.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Fix invalidation of alert responses upon alert edits.
+    issue: DP-22571

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -32,7 +32,7 @@ const MASS_ALERTS_TAG_SITEWIDE = 'mass_alerts_sitewide';
  *   One of three options.
  */
 function mass_alerts_get_scope(NodeInterface $node) {
-  return $node->get("field_alert_display")->getValue();
+  return $node->get("field_alert_display")->getString();
 }
 
 /**
@@ -170,7 +170,7 @@ function mass_alerts_entity_operation_alter(array &$operations, EntityInterface 
 function mass_alerts_node_access(NodeInterface $node, $operation, AccountInterface $account) {
   if ($operation === "update" && $node->bundle() === "alert") {
     $alert_placement = mass_alerts_get_scope($node);
-    if (!empty($alert_placement) && $alert_placement[0]['value'] === 'site_wide') {
+    if (!empty($alert_placement) && $alert_placement === 'site_wide') {
       return AccessResult::forbiddenIf(!$account->hasPermission("create site wide alerts"));
     }
   }
@@ -209,14 +209,16 @@ function mass_alerts_invalidate_tags(NodeInterface $node) {
   if ($node->bundle() === "alert") {
     $scope = mass_alerts_get_scope($node);
     if ($scope == MASS_ALERTS_SCOPE_ORG) {
-      $orgs = $node->get('field_target_organization.target_id')->getValue();
+      $orgs = array_column($node->field_target_organization->getValue(), 'target_id');
       $tags = Cache::buildTags(MASS_ALERTS_TAG_ORG, $orgs);
     }
-    elseif ($scope == MASS_ALERTS_SCOPE_PAGE) {
-      $pages = $node->get('field_target_page.target_id')->getValue();
-      $tags = Cache::buildTags(MASS_ALERTS_TAG_PAGE, $pages);
+    elseif ($scope === MASS_ALERTS_SCOPE_PAGE) {
+      if (!$node->get('field_target_page')->isEmpty()) {
+        $pages = array_column($node->field_target_page->getValue(), 'target_id');
+        $tags = Cache::buildTags(MASS_ALERTS_TAG_PAGE, $pages);
+      }
     }
-    elseif ($scope == MASS_ALERTS_SCOPE_SITEWIDE) {
+    elseif ($scope === MASS_ALERTS_SCOPE_SITEWIDE) {
       $tags = [MASS_ALERTS_TAG_SITEWIDE . ':list'];
     }
     Cache::invalidateTags($tags);
@@ -250,7 +252,7 @@ function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
   if ($node->bundle() === "alert" && !MassModeration::isPrepublish($node)) {
     // Only send notifications if the alert is site-wide.
     $alert_placement = mass_alerts_get_scope($node);
-    if (!empty($alert_placement) && $alert_placement[0]['value'] === 'site_wide') {
+    if (!empty($alert_placement) && $alert_placement === 'site_wide') {
       $langcode = $node->language()->getId();
       $email_addresses = \Drupal::state()->get('mass_alerts.alert_emails');
       if (!empty($email_addresses)) {

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -18,6 +18,7 @@ use Drupal\node\Entity\Node;
 const MASS_ALERTS_SCOPE_SITEWIDE = 'site_wide';
 const MASS_ALERTS_SCOPE_PAGE = 'specific_target_pages';
 const MASS_ALERTS_SCOPE_ORG = 'by_organization';
+const MASS_ALERTS_TAG_GLOBAL = 'mass_alerts';
 const MASS_ALERTS_TAG_PAGE = 'mass_alerts_page';
 const MASS_ALERTS_TAG_ORG = 'mass_alerts_org';
 const MASS_ALERTS_TAG_SITEWIDE = 'mass_alerts_sitewide';

--- a/docroot/modules/custom/mass_alerts/src/Controller/AlertsController.php
+++ b/docroot/modules/custom/mass_alerts/src/Controller/AlertsController.php
@@ -134,6 +134,7 @@ class AlertsController extends ControllerBase implements ContainerInjectionInter
       '#emergencyAlerts' => $results['emergencyAlerts'],
       '#cache' => [
         'tags' => [
+          MASS_ALERTS_TAG_GLOBAL,
           MASS_ALERTS_TAG_SITEWIDE . ':list'
         ]
       ],
@@ -241,6 +242,7 @@ class AlertsController extends ControllerBase implements ContainerInjectionInter
       $results['headerAlerts'] = array_values($alerts);
     }
 
+    $tags[] = MASS_ALERTS_TAG_GLOBAL;
     $tags = Cache::buildTags(MASS_ALERTS_TAG_ORG, $org_ids);
     $tags[] = MASS_ALERTS_TAG_PAGE . ":$nid";
     $build = [


### PR DESCRIPTION
**Description:**
getValue() and getString() confusion broke tag invalidation. None of the conditions matched so no invalidation happens.

**Jira:** (Skip unless you are MA staff)
DP-22571


**To Test:**
- [ ] See Fionna bug reports in Teams last night and today (Friday). No 30 min wait needed since the issue was in Drupal and not varnish or cdn.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
