### PR TITLE
DP-22961 removing hotfix that's not longer relevant.

### DIFF
--- a/docroot/themes/custom/mass_theme/overrides/css/hotfix.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/hotfix.css
@@ -45,9 +45,6 @@ body {
   .ma__org-page .ma__stacked-row__section ~ .ma__stacked-row__section .ma__stacked-row__container:before {
     border-top-width: 0px;
   }
-  .ma__org-page--boards .ma__stacked-row__section ~ .ma__stacked-row__section .ma__stacked-row__container:before {
-    border-top-width: 1px;
-  }
   .ma__guide-page .main-content--full .page-content > .ma__split-columns {
     margin-top: 90px;
   }


### PR DESCRIPTION
**Description:**
Hotfix for adding a border top to some elements is not longer relevant now that many paragraphs have the option of adding a separator line.

**Jira:** (Skip unless you are MA staff)
DP-22961


**To Test:**
- [ ] Visit https://massgovfeature3.prod.acquia-sites.com/orgs/pharmacy-advisory-committee and make sure there isn't a border top above "Contact Us" header (.ma__org-page--boards .ma__stacked-row__section ~ .ma__stacked-row__section .ma__stacked-row__container:before)


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
