### PR TITLE
DP-22982 Iframe, Caspio and Tableau components on org page not rendering correctly

### DIFF
--- a/changelogs/DP-22982.yml
+++ b/changelogs/DP-22982.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Modified the logic for outputing organization section components depending if it needs to be wrapped or not.
+    issue: DP-22982

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6840,18 +6840,18 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
   for ($i = 0; $i < count($paragraphs); $i++) {
     $component = [];
     // If the current component has the "wrapping" field, group it with the following component and move the loop pointer.
-    if (mass_theme_org_section_long_form_check_wrapping_field ($paragraphs[$i], $wrap_fields)) {
+    if (mass_theme_org_section_long_form_check_wrapping_field($paragraphs[$i], $wrap_fields)) {
       $items = [];
       do {
         $items[] = $paragraphs[$i];
         $i++;
-      } while (mass_theme_org_section_long_form_check_wrapping_field ($paragraphs[$i], $wrap_fields));
+      } while (mass_theme_org_section_long_form_check_wrapping_field($paragraphs[$i], $wrap_fields));
       $items[] = $paragraphs[$i];
 
       $component = ['group' => TRUE, 'items' => $items];
     }
     // Otherwise, if it's one of the following, wrap it as well.
-    elseif(in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== false) {
+    elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
       $component = ['group' => TRUE, 'items' => [$paragraphs[$i]]];
     }
 
@@ -6865,13 +6865,15 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
 
 }
 
-
-function mass_theme_org_section_long_form_check_wrapping_field ($paragraph, $fields) {
+/**
+ * Checks if the paragraph has one of the fields and has a value for it.
+ */
+function mass_theme_org_section_long_form_check_wrapping_field($paragraph, $fields) {
   foreach ($fields as $field) {
-    if(isset($paragraph) && $paragraph->hasField($field) && $paragraph->get($field)->getValue()) {
-      return true;
+    if (isset($paragraph) && $paragraph->hasField($field) && $paragraph->get($field)->getValue()) {
+      return TRUE;
     }
   }
 
-  return false;
+  return FALSE;
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6831,6 +6831,8 @@ function mass_theme_preprocess_paragraph__organization_contact_logo(&$variables)
  * Break out url pieces for callout link paragraphs.
  */
 function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
+  $wrap_paragraphs = ['iframe', 'caspio_embed', 'tableau'];
+  $wrap_fields = ['field_tabl_wrapping', 'field_iframe_wrapping', 'field_image_wrapping'];
   $components = [];
   $container = $variables['paragraph'];
   $paragraphs = Helper::getReferencedEntitiesFromField($container, "field_section_long_form_content");
@@ -6838,22 +6840,38 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
   for ($i = 0; $i < count($paragraphs); $i++) {
     $component = [];
     // If the current component has the "wrapping" field, group it with the following component and move the loop pointer.
-    if ($paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue()) {
+    if (mass_theme_org_section_long_form_check_wrapping_field ($paragraphs[$i], $wrap_fields)) {
       $items = [];
       do {
         $items[] = $paragraphs[$i];
         $i++;
-      } while (isset($paragraphs[$i]) && $paragraphs[$i]->hasField('field_image_wrapping') && $paragraphs[$i]->get('field_image_wrapping')->getValue());
+      } while (mass_theme_org_section_long_form_check_wrapping_field ($paragraphs[$i], $wrap_fields));
       $items[] = $paragraphs[$i];
 
-      $component = $items;
+      $component = ['group' => TRUE, 'items' => $items];
     }
+    // Otherwise, if it's one of the following, wrap it as well.
+    elseif(in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== false) {
+      $component = ['group' => TRUE, 'items' => [$paragraphs[$i]]];
+    }
+
     else {
-      // Otherwise, create a group of a single element.
+      // Otherwise, just return it as it is.
       $component[] = $paragraphs[$i];
     }
     $components[] = $component;
   }
   $variables["org_components"] = $components;
 
+}
+
+
+function mass_theme_org_section_long_form_check_wrapping_field ($paragraph, $fields) {
+  foreach ($fields as $field) {
+    if(isset($paragraph) && $paragraph->hasField($field) && $paragraph->get($field)->getValue()) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -16,10 +16,10 @@
 } %}
   {% block stackedRowContentOverride %}
     {% for org_component in org_components %}
-      {% if org_component|length > 1 %}
+      {% if org_component.group %}
         {% embed "@organisms/by-author/rich-text.twig"%}
           {% block rteElements %}
-            {% for c in org_component %}
+            {% for c in org_component.items %}
               {{ c|view }}
             {% endfor %}
           {% endblock %}


### PR DESCRIPTION
**Description:**
Modified the logic of preprocessing the org section sub paragraphs for defining a set of paragraphs that need to be wrapped individually with a rich text element for caspio, tableau and iframe or with the next component for paragraphs with a wrapping field.

The paragraphs and fields that will trigger wrapping are defined in mass_theme_preprocess_paragraph__org_section_long_form() 

  $wrap_paragraphs = ['iframe', 'caspio_embed', 'tableau'];
  $wrap_fields = ['field_tabl_wrapping', 'field_iframe_wrapping', 'field_image_wrapping'];

**Jira:** (Skip unless you are MA staff)
DP-22982


**To Test:**
- [ ] Checkout this branch, clear cache.
- [ ] Edit or add a new organization, go to "content" tab.
- [ ] Add a new Tableau component with XL size and validate that it looks right (contained).
- [ ] Add a new Iframe with XL size and validate that it looks right (contained).
- [ ] Add a new Caspio component and validate that it looks right (contained).
- [ ] Add a new or edit the Tableau component, choose a smaller size and select the wrapping checkbox, validate that it's looking right.
- [ ] Do the same with Iframes and also with Images.

<img width="600" alt="j-r-capture 2021-09-30 a la(s) 18 22 27" src="https://user-images.githubusercontent.com/141685/135532885-ccfbca52-c4fb-4f9a-ba71-2515ac1740de.png">
<img width="600" alt="j-r-capture 2021-09-30 a la(s) 18 22 38" src="https://user-images.githubusercontent.com/141685/135532898-8fd01139-5ce2-4688-8d71-2b9b1685b597.png">
<img width="600" alt="j-r-capture 2021-09-30 a la(s) 18 22 44" src="https://user-images.githubusercontent.com/141685/135532902-826e26ef-c30c-4d16-a790-8f8b44b6e760.png">



---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
