### PR TITLE
DP-22773: Add data fields for guide content type

### DIFF
--- a/changelogs/DP-22773.yml
+++ b/changelogs/DP-22773.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added Data Listing fields to the Guide content type.
+    issue: DP-22773

--- a/conf/drupal/config/core.entity_form_display.node.guide_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.guide_page.default.yml
@@ -3,6 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.guide_page.field_data_flag
+    - field.field.node.guide_page.field_data_format
+    - field.field.node.guide_page.field_data_resource_type
+    - field.field.node.guide_page.field_data_topic
+    - field.field.node.guide_page.field_details_data_type
     - field.field.node.guide_page.field_guide_page_bg_wide
     - field.field.node.guide_page.field_guide_page_lede
     - field.field.node.guide_page.field_guide_page_metatags
@@ -17,12 +22,14 @@ dependencies:
     - node.type.guide_page
     - workflows.workflow.editorial
   module:
+    - conditional_fields
     - content_moderation
     - field_group
     - focal_point
     - maxlength
     - metatag
     - paragraphs
+    - term_reference_tree
 third_party_settings:
   field_group:
     group_node_edit_form:
@@ -46,6 +53,11 @@ third_party_settings:
         - field_guide_page_bg_wide
         - field_image_credit
         - field_organizations
+        - field_data_flag
+        - field_details_data_type
+        - field_data_resource_type
+        - field_data_format
+        - field_data_topic
         - field_intended_audience
         - field_reusable_label
       parent_name: group_node_edit_form
@@ -69,7 +81,14 @@ third_party_settings:
         id: ''
         classes: ''
         formatter: closed
-        description: "<p>Guides offer a high level overview of a process or service. They are made up of sections that provide detailed context about each phase or stage. Section titles automatically appear at the top of the guide to give direct access to each section.</p>\n\n<p>A guide section can have different layouts. It can be one column, with room for contact information on the side, or it can be 3 columns of text, each with its own heading.</p>\n\n<p>Guide sections also allow different kinds callouts. These callouts can highlight the estimated time a stage takes, draw attention to an important number/stat, or provide an alert about an important deadline or requirement.</p>\n\n<p>In general, a guide should have at least 3 sections but not more than 8.</p>"
+        description: |-
+          <p>Guides offer a high level overview of a process or service. They are made up of sections that provide detailed context about each phase or stage. Section titles automatically appear at the top of the guide to give direct access to each section.</p>
+
+          <p>A guide section can have different layouts. It can be one column, with room for contact information on the side, or it can be 3 columns of text, each with its own heading.</p>
+
+          <p>Guide sections also allow different kinds callouts. These callouts can highlight the estimated time a stage takes, draw attention to an important number/stat, or provide an alert about an important deadline or requirement.</p>
+
+          <p>In general, a guide should have at least 3 sections but not more than 8.</p>
         required_fields: true
       label: Sections
       region: content
@@ -92,6 +111,113 @@ targetEntityType: node
 bundle: guide_page
 mode: default
 content:
+  field_data_flag:
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_data_format:
+    weight: 3
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        89f3899c-4168-4a49-a0ed-d350e1640a2e:
+          dependee: field_data_flag
+          settings:
+            state: visible
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: data
+            effect: show
+            effect_options: {  }
+            selector: ''
+          entity_type: node
+          bundle: guide_page
+    type: options_buttons
+    region: content
+  field_data_resource_type:
+    weight: 2
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        d9acdc7a-654d-4220-ab9c-5889444ed4a7:
+          dependee: field_details_data_type
+          settings:
+            state: visible
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                target_id: '77936'
+            effect: show
+            effect_options: {  }
+            selector: ''
+          entity_type: node
+          bundle: guide_page
+    type: options_buttons
+    region: content
+  field_data_topic:
+    weight: 4
+    settings:
+      start_minimized: true
+      cascading_selection: 0
+      max_depth: 0
+      leaves_only: false
+      select_parents: false
+    third_party_settings:
+      conditional_fields:
+        189c117b-5c03-4553-80eb-8eebe71562f5:
+          dependee: field_data_flag
+          settings:
+            state: visible
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: data
+            effect: show
+            effect_options: {  }
+            selector: ''
+          entity_type: node
+          bundle: guide_page
+    type: term_reference_tree
+    region: content
+  field_details_data_type:
+    weight: 1
+    settings: {  }
+    third_party_settings:
+      conditional_fields:
+        73df8a8c-1115-4d53-b464-06382b3e5a1d:
+          dependee: field_data_flag
+          settings:
+            state: visible
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: data
+            effect: show
+            effect_options: {  }
+            selector: ''
+          entity_type: node
+          bundle: guide_page
+    type: options_buttons
+    region: content
   field_guide_page_bg_wide:
     weight: -3
     settings:
