### PR TITLE
More robust queue worker for unpublished email reminders.

### DIFF
--- a/changelogs/DP-22715 .yml
+++ b/changelogs/DP-22715 .yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: More robust queue worker for unpublished email reminders.
+    issue: DP-22715

--- a/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
+++ b/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php
@@ -59,6 +59,10 @@ class UnpublishReminderQueue extends QueueWorkerBase {
       $url = Url::fromRoute('entity.node.canonical', ['node' => $nid])->setAbsolute()->toString();
 
       $transitions = mass_scheduled_transitions_load_by_host_entity($node, FALSE, MassModeration::UNPUBLISHED);
+      if (empty($transitions)) {
+        // This node became published or something. Just mark as processed.
+        return;
+      }
       // Just pick the first one since multiple unpublishes is super rare.
       $transition = array_shift($transitions);
       $unpublish_date = $transition->getTransitionDate()->format('F d, Y h:i a');


### PR DESCRIPTION
**Description:**
The error in the cron logs is below. From ` tail -n 100 /var/log/sites/massgov/logs/web-21429/drush-cron-unpublish-reminder.log`

```
info] Processing item 2817891 from mass_unpublish_reminders_queue queue.
Error: Call to a member function getTransitionDate() on null in Drupal\mass_unpublish_reminders\Plugin\QueueWorker\UnpublishReminderQueue->processItem() (line 64 of /mnt/www/html/massgov/docroot/modules/custom/mass_unpublish_reminders/src/Plugin/QueueWorker/UnpublishReminderQueue.php).
```


**Jira:** (Skip unless you are MA staff)
DP-22715


**To Test:**
- [ ] Add steps to test this feature


**Screenshots/GIFs:**
Use something like [licecap](http://www.cockos.com/licecap/) to capture gifs to demonstrate behaviors.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
