### PR TITLE
Hotfix/fix duplicate fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
   - DP-20436: Fix and optimize Noto Sans multi-language fonts. (MF #1322)
   - DP-22263: Adjusted Picture, KeyMessage, MarketingCampaign to support responsive images. (MF #1484)
   - DP-22971: Fix Behat URL under DDEV.
-  - DP-23001: Updated Mayflower version to 11.15.1.
+  - DP-23001: Updated Mayflower version to 11.15.2.
   - DP-22974: Adjusted it to fix regression issue. (MF #1503)
+  - DP-22979: Fix webfonts `woff2` and `woff` fallback order, to avoid duplicated loading. (MF #1501)
   
 ### Removed
   - DP-19071: Remove person pages from xml sitemap.

--- a/composer.json
+++ b/composer.json
@@ -219,7 +219,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.15.1",
+        "massgov/mayflower-artifacts": "11.15.2",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a06f1a6189b35bf2992aae4a92aa2be0",
+    "content-hash": "a3771f212d2fafd7c00d786962cca759",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11641,16 +11641,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.15.1",
+            "version": "11.15.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "869b2b166982c28a75bd4668b8cab49833ed8c04"
+                "reference": "a6a1607f9f3e67f0453fa1524912deba78ef23c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/869b2b166982c28a75bd4668b8cab49833ed8c04",
-                "reference": "869b2b166982c28a75bd4668b8cab49833ed8c04",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a6a1607f9f3e67f0453fa1524912deba78ef23c7",
+                "reference": "a6a1607f9f3e67f0453fa1524912deba78ef23c7",
                 "shasum": ""
             },
             "require": {
@@ -11670,9 +11670,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.15.1"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.15.2"
             },
-            "time": "2021-09-20T18:55:21+00:00"
+            "time": "2021-09-21T20:10:49+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
  - DP-23001: Updated Mayflower version to 11.15.2.
  - DP-22979: Fix webfonts `woff2` and `woff` fallback order, to avoid duplicated loading. (MF #1501)