### PR TITLE
Mayflower upgrade v11.16.0

### DIFF
--- a/changelogs/DP-23136.yml
+++ b/changelogs/DP-23136.yml
@@ -1,0 +1,57 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+        Updated Mayflower version to 11.16.0.
+          - [SectionsThreeUp] DP-22483: Adjusting section 3up to support a compact version. (MF #1452)
+          - [CollapsibleContent] DP-22561: Added modifier for background style and adjusted width. (MF #1460)
+          - [CollapsibleContent] DP-22657: Adjusted accordions to use a minus "-" for collapsing instead of a cross "x". (MF #1491)
+          - [AboutSection] DP-22689: Added a condition to only show the title if it is defined. (MF #1461)
+          - [Figure] DP-22981: Fixing image displaying when right aligned. (MF #1515)
+          - [StackedRowSection] DP-22982: Adding new modifier class option. (MF #1518)
+          - [RichText] DP-22982: Removing right padding if container has a `.no-sidebar` class. (MF #1518)
+          - [ActionFinder] DP-22983: Adjusting action finder to not render the heading if there isn't a title and adds a background option. (MF #1514)
+          - [SectionsThreeUp] DP-23128: Adjusting section 3up spacing top on mobile. (MF #1522)
+          - [SectionsLinks] DP-23128: Fix SectionLinks with icon overlapping issue. (MF #1522)
+          - [SocialLinksBar] DP-22652: Display an horizontal bar of links. (MF #1466)
+          - [CollapsibleContent] DP-22657: Added Collapsible Content Extended variant to allow expand/collapse all accordions. (MF #1491)
+          - [OrgContact] DP-22666: Added Org Contact organism. (MF #1467)
+          - [Sidebar] DP-22940: Fix the horizontal alignment on sidebar for locations. Fix small text-underline on locations. (MF #1513)
+          - [StackedRowSection] DP-23128: Adjust vertical spacing around the component. (MF #1525)
+    issue: DP-23136

--- a/composer.json
+++ b/composer.json
@@ -234,7 +234,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-22331_flex-orgs",
+        "massgov/mayflower-artifacts": "11.16.0",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e93e70502451f00e9f93583736bd8552",
+    "content-hash": "6da12f14642954b56422037de09da977",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11400,16 +11400,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-22331_flex-orgs",
+            "version": "11.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "5a8e15547675a374b0e8bd690652d517dd9d6206"
+                "reference": "374e87f7fb48b35fee5aa18666cb6934ef96a033"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/5a8e15547675a374b0e8bd690652d517dd9d6206",
-                "reference": "5a8e15547675a374b0e8bd690652d517dd9d6206",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/374e87f7fb48b35fee5aa18666cb6934ef96a033",
+                "reference": "374e87f7fb48b35fee5aa18666cb6934ef96a033",
                 "shasum": ""
             },
             "require": {
@@ -11429,9 +11429,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-22331_flex-orgs"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.16.0"
             },
-            "time": "2021-10-12T21:51:57+00:00"
+            "time": "2021-10-13T13:53:55+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -20465,8 +20465,7 @@
         "drupal/security_review": 20,
         "drupal/views_aggregator": 10,
         "drupal/views_taxonomy_term_name_into_id": 15,
-        "furf/jquery-ui-touch-punch": 20,
-        "massgov/mayflower-artifacts": 20
+        "furf/jquery-ui-touch-punch": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Changed:
  - description: |-
        Updated Mayflower version to 11.16.0.
          - [SectionsThreeUp] DP-22483: Adjusting section 3up to support a compact version. (MF #1452)
          - [CollapsibleContent] DP-22561: Added modifier for background style and adjusted width. (MF #1460)
          - [CollapsibleContent] DP-22657: Adjusted accordions to use a minus "-" for collapsing instead of a cross "x". (MF #1491)
          - [AboutSection] DP-22689: Added a condition to only show the title if it is defined. (MF #1461)
          - [Figure] DP-22981: Fixing image displaying when right aligned. (MF #1515)
          - [StackedRowSection] DP-22982: Adding new modifier class option. (MF #1518)
          - [RichText] DP-22982: Removing right padding if container has a `.no-sidebar` class. (MF #1518)
          - [ActionFinder] DP-22983: Adjusting action finder to not render the heading if there isn't a title and adds a background option. (MF #1514)
          - [SectionsThreeUp] DP-23128: Adjusting section 3up spacing top on mobile. (MF #1522)
          - [SectionsLinks] DP-23128: Fix SectionLinks with icon overlapping issue. (MF #1522)
          - [SocialLinksBar] DP-22652: Display an horizontal bar of links. (MF #1466)
          - [CollapsibleContent] DP-22657: Added Collapsible Content Extended variant to allow expand/collapse all accordions. (MF #1491)
          - [OrgContact] DP-22666: Added Org Contact organism. (MF #1467)
          - [Sidebar] DP-22940: Fix the horizontal alignment on sidebar for locations. Fix small text-underline on locations. (MF #1513)
          - [StackedRowSection] DP-23128: Adjust vertical spacing around the component. (MF #1525)
    issue: DP-23136