### PR TITLE
DP-22981 Adjust the org long form component to support sub grouped elements

### DIFF
--- a/changelogs/DP-22981.yml
+++ b/changelogs/DP-22981.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Adjusted the org long form paragraph to support wrapping sub elements.
+    issue: DP-22981

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6843,12 +6843,13 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
       do {
         $items[] = $paragraphs[$i];
         $i++;
-      } while(isset($paragraphs[$i]) && $paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue());
+      } while (isset($paragraphs[$i]) && $paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue());
       $items[] = $paragraphs[$i];
 
       $component = $items;
-    } else {
-    // Otherwise, create a group of a single element.
+    }
+    else {
+      // Otherwise, create a group of a single element.
       $component[] = $paragraphs[$i];
     }
     $components[] = $component;

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6824,3 +6824,35 @@ function mass_theme_preprocess_paragraph__organization_contact_logo(&$variables)
   $variables['org_logo'] = $node->get('field_sub_brand')->view('logo_link');
 
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Break out url pieces for callout link paragraphs.
+ */
+function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
+  $components = [];
+  $container = $variables['paragraph'];
+  $paragraphs = Helper::getReferencedEntitiesFromField($container, "field_section_long_form_content");
+
+  for ($i = 0; $i < count($paragraphs); $i++) {
+    $component = [];
+    // If the current component has the "wrapping" field, group it with the following component and move the loop pointer.
+    if ($paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue()) {
+      $items = [];
+      do {
+        $items[] = $paragraphs[$i];
+        $i++;
+      } while(isset($paragraphs[$i]) && $paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue());
+      $items[] = $paragraphs[$i];
+
+      $component = $items;
+    } else {
+    // Otherwise, create a group of a single element.
+      $component[] = $paragraphs[$i];
+    }
+    $components[] = $component;
+  }
+  $variables["org_components"] = $components;
+
+}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -15,7 +15,20 @@
   "externalSidebar": true
 } %}
   {% block stackedRowContentOverride %}
-    {{ content.field_section_long_form_content }}
+    {% for org_component in org_components %}
+      {% if org_component|length > 1 %}
+        {% embed "@organisms/by-author/rich-text.twig"%}
+          {% block rteElements %}
+            {% for c in org_component %}
+              {{ c|view }}
+            {% endfor %}
+          {% endblock %}
+        {% endembed %}
+      {% else %}
+        {{ org_component[0]|view }}
+      {% endif %}
+    {% endfor %}
+
   {% endblock %}
 {% endembed %}
 


### PR DESCRIPTION
**Description:**
Modified the (pre processing) org section long form paragraph to take in account the wrapping field to support image and text wrapping.

**Jira:** (Skip unless you are MA staff)
DP-22981


**To Test:**
- [ ] Checkout branch in local.
- [ ] Edit an organization and add a new "organization section"
- [ ] Add an image paragraph, choose "Allow the following rich text or multimedia item to wrap around this one, if there is room." checkbox.
- [ ] Add a rich text component with some sample text and save
- [ ] Validate that the text is wrapping around the image correctly.
- [ ] Replicate a few examples from any of the below links and validate that it looks the same.

https://massgovfeature3.prod.acquia-sites.com/info-details/qaginfo-details-image-in-section-right-align-with-wrap

https://massgovfeature3.prod.acquia-sites.com/info-details/qaginfo-details-image-in-section-left-align-with-text-wrap

https://massgovfeature3.prod.acquia-sites.com/info-details/qaginfo-details-image-in-section-left-align-with-no-text-wrap

https://massgovfeature3.prod.acquia-sites.com/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
