### PR TITLE
DP-22656: Migrate org page Organization Grid to sections

### DIFF
--- a/changelogs/DP-22656.yml
+++ b/changelogs/DP-22656.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Our Organizations data to sections for Organization pages.
+    issue: DP-22656

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -101,7 +101,24 @@ function _mass_content_org_page_migration_who_we_serve(&$node) {
  * Migrate data for the our organizations (organization grid) section.
  */
 function _mass_content_org_page_migration_organization_grid(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_org_our_orgs->isEmpty()) {
+    // Get the field value.
+    $field_org_our_orgs = $node->get('field_org_our_orgs')->getValue();
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_our_orgs);
+    // Get the heading from the paragraph (There can only be one paragraph and
+    // the heading field is required).
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Our Organizations');
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Added logic to migrate Our Organization field values to Organization Sections.


**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22656

**To Test:**
- Visit an org_page that had Our Organizations content.
- [ ] Verify the content it now displayed on the page.
- Login and edit the org_page.
- [ ] Verify the Organization Grid in the Organization Sections field is the same as the one in the Featured Items field.
- [ ] Verify the org_page revision didn’t update.

Feature3 comparison links:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-test-elected-org-page 
- Prod: https://www.mass.gov/orgs/qag-test-elected-org-page


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
