### PR TITLE
DP-22971 Disable client IP restore in Cloudflare module.

### DIFF
--- a/changelogs/DP-22646.yml
+++ b/changelogs/DP-22646.yml
@@ -38,4 +38,4 @@
 #
 Changed:
   - description: Disable client IP restore in Cloudflare module
-    issue: DP-22971
+    issue: DP-22646

--- a/changelogs/DP-22971.yml
+++ b/changelogs/DP-22971.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Disable client IP restore in Cloudflare module
+    issue: DP-22971

--- a/conf/drupal/config/cloudflare.settings.yml
+++ b/conf/drupal/config/cloudflare.settings.yml
@@ -1,4 +1,4 @@
-client_ip_restore_enabled: true
+client_ip_restore_enabled: false
 bypass_host: ''
 valid_credentials: true
 zone_id: null


### PR DESCRIPTION
**Description:**
Reduces log noise at New Relic, Circle, Kibana. See `ddev logs` step at https://app.circleci.com/pipelines/github/massgov/openmass/11858/workflows/825e5700-729c-4106-8e13-cffe6580aacb/jobs/48546/steps. Pretty sure we get client ip through other means, not this module.


**Jira:** (Skip unless you are MA staff)
DP-22971


**To Test:**
- [ ] None. If its green its good.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
