### PR TITLE
DP-22685: Migrate org page "Who we serve" to sections (typo fix)

### DIFF
--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -161,7 +161,7 @@ function _mass_content_org_page_migration_who_we_serve(&$node) {
       $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'About Us');
     }
     else {
-      $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Wo we serve');
+      $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Who we serve');
     }
     // Save the new paragraph.
     $new_org_section_long_form_paragraph->save();


### PR DESCRIPTION
**Description:**
Fixed "Who we serve" heading type in migration logic.


**Jira:** (Skip unless you are MA staff)
DP-22685


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
