### PR TITLE
Dp 22331 flex orgs backstop test

### DIFF
--- a/backstop/pages.json
+++ b/backstop/pages.json
@@ -1,33 +1,4 @@
 [
-    { "label": "Homepage", "url": "/" },
-    { "label": "HomepageWithAlert", "url": "/", "showAlerts": true, "readySelector": "span.ma__emergency-alert__time-stamp", "delay": 2000 },
-    {
-        "label": "Homepage Login link (Large sizes)",
-        "delay": 2000,
-        "url": "/",
-        "clickSelector": ".ma__header__hamburger__utility-nav .ma__utility-nav__items li.ma__utility-nav__item:last-child button.ma__utility-nav__link",
-        "viewports": [{
-                "label": "desktop",
-                "width": 1920,
-                "height": 1080
-            },
-            {
-                "label": "tablet",
-                "width": 1024,
-                "height": 768
-            }
-        ]
-    },
-    {
-        "label": "Homepage Login link (Mobile)",
-        "delay": 2000,
-        "url": "/",
-        "viewports": [{
-            "label": "phone",
-            "width": 320,
-            "height": 480
-        }]
-    },
     { "label": "OrgQAGEOTSSGeneralOrg", "url": "/orgs/qag-executive-office-of-technology-services-and-security" },
     { "label": "OrgQAGDigitalServiceGeneralOrg", "url": "/orgs/qag-digital-services" },
     { "label": "OrgGovernorElectedOffical", "url": "/orgs/office-of-the-governor" },
@@ -37,5 +8,30 @@
     { "label": "OrgsUpcomingEvents", "url": "/orgs/qag-digital-services/events?_page=1" },
     { "label": "OrgsPastEvents", "url": "/orgs/qag-digital-services/events/past?_page=1" },
     { "label": "OrgsServices", "url": "/orgs/qag-executive-office-of-technology-services-and-security/services" },
-    { "label": "OrgsLocationDetails", "url": "/orgs/qag-executive-office-of-technology-services-and-security/locations?page=1" }
+    { "label": "OrgsLocationDetails", "url": "/orgs/qag-executive-office-of-technology-services-and-security/locations?page=1" },
+    { "label": "Department of Unemployment Assistance", "url": "/orgs/department-of-unemployment-assistance" },
+    { "label": "Massachusetts Registry of Motor Vehicles", "url": "/orgs/massachusetts-registry-of-motor-vehicles" },
+    { "label": "Department of Transitional Assistance", "url": "/orgs/department-of-transitional-assistance" },
+    { "label": "Sex Offender Registry Board", "url": "/orgs/sex-offender-registry-board" },
+    { "label": "Department of Public Health", "url": "/orgs/department-of-public-health" },
+    { "label": "Child Support Enforcement Division", "url": "/orgs/child-support-enforcement-division" },
+    { "label": "Massachusetts Department of Revenue", "url": "/orgs/massachusetts-department-of-revenue" },
+    { "label": "Department of Family and Medical Leave", "url": "/orgs/department-of-family-and-medical-leave" },
+    { "label": "Office of Jury Commissioner", "url": "/orgs/office-of-jury-commissioner" },
+    { "label": "Massachusetts Department of Transportation", "url": "/orgs/massachusetts-department-of-transportation" },
+    { "label": "Probate and Family Court", "url": "/orgs/probate-and-family-court" },
+    { "label": "Department of Early Education and Care", "url": "/orgs/department-of-early-education-and-care" },
+    { "label": "Executive Office of Health and Human Services", "url": "/orgs/executive-office-of-health-and-human-services" },
+    { "label": "Board of Registration in Nursing", "url": "/orgs/board-of-registration-in-nursing" },
+    { "label": "Unclaimed Property Division", "url": "/orgs/unclaimed-property-division" },
+    { "label": "Division of Occupational Licensure", "url": "/orgs/division-of-occupational-licensure" },
+    { "label": "Department of Industrial Accidents", "url": "/orgs/department-of-industrial-accidents" },
+    { "label": "Civil Service", "url": "/orgs/civil-service" },
+    { "label": "MassHealth", "url": "/orgs/masshealth" },
+    { "label": "Massachusetts Court System", "url": "/orgs/massachusetts-court-system" },
+    { "label": "Housing and Community Development", "url": "/orgs/housing-and-community-development" },
+    { "label": "Massachusetts Commission for the Blind", "url": "/orgs/massachusetts-commission-for-the-blind" },
+    { "label": "Office of Attorney General Maura Healey", "url": "/orgs/office-of-attorney-general-maura-healey" },
+    { "label": "Office of the State Auditor", "url": "/orgs/office-of-the-state-auditor" },
+    { "label": "Division of Fisheries and Wildlife", "url": "/orgs/division-of-fisheries-and-wildlife" }
 ]

--- a/docroot/sites/default/services.local.yml
+++ b/docroot/sites/default/services.local.yml
@@ -1,7 +1,7 @@
 # Do not commit the changes on this file.
-#parameters:
+parameters:
   # Resolves 500 error for edit pages: https://www.drupal.org/project/paragraphs/issues/3197720
-#  http.response.debug_cacheability_headers: false
+ http.response.debug_cacheability_headers: false
   # Uncomment the lines below to enable debugging.
 #  twig.config:
 #    debug: true

--- a/docroot/sites/development.services.yml
+++ b/docroot/sites/development.services.yml
@@ -1,6 +1,7 @@
 # Local development services.
 #
-#This file is active in CI and Local dev environments.
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
 parameters:
   http.response.debug_cacheability_headers: true
 services:


### PR DESCRIPTION
In order to leverage backstop to test visual regressions on org pages, this PR removed all test pages other than org QA pages and added a list of the highest traffic org pages in the database pulled from the feature3 database (10/6/2021).

- To run the backstop tests in circle comparing feature3 and prod:
```
ahoy drush ma:backstop feature3 prod
```

- To run the backstop tests locally comparing this branch and prod:
  1. ahoy backstop test --target=prod
  2. ahoy backstop approve --target=prod (update the local reference images)
  3. ddev start && ahoy pull && ahoy updatedb (spin up mass.local from this branch)
  4. ahoy backstop test --target=local (The local backstop seems to be using a database out of sync from prod. Is there a way to run the test targeting feature3 instead of local against the new reference images?

> <img width="1766" alt="Screen Shot 2021-10-06 at 6 47 10 PM" src="https://user-images.githubusercontent.com/5789411/136294795-b06a9be2-05f1-4f49-af46-7df6be909174.png">


!! This PR is only for testing purposes, DO NOT MERGE!!