### PR TITLE
DP-22666 adding notice to contact logo paragraph.

### DIFF
--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -668,3 +668,12 @@ function mass_content_node_update(EntityInterface $node) {
     ]);
   }
 }
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function mass_content_field_widget_entity_reference_paragraphs_form_alter(&$element, &$form_state, $context) {
+  if ($element['#paragraph_type'] == 'organization_contact_logo') {
+    $element['#suffix'] = "<br/><span class='mass_content__custom-notice'>Content is required and must be added on the “Title Banner” tab. Logo is optional and is defined on the “Overview” tab.</span>" . $element['#suffix'];
+  }
+}


### PR DESCRIPTION
**Description:**
Adding help message to contact and logo paragraph.


**Jira:** (Skip unless you are MA staff)
DP-22666


**To Test:**
- [ ] Checkout the `DP-22331_flex-orgs` branch and run `ahoy comi; ahoy updatedb`.
- [ ] Checkout the `feature/DP-22666_adding-notice-contact-logo` branch and clear cache.
- [ ] Visit an organization that has a logo or primary contact info, and edit the page.
- [ ] Find the contact and logo paragraph and validated that the following message is shown | Content is required and must be added on the “Title Banner” tab. Logo is optional and is defined on the “Overview” tab.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
