### PR TITLE
DP-22703: Data listing topics/sub topics fixes

### DIFF
--- a/changelogs/DP-22703.yml
+++ b/changelogs/DP-22703.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed bugs related to the Data Listing and Collections features.
+    issue: DP-22703

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.data_topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.data_topic.default.yml
@@ -5,11 +5,21 @@ dependencies:
   config:
     - field.field.taxonomy_term.data_topic.field_url_name
     - taxonomy.vocabulary.data_topic
+  module:
+    - text
 id: taxonomy_term.data_topic.default
 targetEntityType: taxonomy_term
 bundle: data_topic
 mode: default
 content:
+  description:
+    type: text_textarea
+    weight: 2
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_url_name:
     weight: 1
     settings:
@@ -20,7 +30,7 @@ content:
     region: content
   langcode:
     type: language_select
-    weight: 2
+    weight: 3
     region: content
     settings:
       include_locked: true
@@ -37,9 +47,8 @@ content:
     type: boolean_checkbox
     settings:
       display_label: true
-    weight: 3
+    weight: 4
     region: content
     third_party_settings: {  }
 hidden:
-  description: true
   path: true

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.data_topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.data_topic.default.yml
@@ -1,0 +1,45 @@
+uuid: 4902813e-55c2-4a2a-84ee-296c9903b5c3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.data_topic.field_url_name
+    - taxonomy.vocabulary.data_topic
+id: taxonomy_term.data_topic.default
+targetEntityType: taxonomy_term
+bundle: data_topic
+mode: default
+content:
+  field_url_name:
+    weight: 1
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 3
+    region: content
+    third_party_settings: {  }
+hidden:
+  description: true
+  path: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.data_topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.data_topic.default.yml
@@ -1,0 +1,24 @@
+uuid: dc9cd630-2477-4ca0-a4d9-71f54613b86f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.data_topic.field_url_name
+    - taxonomy.vocabulary.data_topic
+  module:
+    - text
+id: taxonomy_term.data_topic.default
+targetEntityType: taxonomy_term
+bundle: data_topic
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_url_name: true
+  langcode: true

--- a/conf/drupal/config/field.field.taxonomy_term.collections.field_url_name.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.collections.field_url_name.yml
@@ -10,7 +10,7 @@ field_name: field_url_name
 entity_type: taxonomy_term
 bundle: collections
 label: 'URL Name'
-description: 'The hyphenated name used in the URL path to view the Collection or Topic pages. Use only letters and hyphens, no special characters. If this value is changed, links to the Collection or Topic pages will need to be updated on the site. (For sub topics, this field will not be used)'
+description: 'The hyphenated name used in the URL path to view the Collection or Topic pages. Use only letters and hyphens, no special characters, and make sure it is unique for this vocabulary. If this value is changed, links to the Collection or Topic pages will need to be updated on the site. (For sub topics, this field will not be used)'
 required: true
 translatable: false
 default_value: {  }

--- a/conf/drupal/config/field.field.taxonomy_term.data_topic.field_url_name.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.data_topic.field_url_name.yml
@@ -1,0 +1,19 @@
+uuid: 25064a7c-f39e-4bf7-b4a9-2350b3d4cdd7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_url_name
+    - taxonomy.vocabulary.data_topic
+id: taxonomy_term.data_topic.field_url_name
+field_name: field_url_name
+entity_type: taxonomy_term
+bundle: data_topic
+label: 'URL Name'
+description: 'The hyphenated name used in the URL path to view the Topic pages. Use only letters and hyphens, no special characters. If this value is changed, links to the Topic pages will need to be updated on the site. (For sub topics, this field will not be used)'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.taxonomy_term.data_topic.field_url_name.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.data_topic.field_url_name.yml
@@ -10,7 +10,7 @@ field_name: field_url_name
 entity_type: taxonomy_term
 bundle: data_topic
 label: 'URL Name'
