### PR TITLE
DP-22796 Invalidate alert responses based on old and new field values.

### DIFF
--- a/changelogs/DP-22796.yml
+++ b/changelogs/DP-22796.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Invalidate alert responses based on old and new field values.
+    issue: DP-22796

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -235,7 +235,7 @@ function mass_alerts_invalidate_tags(NodeInterface $node) {
     // It is harmless to invalidate tags multiple times as they get uniqued later.
     $to_check[] = $node;
     if ((!$node->isNew())) {
-      $to_check[]  = $node->original;
+      $to_check[] = $node->original;
     }
     foreach ($to_check as $node) {
       $scope = mass_alerts_get_scope($node);

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -238,12 +238,14 @@ function mass_alerts_invalidate_tags(NodeInterface $node) {
       if ($scope == MASS_ALERTS_SCOPE_ORG) {
         $orgs = array_column($node->field_target_organization->getValue(), 'target_id');
         $tags = Cache::buildTags(MASS_ALERTS_TAG_ORG, $orgs);
-      } elseif ($scope === MASS_ALERTS_SCOPE_PAGE) {
+      }
+      elseif ($scope === MASS_ALERTS_SCOPE_PAGE) {
         if (!$node->get('field_target_page')->isEmpty()) {
           $pages = array_column($node->field_target_page->getValue(), 'target_id');
           $tags = Cache::buildTags(MASS_ALERTS_TAG_PAGE, $pages);
         }
-      } elseif ($scope === MASS_ALERTS_SCOPE_SITEWIDE) {
+      }
+      elseif ($scope === MASS_ALERTS_SCOPE_SITEWIDE) {
         $tags = [MASS_ALERTS_TAG_SITEWIDE . ':list'];
       }
       Cache::invalidateTags($tags);

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -232,8 +232,12 @@ function mass_alerts_invalidate_tags(NodeInterface $node) {
   $tags = [];
   if ($node->bundle() === "alert") {
     // We must clear based on new and old values for org, target pages, etc.
-    // It is harmless to invalidate tags multiple times as they getu uniqued later.
-    foreach ([$node->original, $node] as $node) {
+    // It is harmless to invalidate tags multiple times as they get uniqued later.
+    $to_check[] = $node;
+    if ((!$node->isNew())) {
+      $to_check[]  = $node->original;
+    }
+    foreach ($to_check as $node) {
       $scope = mass_alerts_get_scope($node);
       if ($scope == MASS_ALERTS_SCOPE_ORG) {
         $orgs = array_column($node->field_target_organization->getValue(), 'target_id');

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -234,7 +234,7 @@ function mass_alerts_invalidate_tags(NodeInterface $node) {
     // We must clear based on new and old values for org, target pages, etc.
     // It is harmless to invalidate tags multiple times as they get uniqued later.
     $to_check[] = $node;
-    if ((!$node->isNew())) {
+    if ((!empty($node->original))) {
       $to_check[] = $node->original;
     }
     foreach ($to_check as $node) {

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -231,21 +231,23 @@ function mass_alerts_node_insert(EntityInterface $node) {
 function mass_alerts_invalidate_tags(NodeInterface $node) {
   $tags = [];
   if ($node->bundle() === "alert") {
-    $scope = mass_alerts_get_scope($node);
-    if ($scope == MASS_ALERTS_SCOPE_ORG) {
-      $orgs = array_column($node->field_target_organization->getValue(), 'target_id');
-      $tags = Cache::buildTags(MASS_ALERTS_TAG_ORG, $orgs);
-    }
-    elseif ($scope === MASS_ALERTS_SCOPE_PAGE) {
-      if (!$node->get('field_target_page')->isEmpty()) {
-        $pages = array_column($node->field_target_page->getValue(), 'target_id');
-        $tags = Cache::buildTags(MASS_ALERTS_TAG_PAGE, $pages);
+    // We must clear based on new and old values for org, target pages, etc.
+    // It is harmless to invalidate tags multiple times as they getu uniqued later.
+    foreach ([$node->original, $node] as $node) {
+      $scope = mass_alerts_get_scope($node);
+      if ($scope == MASS_ALERTS_SCOPE_ORG) {
+        $orgs = array_column($node->field_target_organization->getValue(), 'target_id');
+        $tags = Cache::buildTags(MASS_ALERTS_TAG_ORG, $orgs);
+      } elseif ($scope === MASS_ALERTS_SCOPE_PAGE) {
+        if (!$node->get('field_target_page')->isEmpty()) {
+          $pages = array_column($node->field_target_page->getValue(), 'target_id');
+          $tags = Cache::buildTags(MASS_ALERTS_TAG_PAGE, $pages);
+        }
+      } elseif ($scope === MASS_ALERTS_SCOPE_SITEWIDE) {
+        $tags = [MASS_ALERTS_TAG_SITEWIDE . ':list'];
       }
+      Cache::invalidateTags($tags);
     }
-    elseif ($scope === MASS_ALERTS_SCOPE_SITEWIDE) {
-      $tags = [MASS_ALERTS_TAG_SITEWIDE . ':list'];
-    }
-    Cache::invalidateTags($tags);
   }
 }
 


### PR DESCRIPTION
Add a foreach around the existing code (which is unchanged) so we do clears based on current field values and the prior field values. See Jira ticket for a case where that matters. 

**Jira:** (Skip unless you are MA staff)
DP-22796


**To Test:**
- [ ] If its green its good. We are adding more clears to what we had before.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
