### PR TITLE
DP-22810 removed duplicated library

### DIFF
--- a/changelogs/DP-22810.yml
+++ b/changelogs/DP-22810.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Fixed:
-  - description: removed duplicated library reference.
+  - description: Removed duplicated library reference.
     issue: DP-22810

--- a/changelogs/DP-22810.yml
+++ b/changelogs/DP-22810.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: removed duplicated library reference.
+    issue: DP-22810

--- a/docroot/modules/custom/mass_admin_toolbar/mass_admin_toolbar.libraries.yml
+++ b/docroot/modules/custom/mass_admin_toolbar/mass_admin_toolbar.libraries.yml
@@ -5,7 +5,6 @@ custom_toolbar_styles:
       css/admin.toolbar.css: {}
       css/toolbar.icons.theme.css: {}
       css/toolbar.module.css: {}
-      css/toolbar.menu.css: {}
       css/toolbar.theme.css: {}
       css/toolbar.menu.css: {}
       fontello/css/fontello.css: {}


### PR DESCRIPTION
**Description:**
Removes duplicate reference `css/toolbar.menu.css` from `modules/custom/mass_admin_toolbar/mass_admin_toolbar.libraries.yml`.

**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Deploy to local, clear cache and visit the homepage, no errors should be reported.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
