### PR TITLE
Dp 22982 rich text fix

### DIFF
--- a/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
+++ b/docroot/themes/custom/mass_theme/mass_theme.libraries.yml
@@ -20,6 +20,7 @@ global-styling:
       overrides/css/datatables.css: {}
       overrides/css/alerts.css: {}
       overrides/css/org-page--figure.css: {}
+      overrides/css/contained.css: {}
 
   js:
     overrides/js/fixed-feedback-button.js: {}

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6852,8 +6852,8 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
       do {
         $items[] = $paragraphs[$i];
         $i++;
-        // Keep grouping togheter while the next element has the check.
-      } while (mass_theme_org_section_long_form_check_wrapping_field($paragraphs[$i], $wrap_fields));
+        // Keep grouping together while the next element has the check.
+      } while (isset($paragraphs[$i]) && mass_theme_org_section_long_form_check_wrapping_field($paragraphs[$i], $wrap_fields));
       // Once done, also group the following one.
       $items[] = $paragraphs[$i];
 
@@ -6865,7 +6865,7 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
     }
     // Otherwise, if it's one of the following paragraphs, wrap it as well.
     elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
-      $component = ['group' => 'default', 'items' => [$paragraphs[$i]]];
+      $component = ['group' => 'self', 'items' => $paragraphs[$i]];
     }
 
     else {

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6838,6 +6838,7 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
   // Define fields and paragraphs that should be wrapped, fields have priority over paragraphs.
   $wrap_paragraphs = ['iframe', 'caspio_embed', 'tableau_embed', 'image'];
   $wrap_fields = ['field_tabl_wrapping', 'field_iframe_wrapping', 'field_image_wrapping'];
+  $contained = ['rich_text'];
 
   $components = [];
   $container = $variables['paragraph'];
@@ -6856,11 +6857,15 @@ function mass_theme_preprocess_paragraph__org_section_long_form(&$variables) {
       // Once done, also group the following one.
       $items[] = $paragraphs[$i];
 
-      $component = ['group' => TRUE, 'type' => '', 'items' => $items];
+      $component = ['group' => 'default', 'items' => $items];
+    }
+    // There are some special paragraphs that should have a right margin.
+    elseif (in_array($paragraphs[$i]->getType(), $contained) !== FALSE) {
+      $component = ['group' => 'contained', 'items' => $paragraphs[$i]];
     }
     // Otherwise, if it's one of the following paragraphs, wrap it as well.
     elseif (in_array($paragraphs[$i]->getType(), $wrap_paragraphs) !== FALSE) {
-      $component = ['group' => TRUE, 'type' => $paragraphs[$i]->getType() == 'image' ? NULL : 'full', 'items' => [$paragraphs[$i]]];
+      $component = ['group' => 'default', 'items' => [$paragraphs[$i]]];
     }
 
     else {

--- a/docroot/themes/custom/mass_theme/overrides/css/contained.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/contained.css
@@ -1,5 +1,5 @@
 
-@media (min-width: 1321px) {
+@media (min-width: 911px) {
   .om__contained-component,
   .main-content--full .no-sidebar .page-content>.om__contained-component{
     margin-left: auto;

--- a/docroot/themes/custom/mass_theme/overrides/css/contained.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/contained.css
@@ -1,0 +1,9 @@
+
+@media (min-width: 1321px) {
+  .om__contained-component,
+  .main-content--full .no-sidebar .page-content>.om__contained-component{
+    margin-left: auto;
+    margin-right: auto;
+    padding-right: 500px;
+  }
+}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -25,6 +25,12 @@
             {% endfor %}
           {% endblock %}
         {% endembed %}
+      {% elseif org_component.group == 'self' %}
+        {% embed "@organisms/by-author/rich-text.twig" %}
+          {% block rteElements %}
+            {{ org_component.items|view }}
+          {% endblock %}
+        {% endembed %}
       {% elseif org_component.group == 'contained' %}
         {% embed "@organisms/by-author/rich-text.twig" with {'headerIndent' : 'om__contained-component'} %}
           {% block rteElements %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--org-section-long-form--default.html.twig
@@ -17,13 +17,18 @@
 } %}
   {% block stackedRowContentOverride %}
     {% for org_component in org_components %}
-      {%  set noPadding = "" %}
-      {% if org_component.group %}
+      {% if org_component.group == 'default' %}
         {% embed "@organisms/by-author/rich-text.twig" %}
           {% block rteElements %}
             {% for c in org_component.items %}
               {{ c|view }}
             {% endfor %}
+          {% endblock %}
+        {% endembed %}
+      {% elseif org_component.group == 'contained' %}
+        {% embed "@organisms/by-author/rich-text.twig" with {'headerIndent' : 'om__contained-component'} %}
+          {% block rteElements %}
+            {{ org_component.items|view }}
           {% endblock %}
         {% endembed %}
       {% else %}


### PR DESCRIPTION
**Description:**
Handles rich text paragraphs inside organization details so these are contained (right padding 500px)

**Jira:** (Skip unless you are MA staff)
DP-22982


**To Test:**
- [x] Checkout this branch, visit an organization with an organization detail section that contains images wrapping up text.
- [x] Edit this organization, add a rich text paragraph with some text and save.
- [x] Validate that the standalone rich text paragraph has a class `.om__contained-component`
- [x] Validate that the standalone rich text paragraph has a 500px right padding on desktop  and no margin in tablet, mobile.
- [x] Validate that the rich text wrapping the existing image doesn't have this class and that it looks good.

<img width="800" alt="j-r-capture 2021-10-12 a la(s) 10 35 21" src="https://user-images.githubusercontent.com/141685/136966230-2bffeeeb-d59d-4855-9214-104b0ee55ccb.png">




---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
