### PR TITLE
DP-22661: Migrate org page Locations to sections

### DIFF
--- a/changelogs/DP-22661.yml
+++ b/changelogs/DP-22661.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Locations data to sections for Organization pages.
+    issue: DP-22661

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -197,23 +197,6 @@ third_party_settings:
         speed: fast
       label: 'Organization name'
       region: content
-    group_map:
-      children:
-        - field_org_ref_locations
-        - field_location_button_label
-        - field_location_button_short_desc
-        - field_related_organization_type
-      parent_name: group_node_edit_form
-      weight: 26
-      format_type: tab
-      format_settings:
-        id: ''
-        classes: ''
-        formatter: closed
-        description: ''
-        required_fields: true
-      label: Map
-      region: content
     group_news:
       children:
         - field_get_updates_links
@@ -516,22 +499,6 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  field_location_button_label:
-    weight: 81
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
-  field_location_button_short_desc:
-    weight: 82
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_metatags:
     weight: 2
     settings:
@@ -572,16 +539,6 @@ content:
       preview_image_style: thumbnail
     third_party_settings: {  }
     type: image_image
-    region: content
-  field_org_ref_locations:
-    weight: 79
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
-      match_limit: 10
-    third_party_settings: {  }
-    type: entity_reference_autocomplete
     region: content
   field_org_sentence_phrasing:
     weight: 110
@@ -698,13 +655,6 @@ content:
       match_limit: 10
     third_party_settings: {  }
     type: entity_reference_autocomplete
-    region: content
-  field_related_organization_type:
-    weight: 83
-    settings:
-      display_label: false
-    third_party_settings: {  }
-    type: boolean_checkbox
     region: content
   field_response_expectations:
     weight: 108
@@ -935,12 +885,16 @@ hidden:
   field_action_set__bg_wide: true
   field_boards: true
   field_event_quantity: true
+  field_location_button_label: true
+  field_location_button_short_desc: true
   field_number_of_news_items: true
   field_org_featured_items: true
   field_org_featured_message: true
   field_org_featured_news_items: true
   field_org_our_orgs: true
+  field_org_ref_locations: true
   field_org_show_news_images: true
+  field_related_organization_type: true
   langcode: true
   path: true
   promote: true

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -271,7 +271,48 @@ function _mass_content_org_page_migration_events(&$node) {
  * Migrate data for the locations section.
  */
 function _mass_content_org_page_migration_locations(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->field_location_button_short_desc->isEmpty()
+    || !$node->field_location_button_label->isEmpty()
+    || !$node->field_org_ref_locations->isEmpty()
+    || !$node->field_related_organization_type->isEmpty()) {
+    $field_location_button_short_desc = $node->get('field_location_button_short_desc')->getValue();
+    $field_location_button_label = $node->get('field_location_button_label')->getValue();
+    $field_org_ref_locations = $node->get('field_org_ref_locations')->getValue();
+    $field_related_organization_type = $node->get('field_related_organization_type')->getValue();
+    // Remove the old field values.
+    $node->set('field_location_button_short_desc', []);
+    $node->set('field_location_button_label', []);
+    $node->set('field_org_ref_locations', []);
+    $node->set('field_related_organization_type', []);
+    // Create a new Organization Locations paragraph.
+    $new_org_locations_paragraph = Paragraph::create([
+      'type' => 'org_locations',
+    ]);
+    // Set the field values.
+    $new_org_locations_paragraph->set('field_location_button_short_desc', $field_location_button_short_desc);
+    $new_org_locations_paragraph->set('field_location_button_label', $field_location_button_label);
+    $new_org_locations_paragraph->set('field_org_ref_locations', $field_org_ref_locations);
+    $new_org_locations_paragraph->set('field_related_organization_type', $field_related_organization_type);
+    // Save the new paragraph.
+    $new_org_locations_paragraph->save();
+    // Create a value array for the new section paragraph.
+    $field_section_long_form_content = [
+      'target_id' => $new_org_locations_paragraph->id(),
+      'target_revision_id' => $new_org_locations_paragraph->getRevisionId(),
+    ];
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_section_long_form_content);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Recent news & announcements');
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Migrated Locations data to sections for Organization pages and hid fields on the node form.


**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-22661


**To Test:**
- Visit an org_page that had Locations content.
- Verify the content it now displayed on the page.
- Login and edit the org_page.
- Verify the data in the Organization Sections field is the same as the one in the Locations related fields (compare to Prod example).
- Verify the Locations fields are no longer showing in the node form.
- Verify the org_page revision didn’t update.

Feature3 comparison links:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-executive-office-of-technology-services-and-security 
- Prod: https://www.mass.gov/orgs/qag-executive-office-of-technology-services-and-security 

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