-description: 'The hyphenated name used in the URL path to view the Topic pages. Use only letters and hyphens, no special characters. If this value is changed, links to the Topic pages will need to be updated on the site. (For sub topics, this field will not be used)'
+description: 'The hyphenated name used in the URL path to view the Topic pages. Use only letters and hyphens, no special characters, and make sure it is unique for this vocabulary. If this value is changed, links to the Topic pages will need to be updated on the site. (For sub topics, this field will not be used)'
 required: true
 translatable: true
 default_value: {  }

--- a/conf/drupal/config/rabbit_hole.behavior_settings.taxonomy_vocabulary_data_topic.yml
+++ b/conf/drupal/config/rabbit_hole.behavior_settings.taxonomy_vocabulary_data_topic.yml
@@ -5,10 +5,10 @@ dependencies:
   config:
     - taxonomy.vocabulary.data_topic
 id: taxonomy_vocabulary_data_topic
-entity_type_id: null
-entity_id: null
-action: display_page
-allow_override: 1
+entity_type_id: taxonomy_vocabulary
+entity_id: data_topic
+action: page_not_found
+allow_override: 0
 redirect: ''
 redirect_code: 301
-redirect_fallback_action: null
+redirect_fallback_action: access_denied

--- a/conf/drupal/config/views.view.data_listing_topic.yml
+++ b/conf/drupal/config/views.view.data_listing_topic.yml
@@ -435,14 +435,13 @@ display:
             format: default_summary
           specify_validation: true
           validate:
-            type: mass_taxonomy_term_name_into_id_depth_parent
+            type: mass_taxonomy_term_url_name_into_id_depth_parent
             fail: 'not found'
           validate_options:
             bundles:
               data_topic: data_topic
             access: '1'
             operation: view
-            transform: '1'
             term_depth: '1'
             term_depth_value: '1'
             term_parent: 0

--- a/conf/drupal/config/views.view.taxonomy_term_children.yml
+++ b/conf/drupal/config/views.view.taxonomy_term_children.yml
@@ -125,7 +125,21 @@ display:
             operator_limit_selection: false
             operator_list: {  }
           group: 1
-      sorts: {  }
+      sorts:
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: standard
       header: {  }
       footer: {  }
       empty: {  }
@@ -211,6 +225,10 @@ display:
           inline: {  }
           separator: '-'
           hide_empty: false
+      pager:
+        type: none
+        options:
+          offset: 0
     cache_metadata:
       max-age: -1
       contexts:

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -458,11 +458,8 @@ function mass_content_deploy_data_topic_url_name() {
 
   $terms = $term_storage->loadMultiple($tids);
   foreach ($terms as $term) {
-    $parents = $term_storage->loadParents($term->id());
-    if (empty($parents)) {
-      $field_url_name = strtolower(Html::cleanCssIdentifier($term->label()));
-      $term->set('field_url_name', $field_url_name);
-      $term->save();
-    }
+    $field_url_name = strtolower(Html::cleanCssIdentifier($term->label()));
+    $term->set('field_url_name', $field_url_name);
+    $term->save();
   }
 }

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -5,6 +5,7 @@
  * Implementations of hook_deploy_NAME() for Mass Content.
  */
 
+use Drupal\Component\Utility\Html;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
 
