### PR TITLE
Add Jira notify to CircleCI. Announce branch naming policy

### DIFF
--- a/.build_trigger
+++ b/.build_trigger
@@ -1,2 +1,2 @@
 Use this file to trigger new builds, if needed.
-Build 26 (bottles of beer on the wall)..
+Build 27 (bottles of beer on the wall)..

--- a/.build_trigger
+++ b/.build_trigger
@@ -1,2 +1,2 @@
 Use this file to trigger new builds, if needed.
-Build 27 (bottles of beer on the wall)..
+Build 26 (bottles of beer on the wall)..

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,7 +352,7 @@ jobs:
           environment: << parameters.target >>
           environment_type: development
           job_type: deployment
-          token_name: CIRCLECI_TOKEN_FOR_JIRA
+          token_name: CIRCLE_PERSONAL_TOKEN
 
   crawl:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,9 +349,10 @@ jobs:
           command: "drush ma:deploy -v -y << parameters.skip-maint >> << parameters.refresh-db >> << parameters.target >> << parameters.gitRef >>"
           no_output_timeout: 60m
       - jira/notify:
-            environment: << parameters.target >>
-            environment_type: development
-            job_type: deployment
+          environment: << parameters.target >>
+          environment_type: development
+          job_type: deployment
+          token_name: CIRCLECI_TOKEN_FOR_JIRA
 
   crawl:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  jira: circleci/jira@1.3.1
 
 # YAML anchors/aliases. See;
 # - https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
@@ -346,6 +348,10 @@ jobs:
       - run:
           command: "drush ma:deploy -v -y << parameters.skip-maint >> << parameters.refresh-db >> << parameters.target >> << parameters.gitRef >>"
           no_output_timeout: 60m
+      - jira/notify:
+            environment: << parameters.target >>
+            environment_type: development
+            job_type: deployment
 
   crawl:
     parameters:

--- a/changelogs/DP-11358.yml
+++ b/changelogs/DP-11358.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Added:
-  - description: Show CircleCI deployments in associated Jira issue.
+  - description: Show CircleCI deployments in any associated Jira issue.
     issue: DP-11358

--- a/changelogs/DP-11358.yml
+++ b/changelogs/DP-11358.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Show CircleCI deployments in associated Jira issue.
+    issue: DP-11358


### PR DESCRIPTION
See Development and Releases section of this screenshot (right hand side). This is from a sandbox Jira instance which few people have access to: https://massgov-sandbox-692.atlassian.net/browse/DP-11358

![image](https://user-images.githubusercontent.com/7740/128860981-b3f0560f-c567-445c-8e42-310a75c482cc.png)

[Dev docs have been updated](https://github.com/massgov/massgov-internal-docs/commits/master/development-massgov-team.md)


**Jira:** (Skip unless you are MA staff)
DP-11358 


**To Test:**
- [ ] If its green its good

**Post-Merge**
- Please announce in SSR channel: "Our branch naming convention has changed. Please include the Jira issue ID in your branch names as per https://github.com/massgov/massgov-internal-docs/commit/4d9964d7fd44cc5b6eabf8deb66a2a8133358826. This helps Github share activity info into our Jira issues (coming soon). Also you are welcome to use Smart Commit syntax in your commits https://support.atlassian.com/jira-software-cloud/docs/process-issues-with-smart-commits/"


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
