### PR TITLE
DP-22685: Migrate org page "Who we serve" to sections

### DIFF
--- a/changelogs/DP-22685.yml
+++ b/changelogs/DP-22685.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Migrated Who we serve data to sections for Organization pages.
+    issue: DP-22685

--- a/composer.lock
+++ b/composer.lock
@@ -11586,12 +11586,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "6335d9be05fe05ff5311501e5bdb2118046789a8"
+                "reference": "5aec9fca1511287a38185825f2ffb9811b90c96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/6335d9be05fe05ff5311501e5bdb2118046789a8",
-                "reference": "6335d9be05fe05ff5311501e5bdb2118046789a8",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/5aec9fca1511287a38185825f2ffb9811b90c96c",
+                "reference": "5aec9fca1511287a38185825f2ffb9811b90c96c",
                 "shasum": ""
             },
             "require": {
@@ -11613,7 +11613,7 @@
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
                 "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-22331_flex-orgs"
             },
-            "time": "2021-08-11T17:24:13+00:00"
+            "time": "2021-08-18T20:17:44+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -73,7 +73,6 @@ dependencies:
     - maxlength
     - metatag
     - paragraphs
-    - text
 third_party_settings:
   field_group:
     group_node_edit_form:
@@ -83,7 +82,6 @@ third_party_settings:
         - group_content
         - group_about_details
         - group_actions
-        - group_map
         - group_news
         - group_feedback
         - group_other
@@ -160,7 +158,6 @@ third_party_settings:
         - field_sub_title
         - field_hide_short_description
         - field_sub_brand
-        - body
         - field_org_page_thumbnail
         - field_social_links
         - field_intended_audience
@@ -277,17 +274,6 @@ targetEntityType: node
 bundle: org_page
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 13
-    settings:
-      rows: 9
-      placeholder: ''
-      summary_rows: 3
-      show_summary: false
-    third_party_settings:
-      conditional_fields: {  }
-    region: content
   field_application_login_links:
     weight: 124
     settings:
@@ -879,6 +865,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  body: true
   created: true
   field_about: true
   field_action_set__bg_narrow: true

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -90,7 +90,7 @@ function _mass_content_org_page_migration_contact_logo(&$node) {
  */
 function _mass_content_org_page_migration_about(&$node) {
   // Migrate data if the field has a value.
-  if (!$node->field_org_our_orgs->isEmpty()) {
+  if (!$node->field_about->isEmpty()) {
     // Get the field value.
     $field_about = $node->get('field_about')->getValue();
     $field_short_name_value = $node->get('field_short_name')
@@ -115,7 +115,59 @@ function _mass_content_org_page_migration_about(&$node) {
  * Migrate data for the about section.
  */
 function _mass_content_org_page_migration_who_we_serve(&$node) {
-
+  // Migrate data if the field has a value.
+  if (!$node->body->isEmpty()) {
+    // Get the field value.
+    $body = $node->get('body')->getValue();
+    $field_subtype = $node->get('field_subtype')->getValue()[0]['value'];
+    // Remove the old field values.
+    $node->set('body', []);
+    // Create a new Rich Text paragraph.
+    $new_rich_text_paragraph = Paragraph::create([
+      'type' => 'rich_text',
+    ]);
+    // Set the field values.
+    $new_rich_text_paragraph->set('field_body', $body);
+    // Save the new paragraph.
+    $new_rich_text_paragraph->save();
+    // Create a value array for the new section paragraph.
+    $field_section_long_form_content = [];
+    $field_section_long_form_content[] = [
+      'target_id' => $new_rich_text_paragraph->id(),
+      'target_revision_id' => $new_rich_text_paragraph->getRevisionId(),
+    ];
+    // If there are social links on the org_page, add a Social Media paragraph.
+    if (!$node->field_social_links->isEmpty()) {
+      // Create a new Social Media paragraph.
+      $new_social_media_paragraph = Paragraph::create([
+        'type' => 'social_media',
+      ]);
+      // Save the new paragraph.
+      $new_social_media_paragraph->save();
+      // Add the new paragraph to the field value array.
+      $field_section_long_form_content[] = [
+        'target_id' => $new_social_media_paragraph->id(),
+        'target_revision_id' => $new_social_media_paragraph->getRevisionId(),
+      ];
+    }
+    // Create a new Organization Section paragraph.
+    $new_org_section_long_form_paragraph = Paragraph::create([
+      'type' => 'org_section_long_form',
+    ]);
+    // Set the field values.
+    $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_section_long_form_content);
+    // Set the section heading based on the org subtype.
+    if ($field_subtype === 'Boards') {
+      $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'About Us');
+    }
+    else {
+      $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Wo we serve');
+    }
+    // Save the new paragraph.
+    $new_org_section_long_form_paragraph->save();
+    // Add the new section to the org sections field.
+    _mass_content_org_page_migration_add_section($node, $new_org_section_long_form_paragraph);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
Migration logic for the Who we serve section and a fix for the About field migration.


**Jira:** (Skip unless you are MA staff)
DP-22685


**To Test:**
- Visit an org_page that had “About Us” or “Who we serve” content.
- Verify the content it now displayed on the page.
- Login and edit the org_page.
- Verify the data in the Organization Sections field is the same as the one in the “Who we serve” field (compare to Prod example).
- Verify the “Who we serve” field is no longer showing in the node form.
- Verify the org_page revision didn’t update.

Feature3 comparison links:
General example:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-executive-office-of-technology-services-and-security 
- Prod: https://mass.gov/orgs/qag-executive-office-of-technology-services-and-security  
Board example:
- Feature3: https://massgovfeature3.prod.acquia-sites.com/orgs/qag-organizationboards
- Prod: https://mass.gov/orgs/qag-organizationboards


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
