### PR TITLE
DP-22982 Iframe, Caspio and Tableau components on org page not rendering correctly

### DIFF
--- a/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
+++ b/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
@@ -19,6 +19,7 @@ global-styling:
       overrides/css/view-external-data-resource.css: {}
       overrides/css/datatables.css: {}
       overrides/css/alerts.css: {}
+      overrides/css/rich-text.css: {}
   js:
     overrides/js/fixed-feedback-button.js: {}
   dependencies:

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6857,7 +6857,7 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
     }
     // Otherwise, if it's one of the following paragraphs, wrap it as well.
     elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
-      $component = ['group' => TRUE, 'type' => $paragraphs[$i]->getType() == 'image'? null : 'full', 'items' => [$paragraphs[$i]]];
+      $component = ['group' => TRUE, 'type' => $paragraphs[$i]->getType() == 'image' ? NULL : 'full', 'items' => [$paragraphs[$i]]];
     }
 
     else {

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6835,7 +6835,7 @@ function mass_theme_preprocess_paragraph__organization_contact_logo(&$variables)
  */
 function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
   // Define fields and paragraphs that should be wrapped, fields have priority over paragraphs.
-  $wrap_paragraphs = ['iframe', 'caspio_embed', 'tableau', 'image'];
+  $wrap_paragraphs = ['iframe', 'caspio_embed', 'tableau_embed', 'image'];
   $wrap_fields = ['field_tabl_wrapping', 'field_iframe_wrapping', 'field_image_wrapping'];
 
   $components = [];
@@ -6855,9 +6855,9 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
 
       $component = ['group' => TRUE, 'items' => $items];
     }
-    // Otherwise, if it's one of the following, wrap it as well.
+    // Otherwise, if it's one of the following paragraphs, wrap it as well.
     elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
-      $component = ['group' => TRUE, 'items' => [$paragraphs[$i]]];
+      $component = ['group' => TRUE, 'type' => 'full', 'items' => [$paragraphs[$i]]];
     }
 
     else {

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6853,11 +6853,11 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
       } while (mass_theme_org_section_long_form_check_wrapping_field($paragraphs[$i], $wrap_fields));
       $items[] = $paragraphs[$i];
 
-      $component = ['group' => TRUE, 'items' => $items];
+      $component = ['group' => TRUE, 'type' => '', 'items' => $items];
     }
     // Otherwise, if it's one of the following paragraphs, wrap it as well.
     elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
-      $component = ['group' => TRUE, 'type' => 'full', 'items' => [$paragraphs[$i]]];
+      $component = ['group' => TRUE, 'type' => $paragraphs[$i]->getType() == 'image'? null : 'full', 'items' => [$paragraphs[$i]]];
     }
 
     else {

--- a/docroot/themes/custom/mass_theme/overrides/css/rich-text.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/rich-text.css
@@ -1,0 +1,3 @@
+.om__rich-text--no-padding {
+  padding-right: 0 !important;
+}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -16,8 +16,13 @@
 } %}
   {% block stackedRowContentOverride %}
     {% for org_component in org_components %}
+      {%  set noPadding = "" %}
       {% if org_component.group %}
-        {% embed "@organisms/by-author/rich-text.twig"%}
+        {% if org_component.type == 'full' %}
+          {%  set noPadding = "om__rich-text--no-padding" %}
+        {% endif %}
+
+        {% embed "@organisms/by-author/rich-text.twig" with {"headerIndent": noPadding}%}
           {% block rteElements %}
             {% for c in org_component.items %}
               {{ c|view }}


### PR DESCRIPTION
**Description:**
"Fixes a number of alignments issues with caspio, tableau and iframes.

**Jira:** (Skip unless you are MA staff)
DP-22982


**To Test:**
- [ ] Edit an organization and add different variations of caspio, tableau and iframes to the page, compare with info details (links in the ticket).


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
