### PR TITLE
DP-23040: Investigate 500 error when editing orgs

### DIFF
--- a/changelogs/DP-23040.yml
+++ b/changelogs/DP-23040.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added a workaround for the org_page edit 500 error on local dev environments.
+    issue: DP-23040

--- a/docroot/sites/default/services.local.yml
+++ b/docroot/sites/default/services.local.yml
@@ -1,5 +1,5 @@
 # Do not commit the changes on this file.
-parameters:
+#parameters:
   # Resolves 500 error for edit pages: https://www.drupal.org/project/paragraphs/issues/3197720
 #  http.response.debug_cacheability_headers: false
   # Uncomment the lines below to enable debugging.

--- a/docroot/sites/default/services.local.yml
+++ b/docroot/sites/default/services.local.yml
@@ -1,6 +1,8 @@
-# Uncomment the lines below to enable debugging.
 # Do not commit the changes on this file.
-#parameters:
+parameters:
+  # Resolves 500 error for edit pages: https://www.drupal.org/project/paragraphs/issues/3197720
+#  http.response.debug_cacheability_headers: false
+  # Uncomment the lines below to enable debugging.
 #  twig.config:
 #    debug: true
 #    auto_reload: true


### PR DESCRIPTION
**Description:**
Added a workaround for the org_page edit 500 error on local dev environments.

**Jira:** (Skip unless you are MA staff)
DP-23040


**To Test:**
- Migrate an org_page node with a mosaic.
- Verify you can visit the edit page without a 500 error.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
