### PR TITLE
DP-22961 Org section separator changes for feature branch

### DIFF
--- a/changelogs/DP-22961.yml
+++ b/changelogs/DP-22961.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added ability to control Organization page section separators.
+    issue: DP-22961

--- a/conf/drupal/config/core.entity_form_display.paragraph.about.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.about.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.about.field_component_add_separator
     - field.field.paragraph.about.field_read_more_page
     - field.field.paragraph.about.field_summary
     - paragraphs.paragraphs_type.about
@@ -14,6 +15,13 @@ targetEntityType: paragraph
 bundle: about
 mode: default
 content:
+  field_component_add_separator:
+    weight: 7
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_read_more_page:
     weight: 6
     settings:

--- a/conf/drupal/config/core.entity_form_display.paragraph.org_events.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.org_events.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_events.field_component_add_separator
     - field.field.paragraph.org_events.field_event_quantity
     - paragraphs.paragraphs_type.org_events
 id: paragraph.org_events.default
@@ -10,6 +11,13 @@ targetEntityType: paragraph
 bundle: org_events
 mode: default
 content:
+  field_component_add_separator:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_event_quantity:
     weight: 0
     settings: {  }

--- a/conf/drupal/config/core.entity_form_display.paragraph.org_news.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.org_news.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_news.field_component_add_separator
     - field.field.paragraph.org_news.field_number_of_news_items
     - field.field.paragraph.org_news.field_org_featured_news_items
     - field.field.paragraph.org_news.field_org_show_news_images
@@ -12,6 +13,13 @@ targetEntityType: paragraph
 bundle: org_news
 mode: default
 content:
+  field_component_add_separator:
+    weight: 3
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_number_of_news_items:
     weight: 1
     settings: {  }

--- a/conf/drupal/config/core.entity_form_display.paragraph.org_related_orgs.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.org_related_orgs.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_related_orgs.field_component_add_separator
     - field.field.paragraph.org_related_orgs.field_ref_orgs
     - paragraphs.paragraphs_type.org_related_orgs
 id: paragraph.org_related_orgs.default
@@ -10,6 +11,13 @@ targetEntityType: paragraph
 bundle: org_related_orgs
 mode: default
 content:
+  field_component_add_separator:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
   field_ref_orgs:
     weight: 0
     settings:

--- a/conf/drupal/config/core.entity_form_display.paragraph.organization_contact_logo.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.organization_contact_logo.default.yml
@@ -3,12 +3,20 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.organization_contact_logo.field_component_add_separator
     - paragraphs.paragraphs_type.organization_contact_logo
 id: paragraph.organization_contact_logo.default
 targetEntityType: paragraph
 bundle: organization_contact_logo
 mode: default
-content: {  }
+content:
+  field_component_add_separator:
+    weight: 0
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.paragraph.rich_text.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.rich_text.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.rich_text.field_body
+    - field.field.paragraph.rich_text.field_component_add_separator
     - paragraphs.paragraphs_type.rich_text
   module:
     - text
@@ -19,6 +20,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_component_add_separator:
+    weight: 1
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
     region: content
   paragraphs_type_help__default:
     weight: -100

--- a/conf/drupal/config/core.entity_form_display.paragraph.social_media.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.social_media.default.yml
@@ -1,4 +1,4 @@
-uuid: e7911ed5-9752-4e85-a78c-52f3c91933c3
+uuid: 8a976a82-6602-4f5f-b4e9-6ba39d551620
 langcode: en
 status: true
 dependencies:
@@ -12,12 +12,11 @@ mode: default
 content:
   field_component_add_separator:
     weight: 0
-    label: hidden
     settings:
-      format: true-false
-      format_custom_true: ''
-      format_custom_false: ''
+      display_label: true
     third_party_settings: {  }
-    type: boolean
+    type: boolean_checkbox
     region: content
-hidden: {  }
+hidden:
+  created: true
+  status: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.about.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.about.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.about.field_component_add_separator
     - field.field.paragraph.about.field_read_more_page
     - field.field.paragraph.about.field_summary
     - paragraphs.paragraphs_type.about
@@ -44,6 +45,16 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
+  field_component_add_separator:
+    weight: 5
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_read_more_page:
     weight: 4
     label: hidden