@@ -441,5 +442,27 @@ function mass_content_deploy_eotss_service_catalog_terms() {
     $term->save();
     // Save the term id keyed by name.
     $term_ids[$data['name']] = $term->id();
+  }
+}
+
+/**
+ * Add URL Name values for Data Topic terms.
+ */
+function mass_content_deploy_data_topic_url_name() {
+  $query = \Drupal::entityQuery('taxonomy_term');
+  $query->condition('vid', 'data_topic');
+
+  $tids = $query->sort('tid')->execute();
+
+  $term_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+
+  $terms = $term_storage->loadMultiple($tids);
+  foreach ($terms as $term) {
+    $parents = $term_storage->loadParents($term->id());
+    if (empty($parents)) {
+      $field_url_name = strtolower(Html::cleanCssIdentifier($term->label()));
+      $term->set('field_url_name', $field_url_name);
+      $term->save();
+    }
   }
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -4041,9 +4041,9 @@ function mass_theme_preprocess_node(&$variables) {
 
   // Set data_listing_icon for Data Listing nodes.
   $icon_map = [
-    'Data resource' => 'report',
     'Dataset' => 'data',
     'Data catalog' => 'catalog',
+    'Report' => 'report',
   ];
   // The field_data_flag field determines if it's a data listing. All External
   // Data Resource nodes are data listings.
@@ -4065,7 +4065,21 @@ function mass_theme_preprocess_node(&$variables) {
     if ($tid) {
       // Load the data type term and store the correct id for the component.
       $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
-      $variables['data_listing_icon'] = $icon_map[$term->label()];
+      if ($term->label() == 'Data resource') {
+        if ($node->hasField('field_data_resource_type')
+          && !$node->get('field_data_resource_type')->isEmpty()) {
+          $resource_type_tid = $node->field_data_resource_type->target_id;
+          $resource_type_term = \Drupal::entityTypeManager()
+            ->getStorage('taxonomy_term')
+            ->load($resource_type_tid);
+          $variables['data_listing_icon'] = $icon_map[$resource_type_term->label()];
+          $variables['data_listing_icon_label'] = $resource_type_term->label();
+        }
+      }
+      else {
+        $variables['data_listing_icon'] = $icon_map[$term->label()];
+        $variables['data_listing_icon_label'] = $term->label();
+      }
     }
   }
 }

--- a/docroot/themes/custom/mass_theme/templates/content/node--binder--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--binder--listing.html.twig
@@ -71,6 +71,13 @@
  *
  */
 #}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon ?: '',
+    "label": data_listing_icon_label ?: ''
+  } %}
+{% endif %}
 {% set organizations = [] %}
 {% if content.field_organizations['#items'] %}
   {% for item in content.field_organizations['#items'] %}