@@ -148,7 +274,7 @@ content:
     type: string_textfield
     region: content
   field_intended_audience:
-    weight: 0
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
@@ -164,7 +290,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_reusable_label:
-    weight: 1
+    weight: 6
     settings:
       match_operator: CONTAINS
       match_limit: 10

--- a/conf/drupal/config/core.entity_view_display.node.guide_page.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.guide_page.default.yml
@@ -3,6 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.guide_page.field_data_flag
+    - field.field.node.guide_page.field_data_format
+    - field.field.node.guide_page.field_data_resource_type
+    - field.field.node.guide_page.field_data_topic
+    - field.field.node.guide_page.field_details_data_type
     - field.field.node.guide_page.field_guide_page_bg_wide
     - field.field.node.guide_page.field_guide_page_lede
     - field.field.node.guide_page.field_guide_page_metatags
@@ -44,6 +49,44 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  field_data_flag:
+    weight: 12
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_data_format:
+    weight: 13
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_data_resource_type:
+    weight: 14
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_data_topic:
+    weight: 15
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_details_data_type:
+    weight: 16
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
   field_guide_page_bg_wide:
     weight: 2
     label: above

--- a/conf/drupal/config/core.entity_view_display.node.guide_page.listing.yml
+++ b/conf/drupal/config/core.entity_view_display.node.guide_page.listing.yml
@@ -1,9 +1,9 @@
-uuid: 18053d94-223b-468b-b812-dd2e7f26a538
+uuid: cf2b9bc3-6316-4674-9074-dfe3d443088d
 langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.title_short_desc
+    - core.entity_view_mode.node.listing
     - field.field.node.guide_page.field_data_flag
     - field.field.node.guide_page.field_data_format
     - field.field.node.guide_page.field_data_resource_type
@@ -21,39 +21,76 @@ dependencies:
     - field.field.node.guide_page.field_state_organization_tax
     - node.type.guide_page
   module:
+    - options
     - user
-id: node.guide_page.title_short_desc
+id: node.guide_page.listing
 targetEntityType: node
 bundle: guide_page
-mode: title_short_desc
+mode: listing
 content:
-  field_guide_page_lede:
-    weight: 0
-    label: hidden
+  field_data_flag:
+    weight: 2
+    label: above
     settings: {  }
     third_party_settings: {  }
-    type: basic_string
+    type: list_default
     region: content
+  field_data_format:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_data_resource_type:
+    weight: 4
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_details_data_type:
+    weight: 3
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_guide_page_lede:
+    type: basic_string
+    weight: 1
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_organizations:
+    type: entity_reference_label
+    weight: 0
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  workbench_moderation_control:
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   computed_log_in_links: true
   computed_related_to: true
   content_moderation_control: true
   extra_org_feedback_form: true
-  field_data_flag: true
-  field_data_format: true
-  field_data_resource_type: true
   field_data_topic: true
-  field_details_data_type: true
   field_guide_page_bg_wide: true
   field_guide_page_metatags: true
   field_guide_page_related_guides: true
   field_guide_page_sections: true
   field_image_credit: true
   field_intended_audience: true
-  field_organizations: true
   field_reusable_label: true
   field_state_organization_tax: true
   langcode: true
   links: true
-  referencing_services: true
-  workbench_moderation_control: true