--- a/conf/drupal/config/core.entity_view_display.paragraph.about.organization_navigation.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.about.organization_navigation.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.paragraph.organization_navigation
+    - field.field.paragraph.about.field_component_add_separator
     - field.field.paragraph.about.field_read_more_page
     - field.field.paragraph.about.field_summary
     - paragraphs.paragraphs_type.about
@@ -31,4 +32,5 @@ hidden:
   computed_secondary_bio_page: true
   computed_short_name: true
   computed_social_links: true
+  field_component_add_separator: true
   field_summary: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.org_events.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.org_events.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_events.field_component_add_separator
     - field.field.paragraph.org_events.field_event_quantity
     - paragraphs.paragraphs_type.org_events
   module:
@@ -12,6 +13,16 @@ targetEntityType: paragraph
 bundle: org_events
 mode: default
 content:
+  field_component_add_separator:
+    weight: 1
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_event_quantity:
     weight: 0
     label: above

--- a/conf/drupal/config/core.entity_view_display.paragraph.org_news.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.org_news.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_news.field_component_add_separator
     - field.field.paragraph.org_news.field_number_of_news_items
     - field.field.paragraph.org_news.field_org_featured_news_items
     - field.field.paragraph.org_news.field_org_show_news_images
@@ -14,6 +15,16 @@ targetEntityType: paragraph
 bundle: org_news
 mode: default
 content:
+  field_component_add_separator:
+    weight: 4
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_number_of_news_items:
     weight: 1
     label: above

--- a/conf/drupal/config/core.entity_view_display.paragraph.org_related_orgs.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.org_related_orgs.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.org_related_orgs.field_component_add_separator
     - field.field.paragraph.org_related_orgs.field_ref_orgs
     - paragraphs.paragraphs_type.org_related_orgs
 id: paragraph.org_related_orgs.default
@@ -10,6 +11,16 @@ targetEntityType: paragraph
 bundle: org_related_orgs
 mode: default
 content:
+  field_component_add_separator:
+    weight: 1
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
   field_ref_orgs:
     weight: 0
     label: hidden

--- a/conf/drupal/config/core.entity_view_display.paragraph.organization_contact_logo.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.organization_contact_logo.default.yml
@@ -3,10 +3,21 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.organization_contact_logo.field_component_add_separator
     - paragraphs.paragraphs_type.organization_contact_logo
 id: paragraph.organization_contact_logo.default
 targetEntityType: paragraph
 bundle: organization_contact_logo
 mode: default
-content: {  }
+content:
+  field_component_add_separator:
+    weight: 0
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.paragraph.rich_text.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.rich_text.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.rich_text.field_body
+    - field.field.paragraph.rich_text.field_component_add_separator
     - paragraphs.paragraphs_type.rich_text
   module:
     - text
@@ -18,6 +19,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_component_add_separator:
+    weight: 1
+    label: hidden
+    settings:
+      format: true-false
+      format_custom_true: ''
+      format_custom_false: ''
+    third_party_settings: {  }
+    type: boolean
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.rich_text.stacked_row_section.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.rich_text.stacked_row_section.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.paragraph.stacked_row_section
     - field.field.paragraph.rich_text.field_body
+    - field.field.paragraph.rich_text.field_component_add_separator
     - paragraphs.paragraphs_type.rich_text
   module:
     - text
@@ -22,4 +23,5 @@ content:
     region: content
 hidden:
   created: true
+  field_component_add_separator: true
   uid: true

