### PR TITLE
Hotfix: 0.298.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.298.1] - October 14, 2021
+
+### Fixed
+  - DP-23166: Hotfix binder accordion JS. Updated Mayflower version to 11.16.1.
+
 
 
 ## [0.298.0] - October 13, 2021

--- a/composer.json
+++ b/composer.json
@@ -234,7 +234,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.16.0",
+        "massgov/mayflower-artifacts": "11.16.1",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6da12f14642954b56422037de09da977",
+    "content-hash": "a258d8b241b5912fcd159f16345a964e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11400,16 +11400,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.16.0",
+            "version": "11.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "374e87f7fb48b35fee5aa18666cb6934ef96a033"
+                "reference": "e11306b852642186b5dc579fd029d42d96285353"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/374e87f7fb48b35fee5aa18666cb6934ef96a033",
-                "reference": "374e87f7fb48b35fee5aa18666cb6934ef96a033",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e11306b852642186b5dc579fd029d42d96285353",
+                "reference": "e11306b852642186b5dc579fd029d42d96285353",
                 "shasum": ""
             },
             "require": {
@@ -11429,9 +11429,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.16.0"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.16.1"
             },
-            "time": "2021-10-13T13:53:55+00:00"
+            "time": "2021-10-14T14:44:32+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/sites/development.services.yml
+++ b/docroot/sites/development.services.yml
@@ -1,6 +1,7 @@
 # Local development services.
 #
-#This file is active in CI and Local dev environments.
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
 parameters:
   http.response.debug_cacheability_headers: true
 services:


### PR DESCRIPTION
## [0.298.1] - October 14, 2021

### Fixed
  - DP-23166: Hotfix binder accordion JS. Updated Mayflower version to 11.16.1.

----

To Test:
- [x] Deployed to stage. 
- [x] Confirmed that the reported accordions are fixed on stage
   - [x] https://edit.stage.mass.gov/handbook/financial-industry-resources
   - [x] https://edit.stage.mass.gov/how-to/qag-request-help-with-a-computer-problem