--- a/conf/drupal/config/core.entity_view_display.node.guide_page.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.guide_page.teaser.yml
@@ -4,6 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
+    - field.field.node.guide_page.field_data_flag
+    - field.field.node.guide_page.field_data_format
+    - field.field.node.guide_page.field_data_resource_type
+    - field.field.node.guide_page.field_data_topic
+    - field.field.node.guide_page.field_details_data_type
     - field.field.node.guide_page.field_guide_page_bg_wide
     - field.field.node.guide_page.field_guide_page_lede
     - field.field.node.guide_page.field_guide_page_metatags
@@ -37,6 +42,11 @@ hidden:
   computed_related_to: true
   content_moderation_control: true
   extra_org_feedback_form: true
+  field_data_flag: true
+  field_data_format: true
+  field_data_resource_type: true
+  field_data_topic: true
+  field_details_data_type: true
   field_guide_page_bg_wide: true
   field_guide_page_lede: true
   field_guide_page_metatags: true

--- a/conf/drupal/config/core.entity_view_display.node.guide_page.token.yml
+++ b/conf/drupal/config/core.entity_view_display.node.guide_page.token.yml
@@ -4,6 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.node.token
+    - field.field.node.guide_page.field_data_flag
+    - field.field.node.guide_page.field_data_format
+    - field.field.node.guide_page.field_data_resource_type
+    - field.field.node.guide_page.field_data_topic
+    - field.field.node.guide_page.field_details_data_type
     - field.field.node.guide_page.field_guide_page_bg_wide
     - field.field.node.guide_page.field_guide_page_lede
     - field.field.node.guide_page.field_guide_page_metatags
@@ -79,6 +84,11 @@ hidden:
   computed_related_to: true
   content_moderation_control: true
   extra_org_feedback_form: true
+  field_data_flag: true
+  field_data_format: true
+  field_data_resource_type: true
+  field_data_topic: true
+  field_details_data_type: true
   field_guide_page_metatags: true
   field_intended_audience: true
   field_organizations: true

--- a/conf/drupal/config/field.field.node.guide_page.field_data_flag.yml
+++ b/conf/drupal/config/field.field.node.guide_page.field_data_flag.yml
@@ -1,0 +1,21 @@
+uuid: a775e8c8-597d-4dd5-9f46-c71af8941fba
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_data_flag
+    - node.type.guide_page
+  module:
+    - options
+id: node.guide_page.field_data_flag
+field_name: field_data_flag
+entity_type: node
+bundle: guide_page
+label: 'Data flag'
+description: 'If this page describes or contains a data set, check the box below and it will be included in the “data” tab on search.mass.gov. (For future use).'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/drupal/config/field.field.node.guide_page.field_data_format.yml
+++ b/conf/drupal/config/field.field.node.guide_page.field_data_format.yml
@@ -1,0 +1,21 @@
+uuid: 0ce30586-15c5-46cf-8b56-dfb8c16441f4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_data_format
+    - node.type.guide_page
+  module:
+    - options
+id: node.guide_page.field_data_format
+field_name: field_data_format
+entity_type: node
+bundle: guide_page
+label: 'Data format'
+description: 'Choose the format in which data is published. If data is published in multiple formats, be sure to check them all.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/drupal/config/field.field.node.guide_page.field_data_resource_type.yml
+++ b/conf/drupal/config/field.field.node.guide_page.field_data_resource_type.yml
@@ -1,0 +1,29 @@
+uuid: e49f3903-44b5-4e02-be04-77b5d28df35b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_data_resource_type
+    - node.type.guide_page
+    - taxonomy.vocabulary.tx_data_resource_type
+id: node.guide_page.field_data_resource_type
+field_name: field_data_resource_type
+entity_type: node
+bundle: guide_page
+label: 'Data resource type'
+description: "Choose the data resource type(s) that apply to this page.<br/><br/>\r\n<b>Report:</b> An information summary and analysis of a dataset or a collection of datasets that provide insights into the raw data. This type includes data reports and data stories."
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tx_data_resource_type: tx_data_resource_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.guide_page.field_data_topic.yml
+++ b/conf/drupal/config/field.field.node.guide_page.field_data_topic.yml
@@ -1,0 +1,29 @@
+uuid: da1ae8d0-bbb7-4693-94aa-37b62eae6718
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_data_topic
+    - node.type.guide_page
+    - taxonomy.vocabulary.data_topic
+id: node.guide_page.field_data_topic
+field_name: field_data_topic
+entity_type: node
+bundle: guide_page
+label: 'Data topic'
+description: 'Choose data topics and subtopics that apply to this page.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      data_topic: data_topic
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.guide_page.field_details_data_type.yml
+++ b/conf/drupal/config/field.field.node.guide_page.field_details_data_type.yml
@@ -1,0 +1,29 @@
+uuid: dab26aea-6673-423c-b287-1c2df7611fc1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_details_data_type
+    - node.type.guide_page
+    - taxonomy.vocabulary.tx_details_data_type
+id: node.guide_page.field_details_data_type
+field_name: field_details_data_type
+entity_type: node
+bundle: guide_page
+label: 'Data type'
+description: "Choose the data type that applies to this page.<br/><br/> \r\n<b>Data resource:</b> A report.<br/> \r\n<b>Dataset:</b> A body of structured information describing some topic(s) of interest. A dataset usually comprises a description of the data and one or multiple data resources, which can be in various formats.<br/> \r\n<b>Data catalog:</b> A collection of datasets that covers one or more topics. For example, an open data portal or a curated dataset listing across multiple topics. "
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      tx_details_data_type: tx_details_data_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/metatag.metatag_defaults.node__guide_page.yml
+++ b/conf/drupal/config/metatag.metatag_defaults.node__guide_page.yml
@@ -7,6 +7,7 @@ label: 'Content: Guide Page'
 tags:
   mass_metatag_short_description: '[node:field_guide_page_lede]'
   mass_metatag_organization: '[node:mass_organizations]'