@@ -88,10 +95,7 @@
 
 {% include "@molecules/general-teaser.twig" with {
   "generalTeaser" : {
-    "eyebrow": {
-      "icon": data_listing_icon ?: '',
-      "label": content.field_binder_data_type['#items'].0.entity.name.value ?: ''
-    },
+    "eyebrow": eyebrow,
     "title" : {
       "href": url,
       "text": label,

--- a/docroot/themes/custom/mass_theme/templates/content/node--curated-list--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--curated-list--listing.html.twig
@@ -71,6 +71,13 @@
  *
  */
 #}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon,
+    "label": data_listing_icon_label
+  } %}
+{% endif %}
 {% set organizations = [] %}
 {% if content.field_organizations['#items'] %}
   {% for item in content.field_organizations['#items'] %}
@@ -88,10 +95,7 @@
 
 {% include "@molecules/general-teaser.twig" with {
   "generalTeaser" : {
-    "eyebrow": {
-      "icon": data_listing_icon ?: '',
-      "label": content.field_list_data_type['#items'].0.entity.name.value ?: ''
-    },
+    "eyebrow": eyebrow,
     "title" : {
       "href": url,
       "text": label,

--- a/docroot/themes/custom/mass_theme/templates/content/node--external-data-resource--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--external-data-resource--listing.html.twig
@@ -72,6 +72,13 @@
  *
  */
 #}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon ?: '',
+    "label": data_listing_icon_label ?: ''
+  } %}
+{% endif %}
 {% set organizations = [] %}
 {% if content.field_organizations['#items'] %}
   {% for item in content.field_organizations['#items'] %}
@@ -89,10 +96,7 @@
 
 {% include "@molecules/general-teaser.twig" with {
   "generalTeaser" : {
-    "eyebrow": {
-      "icon": data_listing_icon ?: '',
-      "label": content.field_details_data_type['#items'].0.entity.name.value ?: ''
-    },
+    "eyebrow": eyebrow,
     "title" : {
       "href": node.field_externaldata_url.0.uri ?: '#',
       "text": label,

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details--listing.html.twig
@@ -74,6 +74,13 @@
 {% if content.field_data_flag is defined
   and content.field_data_flag['#items'] is not empty
   and content.field_data_flag['#items'].0.value == 'data' %}
+  {% set eyebrow = {} %}
+  {% if data_listing_icon is defined and data_listing_icon_label is defined %}
+    {% set eyebrow = {
+      "icon": data_listing_icon ?: '',
+      "label": data_listing_icon_label ?: ''
+    } %}
+  {% endif %}
   {% set organizations = [] %}
   {% if content.field_organizations['#items'] %}
     {% for item in content.field_organizations['#items'] %}
@@ -91,10 +98,7 @@
 
   {% include "@molecules/general-teaser.twig" with {
     "generalTeaser" : {
-      "eyebrow": {
-        "icon": data_listing_icon ?: '',
-        "label": content.field_details_data_type['#items'].0.entity.name.value ?: ''
-      },
+      "eyebrow": eyebrow,
       "title" : {
         "href": url,
         "text": label,

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-details--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-details--listing.html.twig
@@ -71,6 +71,13 @@
  *
  */
 #}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon,
+    "label": data_listing_icon_label
+  } %}
+{% endif %}
 {% set organizations = [] %}
 {% if content.field_organizations['#items'] %}
   {% for item in content.field_organizations['#items'] %}
@@ -88,10 +95,7 @@
 
 {% include "@molecules/general-teaser.twig" with {
   "generalTeaser" : {
-    "eyebrow": {
-      "icon": data_listing_icon ?: '',
-      "label": content.field_details_data_type['#items'].0.entity.name.value ?: ''
-    },
+    "eyebrow": eyebrow,
     "title" : {
       "href": url,
       "text": label,

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-page--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-page--listing.html.twig
@@ -71,6 +71,13 @@
  *
  */
 #}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon,
+    "label": data_listing_icon_label
+  } %}
+{% endif %}
 {% set organizations = [] %}
 {% if content.field_organizations['#items'] %}
   {% for item in content.field_organizations['#items'] %}
@@ -88,10 +95,7 @@
 
 {% include "@molecules/general-teaser.twig" with {
   "generalTeaser" : {
-    "eyebrow": {
-      "icon": data_listing_icon ?: '',
-      "label": content.field_list_data_type['#items'].0.entity.name.value ?: ''
-    },
+    "eyebrow": eyebrow,
     "title" : {
       "href": url,
       "text": label,


### PR DESCRIPTION
**Description:**
Made changes to fix a list of Data Topics bugs and some will also fix unreported issues with Collections.


**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22703


**To Test:**
- As a anonymous user, go to the following term URLs and verify you receive a 404 error:
- /taxonomy/term/84411
- /taxonomy/term/84381
- /taxonomy/term/84436
- Go to /data-listing/topic/energy-and-environment.
- Verify there are more than 10 items under “FILTER BY SUB TOPIC”.
- Login and verify the order of those filter items matches the hierarchy of the terms at /admin/structure/taxonomy/manage/data_topic/overview.
- Go to /data-listing/topic/health-and-human-services?title=&page=1.
- Verify none of the listed items have an empty eyebrow.
- Verify none of the listed items have an eyebrow of “Data resource”.
- Go to /data-listing/topic/health-and-human-services?title=&page=2.
- Verify there is a listing with the eyebrow “Report”.
- Go to /mockup-massachusetts-data-hub.
- Verify the topic links work (note: you will need to replace the prod domain with the domain you are testing on).
- Go to /data-listing/topic/administration
- Verify the page loads as expected.
- Go to /data-listing/topic/criminal-justice-and-public-safety
- Verify there is a sub topic “Administration”.

**Screenshots/GIFs:**

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
