### PR TITLE
DP-23165: Content Report: Organization Pages 500 error

### DIFF
--- a/changelogs/DP-23165.yml
+++ b/changelogs/DP-23165.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed the 500 error for Content Reports Organization Pages.
+    issue: DP-23165

--- a/docroot/modules/custom/mass_views/src/Plugin/views/field/OrgPageCountBase.php
+++ b/docroot/modules/custom/mass_views/src/Plugin/views/field/OrgPageCountBase.php
@@ -43,7 +43,6 @@ class OrgPageCountBase extends NumericField {
     $subQuery->addExpression("COUNT($this->pseudoTableAlias.id)", $this->pseudoFieldName);
     $subQuery->condition("$this->pseudoTableAlias.parent_type", 'paragraph');
     $subQuery->condition("$this->pseudoTableAlias.type", $this->paragraphBundle);
-    $subQuery->groupBy("$this->pseudoTableAlias.id");
 
     $relationship = $this->relationship ?: 'paragraphs_item_field_data';
 


### PR DESCRIPTION
**Description:**
Fixed the 500 error for Content Reports Organization Pages by removing the groupBy() from the subquery.


**Jira:** (Skip unless you are MA staff)
DP-23165


**To Test:**
- Login and go to /admin/ma-dash/reports/organization-pages.
- Verify the page loads and content numbers look correct.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