+  mass_metatag_type: '[node:mass_related_terms]'
   mass_metatag_category: '[node:mass_services_category]'
   mg_stakeholder_org: '[node:field_state_organization_tax:entity:name]'
   mass_metatag_body_preview: '[node:field_guide_page_lede]'

--- a/docroot/themes/custom/mass_theme/templates/content/node--guide-page--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--guide-page--listing.html.twig
@@ -1,0 +1,116 @@
+{#
+/**
+ * @file
+ * Theme override to display a Guide node in the Listing view mode.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ */
+#}
+{% set eyebrow = {} %}
+{% if data_listing_icon is defined and data_listing_icon_label is defined %}
+  {% set eyebrow = {
+    "icon": data_listing_icon,
+    "label": data_listing_icon_label
+  } %}
+{% endif %}
+{% set organizations = [] %}
+{% if content.field_organizations['#items'] %}
+  {% for item in content.field_organizations['#items'] %}
+    {% set organization = item.entity.title.value %}
+    {% set organizations = organizations|merge([organization]) %}
+  {% endfor %}
+{% endif %}
+{% set formats = [] %}
+{% if content.field_data_format['#items'] %}
+  {% for item in content.field_data_format['#items'] %}
+    {% set format = item.value %}
+    {% set formats = formats|merge([format]) %}
+  {% endfor %}
+{% endif %}
+
+{% include "@molecules/general-teaser.twig" with {
+  "generalTeaser" : {
+    "eyebrow": eyebrow,
+    "title" : {
+      "href": url,
+      "text": label,
+      "info": "",
+      "property": ""
+    },
+    "level": "",
+    "emphasizedText": organizations,
+    "tags": formats,
+    "contents": [{
+      "path": "@atoms/11-text/paragraph.twig",
+      "data": {
+        "paragraph" : {
+          "text": node.field_guide_page_lede.value ?: ''
+        }
+      }
+    }]
+  }
+} %}


### PR DESCRIPTION
**Description:**
Added Data Listing fields to the Guide content type, metatag tokens, and listing theme template.

**Jira:** (Skip unless you are MA staff)
DP-22773


**To Test:**
- Login and edit a Guide node.
- Verify the data fields exist and have proper dependencies on the Overview tab under the Organization(s) field.
- Set values for the data fields and save.
- Inspect the page and verify the metadata is set as expected.
- Go to /data-listing/all.
- Use filters to verify the Guide page shows in the listings.
- Verify the listing styling is as expected.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
