### PR TITLE
Mayflower/dp 22584 mayflower version 11.9.0

### DIFF
--- a/changelogs/DP-22584.yml
+++ b/changelogs/DP-22584.yml
@@ -1,0 +1,46 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description:  |-
+          Updated Mayflower version to 11.9.0
+            - DP-22292: Hide duplicate links in the component from assistive technology and keyboard users. (MF)
+            - DP-22292: Set up keeping focus in the overaly while it's open. (MF)
+            - DP-22395: Implement new designs for EmergencyAlerts. Added HeaderAlerts to replace HeaderAlert. (MF)
+            - DP-22559: Fixed javascript error regarding moved element. (MF)
+    issue: DP-22584

--- a/composer.json
+++ b/composer.json
@@ -213,7 +213,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.8.0",
+        "massgov/mayflower-artifacts": "11.9.0",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^7",
         "symfony/dom-crawler": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a19f2d9314958a56f5daa5e75efeba8",
+    "content-hash": "74289d63888f7521abeb0a212b129ee3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11431,16 +11431,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.8.0",
+            "version": "11.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "64566763381a29f954042f56578d436553b0b224"
+                "reference": "8b6d9963608d193d548029c6c14ea8c1b576f1d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/64566763381a29f954042f56578d436553b0b224",
-                "reference": "64566763381a29f954042f56578d436553b0b224",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/8b6d9963608d193d548029c6c14ea8c1b576f1d5",
+                "reference": "8b6d9963608d193d548029c6c14ea8c1b576f1d5",
                 "shasum": ""
             },
             "require": {
@@ -11460,9 +11460,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.8.0"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.9.0"
             },
-            "time": "2021-07-12T21:21:23+00:00"
+            "time": "2021-07-20T14:52:43+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -19108,5 +19108,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Changed:
  - description:  |-
          Updated Mayflower version to 11.9.0
            - DP-22292: Hide duplicate links in the component from assistive technology and keyboard users. (MF)
            - DP-22292: Set up keeping focus in the overaly while it's open. (MF)
            - DP-22395: Implement new designs for EmergencyAlerts. Added HeaderAlerts to replace HeaderAlert. (MF)
            - DP-22559: Fixed javascript error regarding moved element. (MF)
    issue: DP-22584
