### PR TITLE
DP-22740: Convert block for news and updates field to use rich text editor

### DIFF
--- a/changelogs/DP-22740.yml
+++ b/changelogs/DP-22740.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Convert block for news and updates field to use rich text.
+    issue: DP-22740

--- a/docroot/modules/custom/mass_admin_pages/src/Form/HelpBlockForm.php
+++ b/docroot/modules/custom/mass_admin_pages/src/Form/HelpBlockForm.php
@@ -39,7 +39,7 @@ class HelpBlockForm extends ConfigFormBase {
     $link_url = \Drupal::state()->get('mass_admin_pages.help_block_settings.link_url');
 
     $form['text_field'] = [
-      '#type' => 'textarea',
+      '#type' => 'text_format',
       '#title' => $this->t('Main content'),
       '#description' => $this->t('Add content to provide help and support for content authors'),
       '#default_value' => isset($text_field) ? $text_field : '',
@@ -87,7 +87,7 @@ class HelpBlockForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    \Drupal::state()->set('mass_admin_pages.help_block_settings.text_field', $form_state->getValue('text_field'));
+    \Drupal::state()->set('mass_admin_pages.help_block_settings.text_field', $form_state->getValue('text_field')['value']);
     $link_field = $form_state->getValue(['link_field', 'link_subfields']);
     \Drupal::state()->set('mass_admin_pages.help_block_settings.link_title', $link_field['link_title']);
     \Drupal::state()->set('mass_admin_pages.help_block_settings.link_url', $link_field['link_url']);


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-22740


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
