### PR TITLE
DP-22537: Make paragraph for Related Organizations on org page

### DIFF
--- a/changelogs/DP-22537.yml
+++ b/changelogs/DP-22537.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Converted Organization Page Related Organizations field into an Organization Related Organizations paragraph.
+    issue: DP-22537

--- a/conf/drupal/config/core.entity_form_display.paragraph.org_related_orgs.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.org_related_orgs.default.yml
@@ -1,0 +1,25 @@
+uuid: d553caf6-2601-4f92-a202-e24d76400cd3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.org_related_orgs.field_ref_orgs
+    - paragraphs.paragraphs_type.org_related_orgs
+id: paragraph.org_related_orgs.default
+targetEntityType: paragraph
+bundle: org_related_orgs
+mode: default
+content:
+  field_ref_orgs:
+    weight: 0
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+hidden:
+  created: true
+  status: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.org_related_orgs.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.org_related_orgs.default.yml
@@ -1,0 +1,22 @@
+uuid: 0e0102ad-7486-4b2e-9bea-5c8eb1dc7e74
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.org_related_orgs.field_ref_orgs
+    - paragraphs.paragraphs_type.org_related_orgs
+id: paragraph.org_related_orgs.default
+targetEntityType: paragraph
+bundle: org_related_orgs
+mode: default
+content:
+  field_ref_orgs:
+    weight: 0
+    label: hidden
+    settings:
+      link: true
+      view_mode: default
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+    region: content
+hidden: {  }

--- a/conf/drupal/config/field.field.paragraph.org_related_orgs.field_ref_orgs.yml
+++ b/conf/drupal/config/field.field.paragraph.org_related_orgs.field_ref_orgs.yml
@@ -1,0 +1,28 @@
+uuid: 8346d4a0-de2f-40be-aea1-b674ed33fa3f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_ref_orgs
+    - node.type.org_page
+    - paragraphs.paragraphs_type.org_related_orgs
+id: paragraph.org_related_orgs.field_ref_orgs
+field_name: field_ref_orgs
+entity_type: paragraph
+bundle: org_related_orgs
+label: 'Related Organizations'
+description: 'Choose other organizations to surface as related to this organization''s page. Do not include organizations that fall under the current organization.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      org_page: org_page
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.paragraph.org_section_long_form.field_section_long_form_content.yml
+++ b/conf/drupal/config/field.field.paragraph.org_section_long_form.field_section_long_form_content.yml
@@ -7,15 +7,13 @@ dependencies:
     - paragraphs.paragraphs_type.callout_link
     - paragraphs.paragraphs_type.caspio_embed
     - paragraphs.paragraphs_type.featured_topics
-    - paragraphs.paragraphs_type.featured_item_mosaic
-    - paragraphs.paragraphs_type.featured_message
     - paragraphs.paragraphs_type.iframe
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.info_details_card_group
-    - paragraphs.paragraphs_type.list_board_members
-    - paragraphs.paragraphs_type.org_news
     - paragraphs.paragraphs_type.org_events
     - paragraphs.paragraphs_type.org_locations
+    - paragraphs.paragraphs_type.org_news
+    - paragraphs.paragraphs_type.org_related_orgs
     - paragraphs.paragraphs_type.org_section_long_form
     - paragraphs.paragraphs_type.organization_grid
     - paragraphs.paragraphs_type.pull_quote
@@ -43,17 +41,15 @@ settings:
       callout_link: callout_link
       caspio_embed: caspio_embed
       featured_topics: featured_topics
-      featured_item_mosaic: featured_item_mosaic
-      featured_message: featured_message
       iframe: iframe
       image: image
       info_details_card_group: info_details_card_group
-      list_board_members: list_board_members
       organization_grid: organization_grid
-      org_news: org_news
-      org_events: org_events
       org_locations: org_locations
+      org_events: org_events
+      org_news: org_news
       pull_quote: pull_quote
+      org_related_orgs: org_related_orgs
       rich_text: rich_text
       stat: stat
       tableau_embed: tableau_embed
@@ -323,6 +319,9 @@ settings:
       org_news:
         enabled: true
         weight: 204
+      org_related_orgs:
+        enabled: true
+        weight: 209
       org_section_long_form:
         weight: 200
         enabled: false

--- a/conf/drupal/config/field.storage.paragraph.field_ref_orgs.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_ref_orgs.yml
@@ -1,0 +1,20 @@
+uuid: f9ba3729-3046-4bbe-b18b-a085c05edaa3
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - paragraphs
+id: paragraph.field_ref_orgs
+field_name: field_ref_orgs
+entity_type: paragraph
+type: entity_reference
+settings:
+  target_type: node
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/paragraphs.paragraphs_type.org_related_orgs.yml
+++ b/conf/drupal/config/paragraphs.paragraphs_type.org_related_orgs.yml
@@ -1,0 +1,10 @@
+uuid: e04df030-0b31-46ba-b09f-228c14006623
+langcode: en
+status: true
+dependencies: {  }
+id: org_related_orgs
+label: 'Organization Related Organizations'
+icon_uuid: null
+icon_default: null
+description: 'Related organizations for an Organization.'
+behavior_plugins: {  }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5285,6 +5285,34 @@ function mass_theme_preprocess_paragraph__related_content(&$variables) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Preprocess logic for the org_related_orgs paragraph.
+ */
+function mass_theme_preprocess_paragraph__org_related_orgs(&$variables) {
+  $paragraph = $variables['paragraph'];
+
+  // Add related orgs stack row section.
+  if (Helper::isFieldPopulated($paragraph, 'field_ref_orgs')) {
+    $linkList_options = [
+      'sectionClass' => 'ma__related-organizations',
+    ];
+
+    $sections[] = [
+      'pageContent' => [
+        [
+          'path' => '@organisms/by-author/link-list.twig',
+          'data' => [
+            'linkList' => Organisms::prepareLinkList($paragraph, 'field_ref_orgs', $linkList_options),
+          ],
+        ],
+      ],
+    ];
+    $variables['stackedRowSections'] = $sections;
+  }
+}
+
+/**
  * Provide the desired design layout for related things.
  *
  * @param array $total_type_with_count

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-related-orgs.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-related-orgs.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   - id: The paragraph ID.
+ *   - bundle: The type of the paragraph, for example, "image" or "text".
+ *   - authorid: The user ID of the paragraph author.
+ *   - createdtime: Formatted creation date. Preprocess functions can
+ *     reformat it by calling format_date() with the desired parameters on
+ *     $variables['paragraph']->getCreatedTime().
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% for stackedRowSection in stackedRowSections %}
+  {% set stackedRowSection = stackedRowSection|merge({'level': level}) %}
+  {% include "@organisms/by-author/stacked-row-section.twig" %}
+{% endfor %}


### PR DESCRIPTION
**Description:**
Converted Organization Page Related Organizations field into an Organization Related Organizations paragraph.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22537

**To Test:**
- Login and go to /node/add/org_page (or edit an existing org_page).
- Click on the "Content" tab.
- Expand the "Section Content" field.
- [ ] Verify there is an "Add Organization Related Organizations" button.
- Click the "Add Organization Related Organizations" button.
- [ ] Verify there is an "Related Organizations" field.
- Add content to the fields and save (recommend editing an existing org_page with Related Organizations content).
- [ ] View the org_page and verify the content displays as expected.

**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
