### PR TITLE
Mayflower/dp 22673 mayflower version 11.11.0

### DIFF
--- a/changelogs/DP-2267.yml
+++ b/changelogs/DP-2267.yml
@@ -1,0 +1,44 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 11.11.0.
+          - DP-22653: Adds PageHeaderAddons component to render additional contents below PageHeader. (MF)
+          - DP-22653: Takes out optionalContents and widgets from the PageHeader component. Add PageHeaderAddons to the template to render those instead (no change to the PageHeader data object structure). (MF)
+    issue: DP-22673

--- a/composer.json
+++ b/composer.json
@@ -214,7 +214,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.10.0",
+        "massgov/mayflower-artifacts": "11.11.0",
         "phlak/semver": "^2.0",
         "phpunit/phpunit": "^7",
         "symfony/dom-crawler": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1b3a9eefa6c84a68c309b36fddb32b0",
+    "content-hash": "d72d1380d8b99e65495ccb7e82e795fd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11570,16 +11570,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.10.0",
+            "version": "11.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "97f1d04f3a7915b66b3e969cf5bbac9f880badc4"
+                "reference": "897f5cbc969a2fdc94f705aba9b1734d50a5912b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/97f1d04f3a7915b66b3e969cf5bbac9f880badc4",
-                "reference": "97f1d04f3a7915b66b3e969cf5bbac9f880badc4",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/897f5cbc969a2fdc94f705aba9b1734d50a5912b",
+                "reference": "897f5cbc969a2fdc94f705aba9b1734d50a5912b",
                 "shasum": ""
             },
             "require": {
@@ -11599,9 +11599,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.10.0"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.11.0"
             },
-            "time": "2021-07-26T19:38:38+00:00"
+            "time": "2021-08-02T20:35:08+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -19249,5 +19249,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 11.11.0.
          - DP-22653: Adds PageHeaderAddons component to render additional contents below PageHeader. (MF)
          - DP-22653: Takes out optionalContents and widgets from the PageHeader component. Add PageHeaderAddons to the template to render those instead (no change to the PageHeader data object structure). (MF)
    issue: DP-22673