### PR TITLE
DP-22745: bug - changing sitewide alert severity label from alert to notice doesn't change alert

### DIFF
--- a/changelogs/DP-22745.yml
+++ b/changelogs/DP-22745.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed the sitewide alert header to correspond to the alert label selection.
+    issue: DP-22745

--- a/conf/drupal/config/field.field.node.alert.field_alert_severity.yml
+++ b/conf/drupal/config/field.field.node.alert.field_alert_severity.yml
@@ -12,7 +12,7 @@ field_name: field_alert_severity
 entity_type: node
 bundle: alert
 label: 'Alert severity label'
-description: '<strong>Page-level</strong> and <strong>Organization alerts</strong>: An icon will display prior to the Alert title. <br><strong>Sitewide alerts:</strong> Choose "Alert" to display “Emergency Alerts” in front of the alert message; choose "Notice" to display “Informational Alert.”'
+description: '<strong>Page-level</strong> and <strong>Organization alerts</strong>: An icon will display prior to the Alert title. <br><strong>Sitewide alerts:</strong> Choose "Alert" to display “Emergency Alerts” in front of the alert message; choose "Notice" to display “Informational Alerts.”'
 required: true
 translatable: false
 default_value:

--- a/docroot/modules/custom/mass_alerts/src/Controller/AlertsController.php
+++ b/docroot/modules/custom/mass_alerts/src/Controller/AlertsController.php
@@ -126,6 +126,13 @@ class AlertsController extends ControllerBase implements ContainerInjectionInter
       $results['emergencyAlerts']['alerts'] = array_values($alerts);
     }
 
+    $severity = $node->get('field_alert_severity')->getString();
+    // The header prefix defaults to "Emergency Alerts" in the
+    // emergency-header.twig molecule mayflower component.
+    if ($severity == 'informational_notice') {
+      $results['emergencyAlerts']['emergencyHeader']['prefix'] = "Informational Alerts";
+    }
+
     $results['emergencyAlerts']['emergencyHeader']['title'] = $node->label();
 
     $build = [


### PR DESCRIPTION
**Description:**
Fixed the sitewide alert header to correspond to the alert label selection.


**Jira:** (Skip unless you are MA staff)
DP-22745


**To Test:**
- Go to the homepage and verify the text after the emergency alert icon (bell) is "Emergency Alerts".
- Login and go to /admin/ma-dash/reports/published-alerts?node_org_filter=&field_reusable_label_target_id=&uid=&title=&nid=&field_alert_display_value=site_wide&field_alert_severity_value=All.
- Edit the alert in the results.
- Click on the "Alert Content" tab.
- Verify the help text of "Alert severity label" includes the plural "Informational Alerts".
- Change the "Alert severity label" to "Notice" and save.
- Go to the home page and verify the text after the emergency alert icon (bell) is "Informational Alerts".

<img width="352" alt="informational_alerts" src="https://user-images.githubusercontent.com/1434979/131046413-7c655c0d-e613-484f-b0f0-f6ebbe347e99.png">


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
