### PR TITLE
DP-22654: Migrate org page Featured Message to sections

### DIFF
--- a/changelogs/DP-22654.yml
+++ b/changelogs/DP-22654.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Feature Message data to sections for Organization pages.
+    issue: DP-22654

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -5,11 +5,47 @@
  * Functions needed for the migration of org_page data into dynamic sections.
  */
 
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Add a new org section paragraph to the org sections field.
+ */
+function _mass_content_org_page_migration_add_section(&$node, $new_section_paragraph) {
+  $field_organization_sections = [];
+  if (!$node->field_organization_sections->isEmpty()) {
+    // Get the field_organization_sections value.
+    $field_organization_sections = $node->get('field_organization_sections')->getValue();
+  }
+  // Create a value array for the new section paragraph.
+  $new_section_paragraph_value = [
+    'target_id' => $new_section_paragraph->id(),
+    'target_revision_id' => $new_section_paragraph->getRevisionId(),
+  ];
+  // Add the new section paragraph value to the end of the section field value.
+  array_push($field_organization_sections, $new_section_paragraph_value);
+  // Update the node field value.
+  $node->set('field_organization_sections', $field_organization_sections);
+}
+
 /**
  * Migrate data for the featured message section.
  */
 function _mass_content_org_page_migration_featured_message(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_org_featured_message->isEmpty()) {
+    // Get the field value.
+    $field_org_featured_message = $node->get('field_org_featured_message')->getValue();
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+      ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_featured_message);
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -38,7 +38,7 @@ function _mass_content_org_page_migration_featured_message(&$node) {
     // Create a new Organization Section paragraph.
     $new_org_section_long_form_paragraph = Paragraph::create([
       'type' => 'org_section_long_form',
-      ]);
+    ]);
     // Set the field values.
     $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_featured_message);
     // Save the new paragraph.


### PR DESCRIPTION
**Description:**
Added logic to migrate Featured Message content for org_page nodes.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22654

**To Test:**
- Visit an org_page that had Featured Message content.
- Verify the content it now displayed on the page.
- Login and edit the org_page.
- Verify the Featured Message in the Organization Sections field is the same as the one in the Featured Message field.
- Verify the org_page revision didn’t update.

**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
