### PR TITLE
DP-22958: Org section header changes for integration branch

### DIFF
--- a/changelogs/DP-22958.yml
+++ b/changelogs/DP-22958.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added a checkbox to hide Organization Section paragraph headings on Organizations.
+    issue: DP-22958

--- a/conf/drupal/config/core.entity_form_display.paragraph.org_section_long_form.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.org_section_long_form.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_section_long_form.field_hide_heading
     - field.field.paragraph.org_section_long_form.field_section_long_form_content
     - field.field.paragraph.org_section_long_form.field_section_long_form_heading
     - paragraphs.paragraphs_type.org_section_long_form
@@ -15,7 +16,7 @@ third_party_settings:
       children:
         - field_section_long_form_content
       parent_name: ''
-      weight: 1
+      weight: 2
       format_type: details
       region: content
       format_settings:
@@ -26,10 +27,9 @@ third_party_settings:
         open: false
       label: 'Section Content'
     group_additional_resources:
-      children:
-        - field_section_long_form_addition
+      children: {  }
       parent_name: ''
-      weight: 2
+      weight: 3
       format_type: details
       region: content
       format_settings:
@@ -44,6 +44,13 @@ targetEntityType: paragraph
 bundle: org_section_long_form
 mode: default
 content:
+  field_hide_heading:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_section_long_form_content:
     weight: 3
     settings:

--- a/conf/drupal/config/core.entity_view_display.paragraph.org_section_long_form.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.org_section_long_form.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_section_long_form.field_hide_heading
     - field.field.paragraph.org_section_long_form.field_section_long_form_content
     - field.field.paragraph.org_section_long_form.field_section_long_form_heading
     - paragraphs.paragraphs_type.org_section_long_form
@@ -23,7 +24,7 @@ content:
     type: entity_reference_revisions_entity_view
     region: content
   field_section_long_form_heading:
-    weight: 2
+    weight: 0
     label: above
     settings:
       link_to_entity: false
@@ -32,3 +33,4 @@ content:
     region: content
 hidden:
   computed_org_page: true
+  field_hide_heading: true

--- a/conf/drupal/config/field.field.paragraph.org_section_long_form.field_hide_heading.yml
+++ b/conf/drupal/config/field.field.paragraph.org_section_long_form.field_hide_heading.yml
@@ -1,0 +1,23 @@
+uuid: ba4b5d97-81fc-4ce5-8c51-29e9457ffd24
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_hide_heading
+    - paragraphs.paragraphs_type.org_section_long_form
+id: paragraph.org_section_long_form.field_hide_heading
+field_name: field_hide_heading
+entity_type: paragraph
+bundle: org_section_long_form
+label: 'Hide organization section heading on the published page'
+description: 'If you start a section with content that has a built in heading you can hide the organization section heading. This is recommended for sections that start with "Key Message" or "What would you like to do?"'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.org_section_long_form.field_section_long_form_heading.yml
+++ b/conf/drupal/config/field.field.paragraph.org_section_long_form.field_section_long_form_heading.yml
@@ -10,8 +10,8 @@ field_name: field_section_long_form_heading
 entity_type: paragraph
 bundle: org_section_long_form
 label: Heading
-description: 'This heading will be used in the table of contents for the page. Leave blank if a header is not needed.'
-required: false
+description: 'This heading will be shown on the page unless it is hidden with the checkbox below.'
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/conf/drupal/config/field.storage.paragraph.field_hide_heading.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_hide_heading.yml
@@ -1,0 +1,18 @@
+uuid: 63a23dc4-7327-4a25-a767-fa040c6e16e4
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_hide_heading
+field_name: field_hide_heading
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
+++ b/docroot/modules/custom/mass_content/includes/mass_content.org_migration.inc
@@ -43,6 +43,8 @@ function _mass_content_org_page_migration_featured_message(&$node) {
     ]);
     // Set the field values.
     $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_org_featured_message);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Featured message');
+    $new_org_section_long_form_paragraph->set('field_hide_heading', 1);
     // Save the new paragraph.
     $new_org_section_long_form_paragraph->save();
     // Add the new section to the org sections field.
@@ -288,6 +290,8 @@ function _mass_content_org_page_migration_what_would_you_like_to_do(&$node) {
     ]);
     // Set the field values.
     $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_section_long_form_content);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'What would you like to do?');
+    $new_org_section_long_form_paragraph->set('field_hide_heading', 1);
     // Save the new paragraph.
     $new_org_section_long_form_paragraph->save();
     // Remove the old field values.
@@ -392,6 +396,8 @@ function _mass_content_org_page_migration_board(&$node) {
     ]);
     // Set the field values.
     $new_org_section_long_form_paragraph->set('field_section_long_form_content', $field_boards);
+    $new_org_section_long_form_paragraph->set('field_section_long_form_heading', 'Board members');
+    $new_org_section_long_form_paragraph->set('field_hide_heading', 1);
     // Save the new paragraph.
     $new_org_section_long_form_paragraph->save();
     // Add the new section to the org sections field.

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -1,5 +1,5 @@
 {% set heading = { } %}
-{% if content.field_section_long_form_heading|field_value is not empty %}
+{% if paragraph.field_hide_heading is not defined or paragraph.field_hide_heading.0.value == 0 %}
   {% set heading = {
     "title": (content.field_section_long_form_heading|field_value),
     "id": "",


### PR DESCRIPTION
**Description:**
Added a checkbox to hide Organization Section paragraph headings and updating org_page migration to set headings for all sections, hide the ones that should be hidden.


**Jira:** (Skip unless you are MA staff)
DP-22958


**To Test:**
- Go to /orgs/qag-organizationboards.
- Verify there are no duplicate headings.
- Login and go to orgs/qag-organizationboards/edit
- Click on the "Content" tab.
- Verify all Organization Sections have headings and the heading fields are required.
- Verify there is a "Hide organization section heading on the published page" checkbox below each heading.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
