### PR TITLE
DP-22656: Migrate org page Organization Grid to sections (follow up)

### DIFF
--- a/changelogs/DP-22656.yml
+++ b/changelogs/DP-22656.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Our Organizations data to sections for Organization pages.
+    issue: DP-22656

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -135,7 +135,6 @@ third_party_settings:
     group_other:
       children:
         - field_ref_card_view_6
-        - field_org_our_orgs
         - field_ref_orgs
         - field_more_about_agency_link
         - field_more_about_leadership
@@ -618,19 +617,6 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  field_org_our_orgs:
-    type: entity_reference_paragraphs
-    weight: 117
-    settings:
-      title: Paragraph
-      title_plural: Paragraphs
-      edit_mode: open
-      add_mode: dropdown
-      form_display_mode: default
-      default_paragraph_type: _none
-    third_party_settings:
-      conditional_fields: {  }
-    region: content
   field_org_page_thumbnail:
     weight: 14
     settings:
@@ -1008,6 +994,7 @@ hidden:
   field_boards: true
   field_org_featured_items: true
   field_org_featured_message: true
+  field_org_our_orgs: true
   langcode: true
   path: true
   promote: true

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -101,7 +101,24 @@ function _mass_content_org_page_migration_who_we_serve(&$node) {
  * Migrate data for the our organizations (organization grid) section.
  */
 function _mass_content_org_page_migration_organization_grid(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_org_our_orgs->isEmpty()) {
+    // Get the field value.
+    $field_org_our_orgs = $node->get('field_org_our_orgs')->getValue();
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_our_orgs);
+    // Get the heading from the paragraph (There can only be one paragraph and
+    // the heading field is required).
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Our Organizations');
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -107,6 +107,8 @@ function _mass_content_org_page_migration_organization_grid(&$node) {
   if (!$node->field_org_our_orgs->isEmpty()) {
     // Get the field value.
     $field_org_our_orgs = $node->get('field_org_our_orgs')->getValue();
+    // Remove the old field values.
+    $node->set('field_org_our_orgs', []);
     // Create a new Organization Section paragraph.
     $new_org_section_long_form_paragraph = Paragraph::create([
       'type' => 'org_section_long_form',


### PR DESCRIPTION
**Description:**
Added logic to remove field data and hid the field.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22656

**To Test:**
- [ ] Verify the Our Organizations field is no longer visible on org_page node form.


**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
