### PR TITLE
DP-22660: Migrate org page Events to sections

### DIFF
--- a/changelogs/DP-22660.yml
+++ b/changelogs/DP-22660.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Events data to sections for Organization pages.
+    issue: DP-22660

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -143,7 +143,6 @@ third_party_settings:
         - field_application_login_links
         - field_public_records_link
         - field_parent
-        - field_event_quantity
         - field_billing_organization
       parent_name: group_node_edit_form
       weight: 30
@@ -476,12 +475,6 @@ content:
     region: content
   field_constituent_communication:
     weight: 103
-    settings: {  }
-    third_party_settings: {  }
-    type: options_select
-    region: content
-  field_event_quantity:
-    weight: 127
     settings: {  }
     third_party_settings: {  }
     type: options_select
@@ -966,6 +959,7 @@ hidden:
   field_action_set__bg_narrow: true
   field_action_set__bg_wide: true
   field_boards: true
+  field_event_quantity: true
   field_number_of_news_items: true
   field_org_featured_items: true
   field_org_featured_message: true

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -235,7 +235,36 @@ function _mass_content_org_page_migration_board(&$node) {
  * Migrate data for the events section.
  */
 function _mass_content_org_page_migration_events(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_event_quantity->isEmpty()) {
+    $field_event_quantity = $node->get('field_event_quantity')->getValue();
+    // Remove the old field values.
+    $node->set('field_event_quantity', []);
+    // Create a new Organization Events paragraph.
+    $new_org_events_paragraph = Paragraph::create([
+      'type' => 'org_events',
+    ]);
+    // Set the field values.
+    $new_org_events_paragraph->set('field_event_quantity', $field_event_quantity);
+    // Save the new paragraph.
+    $new_org_events_paragraph->save();
+    // Create a value array for the new section paragraph.
+    $field_section_long_form_content = [
+      'target_id' => $new_org_events_paragraph->id(),
+      'target_revision_id' => $new_org_events_paragraph->getRevisionId(),
+    ];
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_section_long_form_content);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Upcoming Events');
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Migrated the Events field to Organization Sections for org_page nodes and hid the field in the node form.

**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22660

**To Test:**
- Visit an org_page that had Events content.
- Verify the content it now displayed on the page.
- Login and edit the org_page.
- Verify the data in the Organization Sections field is the same as the one in the Events related fields (compare to Prod example).
- Verify the Events fields are no longer showing in the node form.
- Verify the org_page revision didn’t update.

Feature3 comparison links:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-organizationboards
- Prod: https://www.mass.gov/orgs/qag-organizationboards

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
