### PR TITLE
DP-22533: Allow authors to hide short description on org page

### DIFF
--- a/changelogs/DP-22533.yml
+++ b/changelogs/DP-22533.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added a checkbox to the Organization content type to hide the short description on page display.
+    issue: DP-22533

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -161,6 +162,7 @@ third_party_settings:
     group_overview:
       children:
         - field_sub_title
+        - field_hide_short_description
         - field_sub_brand
         - body
         - field_org_page_thumbnail
@@ -331,7 +333,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 12
+    weight: 13
     settings:
       rows: 9
       placeholder: ''
@@ -353,7 +355,7 @@ content:
     third_party_settings: {  }
     region: content
   field_application_login_links:
-    weight: 118
+    weight: 123
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -469,7 +471,7 @@ content:
     type: image_image
     region: content
   field_billing_organization:
-    weight: 122
+    weight: 127
     settings: {  }
     third_party_settings: {  }
     type: dynamic_entity_reference_options_select
@@ -488,7 +490,7 @@ content:
     region: content
   field_boards:
     type: entity_reference_paragraphs
-    weight: 79
+    weight: 106
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -499,7 +501,7 @@ content:
     third_party_settings: {  }
     region: content
   field_career_opportunities:
-    weight: 117
+    weight: 122
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -513,7 +515,7 @@ content:
     type: options_select
     region: content
   field_event_quantity:
-    weight: 121
+    weight: 126
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -545,12 +547,19 @@ content:
     type: link_default
     region: content
   field_get_updates_links:
-    weight: 33
+    weight: 109
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_hide_short_description:
+    weight: 11
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   field_image_credit:
     weight: 13
@@ -561,13 +570,13 @@ content:
     type: string_textfield
     region: content
   field_intended_audience:
-    weight: 15
+    weight: 16
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_links_actions_3:
-    weight: 26
+    weight: 81
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -598,7 +607,7 @@ content:
     type: metatag_firehose
     region: content
   field_more_about_agency_link:
-    weight: 114
+    weight: 119
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -606,7 +615,7 @@ content:
     type: link_default
     region: content
   field_more_about_leadership:
-    weight: 115
+    weight: 120
     settings:
       match_operator: CONTAINS
       size: 60
@@ -616,13 +625,13 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_number_of_news_items:
-    weight: 31
+    weight: 107
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_org_directory_page:
-    weight: 116
+    weight: 121
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -654,7 +663,7 @@ content:
     third_party_settings: {  }
     region: content
   field_org_featured_news_items:
-    weight: 29
+    weight: 106
     settings:
       match_operator: CONTAINS
       size: 60
@@ -665,7 +674,7 @@ content:
     region: content
   field_org_our_orgs:
     type: entity_reference_paragraphs
-    weight: 112
+    weight: 117
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -677,7 +686,7 @@ content:
       conditional_fields: {  }
     region: content
   field_org_page_thumbnail:
-    weight: 13
+    weight: 14
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -703,7 +712,7 @@ content:
     type: string_textfield
     region: content
   field_org_show_news_images:
-    weight: 32
+    weight: 108
     settings:
       display_label: true
     third_party_settings: {  }
@@ -732,7 +741,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_parent:
-    weight: 120
+    weight: 125
     settings:
       match_operator: CONTAINS
       size: 60
@@ -770,7 +779,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_public_records_link:
-    weight: 119
+    weight: 124
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -778,7 +787,7 @@ content:
     type: link_default
     region: content
   field_ref_actions_6:
-    weight: 28
+    weight: 82
     settings:
       match_operator: CONTAINS
       size: 60
@@ -788,7 +797,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_ref_card_view_6:
-    weight: 111
+    weight: 116
     settings:
       match_operator: CONTAINS
       size: 60
@@ -808,7 +817,7 @@ content:
     third_party_settings: {  }
     region: content
   field_ref_orgs:
-    weight: 113
+    weight: 118
     settings:
       match_operator: CONTAINS
       size: 60
@@ -903,7 +912,7 @@ content:
     type: string_textfield
     region: content
   field_social_links:
-    weight: 14
+    weight: 15
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -922,7 +931,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_sub_brand:
-    weight: 11
+    weight: 12
     settings:
       preview_image_style: thumbnail
       progress_indicator: throbber

--- a/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -140,6 +141,7 @@ hidden:
   field_featured_board_members: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.all_services.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.all_services.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -138,6 +139,7 @@ hidden:
   field_event_quantity: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_location_button_label: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -408,7 +409,7 @@ content:
     region: content
   field_organization_sections:
     type: entity_reference_revisions_entity_view
-    weight: 137
+    weight: 52
     label: above
     settings:
       view_mode: default
@@ -554,6 +555,7 @@ hidden:
   field_approver: true
   field_constituent_communication: true
   field_feedback_com_link: true
+  field_hide_short_description: true
   field_metatags: true
   field_org_sentence_phrasing: true
   field_parent: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -149,6 +150,7 @@ hidden:
   field_constituent_communication: true
   field_event_quantity: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -111,6 +112,7 @@ hidden:
   field_event_quantity: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -131,6 +132,7 @@ hidden:
   field_event_quantity: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_location_button_label: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -126,6 +127,7 @@ hidden:
   field_event_quantity: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -114,6 +115,7 @@ hidden:
   field_featured_board_members: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -120,6 +121,7 @@ hidden:
   field_featured_board_members: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -111,6 +112,7 @@ hidden:
   field_feedback_com_link: true
   field_file_attachment: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.org_page.field_event_quantity
     - field.field.node.org_page.field_feedback_com_link
     - field.field.node.org_page.field_get_updates_links
+    - field.field.node.org_page.field_hide_short_description
     - field.field.node.org_page.field_image_credit
     - field.field.node.org_page.field_intended_audience
     - field.field.node.org_page.field_links_actions_3
@@ -107,6 +108,7 @@ hidden:
   field_event_quantity: true
   field_feedback_com_link: true
   field_get_updates_links: true
+  field_hide_short_description: true
   field_image_credit: true
   field_intended_audience: true
   field_links_actions_3: true

--- a/conf/drupal/config/field.field.node.org_page.field_hide_short_description.yml
+++ b/conf/drupal/config/field.field.node.org_page.field_hide_short_description.yml
@@ -1,0 +1,23 @@
+uuid: 3422d9b3-e0c2-4fb4-a3ce-8b931713a697
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_short_description
+    - node.type.org_page
+id: node.org_page.field_hide_short_description
+field_name: field_hide_short_description
+entity_type: node
+bundle: org_page
+label: 'Hide short description on page'
+description: 'The short description field is used for page metadata and is displayed at the top of the page, but you can prevent it from being displayed on the page if you check this box.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.storage.node.field_hide_short_description.yml
+++ b/conf/drupal/config/field.storage.node.field_hide_short_description.yml
@@ -1,0 +1,18 @@
+uuid: b9a62e80-74fb-406b-bc4e-f0b01b08d1bb
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hide_short_description
+field_name: field_hide_short_description
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page.html.twig
@@ -335,6 +335,12 @@
 {% block main %}
   <div class="main-content{{ _sidebar is not empty ? ' main-content--two': ' main-content--full'}}">
     <div class="page-content">
+      {# Short Description #}
+      {% if node.field_hide_short_description is not defined or node.field_hide_short_description.0.value == 0 %}
+        {% block shortDescription %}
+          {{ content.field_sub_title }}
+        {% endblock %}
+      {% endif %}
       {% block pageContent %}
         {{ content.field_organization_sections }}
       {% endblock %}


### PR DESCRIPTION
**Description:**
Added a checkbox to the Organization content type to hide the short description on page display.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22533


**To Test:**
- Login and view an organization page.
- Verify the short description is showing.
- Edit the organization page.
- Click on the "Overview" tab.
- Check the "Hide short description on page" checkbox and save.
- View the organization page.
- [ ] Verify there is no short description showing.
- Edit the organization page again, uncheck the checkbox and save.
- [ ] Verify the short description is showing again.


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