--- a/conf/drupal/config/field.field.paragraph.about.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.about.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: 9eae55cf-eade-44e5-9a7d-99cd8d9d04ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.about
+id: paragraph.about.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: about
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.org_events.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.org_events.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: 9f5cd2fe-eaf0-4579-8074-39deee37166b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.org_events
+id: paragraph.org_events.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: org_events
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.org_news.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.org_news.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: eccf553e-09ac-44fa-aed8-4b5db7aa5561
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.org_news
+id: paragraph.org_news.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: org_news
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.org_related_orgs.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.org_related_orgs.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: c2af5db1-8dd9-4d6f-95da-db3424033b26
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.org_related_orgs
+id: paragraph.org_related_orgs.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: org_related_orgs
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.organization_contact_logo.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.organization_contact_logo.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: 1404c4dd-ffbb-44a8-a77f-8c25a6ae7a99
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.organization_contact_logo
+id: paragraph.organization_contact_logo.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: organization_contact_logo
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.rich_text.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.rich_text.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: 2820c168-99ba-4cdc-8439-d3bdc2880954
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.rich_text
+id: paragraph.rich_text.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: rich_text
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.field.paragraph.social_media.field_component_add_separator.yml
+++ b/conf/drupal/config/field.field.paragraph.social_media.field_component_add_separator.yml
@@ -1,0 +1,23 @@
+uuid: 0f4d202d-4d34-4d3b-aa72-bee0093b0f14
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_add_separator
+    - paragraphs.paragraphs_type.social_media
+id: paragraph.social_media.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+bundle: social_media
+label: 'Add horizontal separator after this content'
+description: 'In many cases, a separator line is not needed. If your content needs more separation from the following content, checking this box will add a horizontal line.'
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.storage.paragraph.field_component_add_separator.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_component_add_separator.yml
@@ -1,0 +1,18 @@
+uuid: 6e548bec-b702-401b-ba1a-6a676e25d7a5
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_component_add_separator
+field_name: field_component_add_separator
+entity_type: paragraph
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--about.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--about.html.twig
@@ -87,5 +87,8 @@
     {{ content.computed_social_links }}
   {% endblock %}
 {% endembed %}
-{{ content | without ('computed_bio_page', 'computed_secondary_bio_page', 'computed_social_links', 'field_read_more_page') }}
+{{ content | without ('computed_bio_page', 'computed_secondary_bio_page', 'computed_social_links', 'field_read_more_page', 'field_component_add_separator') }}
 
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-events.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-events.html.twig
@@ -44,3 +44,6 @@
     } %}
   {% endif %}
 {% endblock %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-news.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-news.html.twig
@@ -41,7 +41,10 @@
 {% block recentNews %}
   {% if news %}
     {% include "@organisms/by-author/stacked-row-section.twig" with {
-      "stackedRowSection": news,
+      "stackedRowSection": news
     } %}
   {% endif %}
 {% endblock %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-related-orgs.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-related-orgs.html.twig
@@ -41,3 +41,6 @@
   {% set stackedRowSection = stackedRowSection|merge({'level': level}) %}
   {% include "@organisms/by-author/stacked-row-section.twig" %}
 {% endfor %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--organization-contact-logo.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--organization-contact-logo.html.twig
@@ -40,8 +40,7 @@
  * @ingroup themeable
  */
 #}
-
-{% embed "@organisms/by-template/org-contact.twig"%}
+{% embed "@organisms/by-template/org-contact.twig" %}
 
   {% block contact_first %}
     {{ org_contact }}
@@ -51,3 +50,6 @@
     {{ org_logo }}
   {% endblock %}
 {% endembed %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--rich-text.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--rich-text.html.twig
@@ -41,3 +41,6 @@
     {{ content }}
   {% endblock %}
 {% endembed %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--social-media.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--social-media.html.twig
@@ -51,3 +51,6 @@
      {{ social_links }}
    {% endblock %}
  {% endembed %}
+{% if content.field_component_add_separator|field_value|render == "True" %}
+  <div class="ma__divider ma__divider--thin"></div>
+{% endif %}


### PR DESCRIPTION
**Description:**
Added a new "show separator" field to the following paragraphs:

- Organization Events
- Organization News
- Related organization
- Contact and logo
- Rich text
- Social media
- About

**Jira:** (Skip unless you are MA staff)
DP-22961


**To Test:**
- [ ] Edit or add a new organization including all above paragraphs. 
- [ ] Validate that each one has a new field called "Add horizontal separator after this content".
- [ ] Validate that each one has the correct help text.
- [ ] Leave all unchecked and save the page.
- [ ] Validate that there isn't a thin gray line below each one.
- [ ] Edit the page and check "Add horizontal separator after this content" for all the components.
- [ ] Save it and validate that there is a thin gray line below each one.
- [ ] Validate that the skewed 10px height green separator not longer appears below the mosaic y about (elected).


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
