### PR TITLE
Changing  "content" with "contact"

### DIFF
--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -674,6 +674,6 @@ function mass_content_node_update(EntityInterface $node) {
  */
 function mass_content_field_widget_entity_reference_paragraphs_form_alter(&$element, &$form_state, $context) {
   if ($element['#paragraph_type'] == 'organization_contact_logo') {
-    $element['#suffix'] = "<br/><span class='mass_content__custom-notice'>Content is required and must be added on the “Title Banner” tab. Logo is optional and is defined on the “Overview” tab.</span>" . $element['#suffix'];
+    $element['#suffix'] = "<br/><span class='mass_content__custom-notice'>Contact is required and must be added on the “Title Banner” tab. Logo is optional and is defined on the “Overview” tab.</span>" . $element['#suffix'];
   }
 }


### PR DESCRIPTION
**Description:**
Changes the word "content" with "contact"


**Jira:** (Skip unless you are MA staff)
DP-22331


**To Test:**
- [ ] Edit an organization, go to the "content" tab.
- [ ] Add or edit an "organization section".
- [ ] Add or edit a "contact and logo" paragraph.
- [ ] The following sentence should be displayed under the title: 'Contact is required and must be added on the “Title Banner” tab. Logo is optional and is defined on the “Overview” tab.'


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
