### PR TITLE
Feature/dp 22899 alert message timestamp helptext

### DIFF
--- a/changelogs/DP-22899.yml
+++ b/changelogs/DP-22899.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Help text of alert message timestamp changed to emphasize that it is used only on sitewide alerts.
+    issue: DP-22899

--- a/conf/drupal/config/field.field.paragraph.emergency_alert.field_emergency_alert_timestamp.yml
+++ b/conf/drupal/config/field.field.paragraph.emergency_alert.field_emergency_alert_timestamp.yml
@@ -12,7 +12,7 @@ field_name: field_emergency_alert_timestamp
 entity_type: paragraph
 bundle: emergency_alert
 label: 'Alert message timestamp'
-description: 'The date and time that this alert message was created or last updated. The timestamp is initially filled with the current time when you start creating the alert. For accuracy, update it manually whenever you publish or update an alert.'
+description: 'THIS FIELD IS ONLY DISPLAYED WITH SITEWIDE ALERTS. For organization and page alerts, see the alert timestamp on the first tab. For sitewide alerts, this date is shown with each alert message.'
 required: true
 translatable: false
 default_value:


### PR DESCRIPTION
**Description:**
Updated help text for alert message timestamp to emphasize that it is used for sitewide alerts only.


**Jira:** (Skip unless you are MA staff)
DP-22899


**To Test:**
- [ ] Verify that help text for alert message timestamp reads: THIS FIELD IS ONLY DISPLAYED WITH SITEWIDE ALERTS. For organization and page alerts, see the alert timestamp on the first tab. For sitewide alerts, this date is shown with each alert message.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
