### PR TITLE
DDEV instructions to install frontend and backend packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ See the [Table of Contents](/docs/README.md) for additional documentation relate
 1. [Install Docker](https://docs.docker.com/get-docker/).
 1. [Install DDEV](https://ddev.readthedocs.io/en/stable/). On Windows, use the WSL2 method.
 1. Inject your ssh keys into the container via `ddev auth ssh`. [Read more about ddev CLI](https://ddev.readthedocs.io/en/stable/users/cli-usage/).
+1. Start DDEV and install packages.
+    ```
+    ddev start
+    ddev composer install
+    ddev yarn
+    ```
 
 ### Native (optional)
 If the Docker section above is unappealing, its easy to run mass.gov natively on any OS. You need to provide your own PHP, web server and DB server (and optional memcache). On OSX, [these install instructions](https://getgrav.org/blog/macos-bigsur-apache-multiple-php-versions) are good (stop at the section called _PHP Switcher Script_), along with this [mysql section](https://getgrav.org/blog/macos-bigsur-apache-mysql-vhost-apc). Point your web server at the /docroot directory.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ See the [Table of Contents](/docs/README.md) for additional documentation relate
     ddev composer install
     ddev yarn
     ```
+1. To get information about this project.
+    ```
+    ddev describe
+    ```
 
 ### Native (optional)
 If the Docker section above is unappealing, its easy to run mass.gov natively on any OS. You need to provide your own PHP, web server and DB server (and optional memcache). On OSX, [these install instructions](https://getgrav.org/blog/macos-bigsur-apache-multiple-php-versions) are good (stop at the section called _PHP Switcher Script_), along with this [mysql section](https://getgrav.org/blog/macos-bigsur-apache-mysql-vhost-apc). Point your web server at the /docroot directory.


### PR DESCRIPTION
**Description:**
- Updates documentation on DDEV
- I haven't used DDEV before, only Lando. Despite these are similar tools, might not be obvious for Lando users or users unfamiliar with DDEV.
- After I ran `ddev start` in the root of the repo, I got errors due to missing packages, which were fixed after running `ddev composer install`
- I also added a instruction to get information of the DDEV running instance (similar to `lando info`)

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
