### PR TITLE
Drush ma:backstop can now send custom --list and --viewport params.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,12 @@ parameters:
   reference:
     type: string
     default: ""
+  list:
+    type: string
+    default: "all"
+  viewport:
+    type: string
+    default: "all"
 
   # These params for currently used in drush ma:release
   ma-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1029,6 +1029,8 @@ workflows:
           requires: [build]
           target: << pipeline.parameters.target >>
           reference: << pipeline.parameters.reference >>
+          list: << pipeline.parameters.list >>
+          viewport: << pipeline.parameters.viewport >>
 
   # Usually triggered by drush ma:release.
   deploy_ad_hoc:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,15 +3,12 @@ Explain the technical implementation of the work done.
 
 
 **Jira:** (Skip unless you are MA staff)
-https://jira.mass.gov/browse/DP-****
+DP-****
 
 
 **To Test:**
 - [ ] Add steps to test this feature
 
-
-**Screenshots/GIFs:**
-Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.
 
 ---
 

--- a/changelogs/DP-22551.yml
+++ b/changelogs/DP-22551.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Drush ma:backstop can now send custom --list and --viewport params.
+    issue: DP-22551

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -33,6 +33,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    *
    * @param string $target Target environment.
    * @param string $reference Reference environment.
+   * @option list The list you want to run. See backstop/backstop.js
+   * @option viewport The viewport you want to run.  See backstop/backstop.js.
    * @option ci-branch The branch that CircleCI should check out at start.
    *
    * @aliases ma-backstop
@@ -43,7 +45,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @throws \Exception
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function backstop($target, $reference, array $options = ['ci-branch' => 'develop']) {
+  public function backstop($target, $reference, array $options = ['ci-branch' => 'develop', 'list' => 'all', 'viewport' => 'all']) {
     $stack = $this->getStack();
     $client = new \GuzzleHttp\Client(['handler' => $stack]);
     $options = [
@@ -56,6 +58,8 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
           'ma-backstop' => TRUE,
           'target' => $target,
           'reference' => $reference,
+          'list' => $options['list'],
+          'viewport' => $options['viewport'],
         ],
       ],
     ];


### PR DESCRIPTION
**Jira:**
DP-22551

**To Test:**
- [ ] assure `list` param is set properly in the pipeline resulting from `drush ma:backstop --ci-branch=ma-backstop-params feature5 prod --list=post-release -vvv`/ Here is such a run (last step) https://app.circleci.com/pipelines/github/massgov/openmass/10526/workflows/0812b858-d40e-4cb2-ae63-6934d36fae39/jobs/43133

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
