### PR TITLE
DP-22659: Make paragraph for News on org page

### DIFF
--- a/changelogs/DP-22659.yml
+++ b/changelogs/DP-22659.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated News data to sections for Organization pages.
+    issue: DP-22659

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -111,8 +111,6 @@ function _mass_content_org_page_migration_organization_grid(&$node) {
     ]);
     // Set the field values.
     $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_our_orgs);
-    // Get the heading from the paragraph (There can only be one paragraph and
-    // the heading field is required).
     $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Our Organizations');
     // Save the new paragraph.
     $new_org_section_long_form_paragraph->save();
@@ -139,7 +137,39 @@ function _mass_content_org_page_migration_featured_topics(&$node) {
  * Migrate data for the news section.
  */
 function _mass_content_org_page_migration_news(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_org_featured_news_items->isEmpty()
+    || !$node->field_number_of_news_items->isEmpty()) {
+    $field_org_featured_news_items = $node->get('field_org_featured_news_items')->getValue();
+    $field_number_of_news_items = $node->get('field_number_of_news_items')->getValue();
+    $field_org_show_news_images = $node->get('field_org_show_news_images')->getValue();
+    // Create a new Organization News paragraph.
+    $new_org_news_paragraph = Paragraph::create([
+      'type' => 'org_news',
+    ]);
+    // Set the field values.
+    $new_org_news_paragraph->set('field_org_featured_news_items', $field_org_featured_news_items);
+    $new_org_news_paragraph->set('field_number_of_news_items', $field_number_of_news_items);
+    $new_org_news_paragraph->set('field_org_show_news_images', $field_org_show_news_images);
+    // Save the new paragraph.
+    $new_org_news_paragraph->save();
+    // Create a value array for the new section paragraph.
+    $field_section_long_form_content = [
+      'target_id' => $new_org_news_paragraph->id(),
+      'target_revision_id' => $new_org_news_paragraph->getRevisionId(),
+    ];
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_section_long_form_content);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Recent news & announcements');
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Added logic to migrate News data to Organization Sections.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22534

**To Test:**
- Visit an org_page that had News content.
- [ ] Verify the content it now displayed on the page.
- Login and edit the org_page.
- [ ] Verify the News in the Organization Sections field is the same as the one in the News related fields.
- [ ] Verify the org_page revision didn’t update.

Feature3 comparison links:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-test-elected-org-page 
- Prod: https://www.mass.gov/orgs/qag-test-elected-org-page

**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
