### PR TITLE
Dp 3188 a11y autocomplete for search

### DIFF
--- a/changelogs/DP-3188.yml
+++ b/changelogs/DP-3188.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: To make search comply with https://rawgit.com/w3c/aria-practices/master/aria-practices-DeletedSectionsArchive.html#autocomplete
+    issue: DP-3188

--- a/changelogs/DP-3188.yml
+++ b/changelogs/DP-3188.yml
@@ -37,5 +37,7 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: To make search comply with https://rawgit.com/w3c/aria-practices/master/aria-practices-DeletedSectionsArchive.html#autocomplete
+  - description: |-
+      To make search comply with https://rawgit.com/w3c/aria-practices/master/aria-practices-DeletedSectionsArchive.html#autocomplete
+      Accesibility improvements for screenreaders on search https://github.com/massgov/openmass/pull/1081#issuecomment-947854475
     issue: DP-3188

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -136,7 +136,7 @@
     $input.trigger('autocomplete:suggestionsUpdated', [results]);
   });
   $input.on('keyup', function (event) {
-    if (event.keyCode !== 13 && event.keyCode !== 38 && event.keyCode !== 40) {
+    if (event.key !== 'Enter' && event.key !== 'ArrowUp' && event.key !== 'ArrowDown') {
       ac.update(event.target.value);
     }
   });
@@ -146,7 +146,7 @@
     var scope = input.parents('.js-suggestions-container');
 
     $('[role="listbox"]', scope).remove();
-    $('[data-suggestions]', scope).html('<div role="listbox" id="suggestions-list"></div>');  
+    $('[data-suggestions]', scope).html('<div role="listbox" id="suggestions-list"></div>');
     $('.js-suggestions-help', scope).empty();
 
     var $listbox = $('[role="listbox"]', scope);
@@ -172,7 +172,7 @@
 
     $listbox.on('keydown', function (e) {
 
-      if (e.keyCode === 13) {
+      if (e.key === 'Enter') {
         e.preventDefault();
         e.stopPropagation();
         input.data('realValue', input.val());
@@ -181,7 +181,7 @@
         return;
       }
 
-      if (e.keyCode === 27) {
+      if (e.key === 'Esc') {
         input.val(input.data('realValue'));
         input.focus();
         $listbox.hide();
@@ -189,7 +189,7 @@
       }
 
       var newOption;
-      if (e.keyCode === 40) {
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
         newOption = $('.selected', scope).next();
 
@@ -201,7 +201,7 @@
         }
       }
 
-      if (e.keyCode === 38) {
+      if (e.key === 'ArrowUp') {
         e.preventDefault();
         newOption = $('.selected', scope).prev();
 
@@ -245,7 +245,7 @@
       // hence we need to update the reference.
       $listbox = $('[role="listbox"]', scope);
 
-      if (e.keyCode === 27) {
+      if (e.key === 'Escape') {
 
         if (input.val() !== '' && ($listbox.length === 0 || !$listbox.is(':visible'))) {
           input.val('');
@@ -258,7 +258,7 @@
         return;
       }
 
-      if (e.keyCode === 38) {
+      if (e.key === 'ArrowUp') {
         e.preventDefault();
         $listbox.find('.selected', scope).removeClass('selected');
         $listbox.attr('tabindex', '0').focus();
@@ -267,7 +267,7 @@
         return;
       }
 
-      if (e.keyCode === 40) {
+      if (e.key === 'ArrowDown') {
         e.preventDefault();
         $listbox.find('.selected', scope).removeClass('selected');
 
@@ -285,7 +285,7 @@
         return;
       }
 
-      if (e.keyCode === 9) {
+      if (e.key === 'Tab') {
         $listbox.remove();
         return;
       }

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -222,7 +222,6 @@
     });
 
     $('[role="option"]', scope).on('click', function () {
-      console.log('clicking');
       input.data('realValue', $(this).text());
       $('[data-suggest]', scope).val($(this).text())
         .focus();

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -186,11 +186,11 @@
       var newOption;
       if (e.keyCode === 40) {
         e.preventDefault();
-        newOption = $('.selected').next();
+        newOption = $('.selected', scope).next();
 
         if (!newOption.length) {
           input.focus();
-          $('.selected').removeClass('selected');
+          $('.selected', scope).removeClass('selected');
           input.val(input.data('realValue'));
           return;
         }
@@ -198,7 +198,7 @@
 
       if (e.keyCode === 38) {
         e.preventDefault();
-        newOption = $('.selected').prev();
+        newOption = $('.selected', scope).prev();
 
         if (!newOption.length) {
           input.focus();
@@ -209,7 +209,7 @@
       }
 
       if (newOption && newOption.length) {
-        $('.selected').removeClass('selected');
+        $('.selected', scope).removeClass('selected');
         newOption.addClass('selected');
         $(this).attr('aria-activedescendant', newOption.attr('id'));
         input.val($('.selected').text());
@@ -233,7 +233,7 @@
 
       if (e.keyCode === 27) {
 
-        if (input.val() !== '' && ($('[role="listbox"]').length === 0 || !$('[role="listbox"]').is(':visible'))) {
+        if (input.val() !== '' && ($('[role="listbox"]', scope).length === 0 || !$('[role="listbox"]').is(':visible'))) {
           input.val('');
           input.data('realValue', '');
         }
@@ -262,8 +262,8 @@
         }
         else {
           $('[role="listbox"]', scope).attr('tabindex', '0').focus();
-          $('[role="listbox"]').attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
-          $('[role="listbox"] [role="option"]:first-child').addClass('selected');
+          $('[role="listbox"]', scope).attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
+          $('[role="listbox"] [role="option"]:first-child', scope).addClass('selected');
           input.data('realValue', input.val());
           input.val($('.selected').text());
         }

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -202,7 +202,7 @@
 
         if (!newOption.length) {
           input.focus();
-          $('.selected').removeClass('selected');
+          $('.selected', scope).removeClass('selected');
           input.val(input.data('realValue'));
           return;
         }
@@ -212,7 +212,7 @@
         $('.selected', scope).removeClass('selected');
         newOption.addClass('selected');
         $(this).attr('aria-activedescendant', newOption.attr('id'));
-        input.val($('.selected').text());
+        input.val($('.selected', scope).text());
       }
     });
 
@@ -233,7 +233,7 @@
 
       if (e.keyCode === 27) {
 
-        if (input.val() !== '' && ($('[role="listbox"]', scope).length === 0 || !$('[role="listbox"]').is(':visible'))) {
+        if (input.val() !== '' && ($('[role="listbox"]', scope).length === 0 || !$('[role="listbox"]', scope).is(':visible'))) {
           input.val('');
           input.data('realValue', '');
         }
@@ -248,8 +248,8 @@
         e.preventDefault();
         $('[role="listbox"] .selected', scope).removeClass('selected');
         $('[role="listbox"]', scope).attr('tabindex', '0').focus();
-        $('[role="listbox"]').attr('aria-activedescendant', $('[role="listbox"] [role="option"]:last-child', scope).attr('id'));
-        $('[role="listbox"] [role="option"]:last-child').addClass('selected');
+        $('[role="listbox"]', scope).attr('aria-activedescendant', $('[role="listbox"] [role="option"]:last-child', scope).attr('id'));
+        $('[role="listbox"] [role="option"]:last-child', scope).addClass('selected');
         return;
       }
 
@@ -265,7 +265,7 @@
           $('[role="listbox"]', scope).attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
           $('[role="listbox"] [role="option"]:first-child', scope).addClass('selected');
           input.data('realValue', input.val());
-          input.val($('.selected').text());
+          input.val($('.selected', scope).text());
         }
         return;
       }

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -167,36 +167,47 @@
       }
     }
 
-    input.on('keydown', function (e) {
-      if (e.keyCode === 40) {
-        e.preventDefault();
-        $('[role="listbox"]', scope)
-          .attr('tabindex', '0')
-          .focus();
-        $('[role="listbox"]').attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
-        $('[role="listbox"] [role="option"]:first-child').addClass('selected');
-        input.val($('.selected').text());
-      }
-      if (e.keyCode === 9) {
-        $('[role="listbox"]', scope).remove();
-      }
-    });
-
     $('[role="listbox"]', scope).on('keydown', function (e) {
       if (e.keyCode === 13) {
         e.preventDefault();
         e.stopPropagation();
+        input.data('realValue', input.val());
         input.focus();
+        $('[role="listbox"]', scope).remove();
       }
+
+      if (e.keyCode === 27) {
+        input.val(input.data('realValue'));
+        input.focus();
+        $('[role="listbox"]', scope).hide();
+        return;
+      }
+
       var newOption;
       if (e.keyCode === 40) {
         e.preventDefault();
         newOption = $('.selected').next();
+
+        if (!newOption.length) {
+          input.focus();
+          $('.selected').removeClass('selected');
+          input.val(input.data('realValue'));
+          return;
+        }
       }
+
       if (e.keyCode === 38) {
         e.preventDefault();
         newOption = $('.selected').prev();
+
+        if (!newOption.length) {
+          input.focus();
+          $('.selected').removeClass('selected');
+          input.val(input.data('realValue'));
+          return;
+        }
       }
+
       if (newOption && newOption.length) {
         $('.selected').removeClass('selected');
         newOption.addClass('selected');
@@ -205,19 +216,67 @@
       }
     });
 
-    $('[role="listbox"]', scope).on('blur', function () {
-      $(this).children().remove();
-    });
-
     $('[role="option"]', scope).on('click', function () {
+      input.data('realValue', $(this).text());
       $('[data-suggest]', scope).val($(this).text())
         .focus();
       $('[role="listbox"]', scope).remove();
     });
 
+    // To only attach events once.
+    if (input.data('eventsAttached')) {
+      return;
+    }
+
+    // Events below this line...
+    input.on('keydown', function (e) {
+
+      if (e.keyCode === 27) {
+
+        if (input.val() !== '' && ($('[role="listbox"]').length === 0 || !$('[role="listbox"]').is(':visible'))) {
+          input.val('');
+          input.data('realValue', '');
+        }
+
+        e.preventDefault();
+        input.focus();
+        $('[role="listbox"]', scope).hide();
+        return;
+      }
+
+      if (e.keyCode === 38) {
+        e.preventDefault();
+        $('[role="listbox"] .selected', scope).removeClass('selected');
+        $('[role="listbox"]', scope).attr('tabindex', '0').focus();
+        $('[role="listbox"]').attr('aria-activedescendant', $('[role="listbox"] [role="option"]:last-child', scope).attr('id'));
+        $('[role="listbox"] [role="option"]:last-child').addClass('selected');
+        return;
+      }
+
+      if (e.keyCode === 40) {
+        e.preventDefault();
+        $('[role="listbox"] .selected', scope).removeClass('selected');
+
+        if (e.altKey) {
+          $('[role="listbox"]', scope).show();
+        }
+        else {
+          $('[role="listbox"]', scope).attr('tabindex', '0').focus();
+          $('[role="listbox"]').attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
+          $('[role="listbox"] [role="option"]:first-child').addClass('selected');
+          input.data('realValue', input.val());
+          input.val($('.selected').text());
+        }
+        return;
+      }
+
+      if (e.keyCode === 9) {
+        $('[role="listbox"]', scope).remove();
+        return;
+      }
+    });
+
+    input.data('eventsAttached', true);
   });
 
 })(jQuery);
-
-
-

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -146,7 +146,7 @@
     var scope = input.parents('.js-suggestions-container');
 
     $('[role="listbox"]', scope).remove();
-    $('[data-suggestions]', scope).html('<div role="listbox"></div>');
+    $('[data-suggestions]', scope).html('<div role="listbox" id="suggestions-list"></div>');  
     $('.js-suggestions-help', scope).empty();
 
     var $listbox = $('[role="listbox"]', scope);

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -144,9 +144,12 @@
   $input.on('autocomplete:suggestionsUpdated', function (e, suggestionList) {
     var input = $(this);
     var scope = input.parents('.js-suggestions-container');
+
+    $('[role="listbox"]', scope).remove();
     $('[data-suggestions]', scope).html('<div role="listbox"></div>');
     $('.js-suggestions-help', scope).empty();
 
+    var $listbox = $('[role="listbox"]', scope);
     var value = input.val();
     var suggestions = [].filter.call(suggestionList.sort(), function (suggestionItem) {
       return !suggestionItem.indexOf(value);
@@ -154,11 +157,11 @@
 
     if (value) {
       $.each(suggestions, function (k, v) {
-        $('[role="listbox"]', scope).append(
+        $listbox.append(
           '<div role="option" tabindex="-1" >' + v + '</div>'
         );
       });
-      $('[role="listbox"]  [role="option"]', scope).each(function () {
+      $listbox.find('[role="option"]', scope).each(function () {
         $(this).attr('id', input.attr('id') + '-' + $(this).index());
       });
       if (suggestions) {
@@ -167,19 +170,21 @@
       }
     }
 
-    $('[role="listbox"]', scope).on('keydown', function (e) {
+    $listbox.on('keydown', function (e) {
+
       if (e.keyCode === 13) {
         e.preventDefault();
         e.stopPropagation();
         input.data('realValue', input.val());
         input.focus();
-        $('[role="listbox"]', scope).remove();
+        $listbox.remove();
+        return;
       }
 
       if (e.keyCode === 27) {
         input.val(input.data('realValue'));
         input.focus();
-        $('[role="listbox"]', scope).hide();
+        $listbox.hide();
         return;
       }
 
@@ -217,10 +222,11 @@
     });
 
     $('[role="option"]', scope).on('click', function () {
+      console.log('clicking');
       input.data('realValue', $(this).text());
       $('[data-suggest]', scope).val($(this).text())
         .focus();
-      $('[role="listbox"]', scope).remove();
+      $listbox.remove();
     });
 
     // To only attach events once.
@@ -231,39 +237,44 @@
     // Events below this line...
     input.on('keydown', function (e) {
 
+      // Listbox is recreated when suggestions are updated,
+      // hence we need to update the reference.
+      $listbox = $('[role="listbox"]', scope);
+
       if (e.keyCode === 27) {
 
-        if (input.val() !== '' && ($('[role="listbox"]', scope).length === 0 || !$('[role="listbox"]', scope).is(':visible'))) {
+        if (input.val() !== '' && ($listbox.length === 0 || !$listbox.is(':visible'))) {
           input.val('');
           input.data('realValue', '');
         }
 
         e.preventDefault();
         input.focus();
-        $('[role="listbox"]', scope).hide();
+        $listbox.hide();
         return;
       }
 
       if (e.keyCode === 38) {
         e.preventDefault();
-        $('[role="listbox"] .selected', scope).removeClass('selected');
-        $('[role="listbox"]', scope).attr('tabindex', '0').focus();
-        $('[role="listbox"]', scope).attr('aria-activedescendant', $('[role="listbox"] [role="option"]:last-child', scope).attr('id'));
-        $('[role="listbox"] [role="option"]:last-child', scope).addClass('selected');
+        $listbox.find('.selected', scope).removeClass('selected');
+        $listbox.attr('tabindex', '0').focus();
+        $listbox.attr('aria-activedescendant', $listbox.find('[role="option"]:last-child', scope).attr('id'));
+        $listbox.find('[role="option"]:last-child', scope).addClass('selected');
         return;
       }
 
       if (e.keyCode === 40) {
         e.preventDefault();
-        $('[role="listbox"] .selected', scope).removeClass('selected');
+        $listbox.find('.selected', scope).removeClass('selected');
 
         if (e.altKey) {
-          $('[role="listbox"]', scope).show();
+          $listbox.show();
         }
         else {
-          $('[role="listbox"]', scope).attr('tabindex', '0').focus();
-          $('[role="listbox"]', scope).attr('aria-activedescendant', $('[role="listbox"] [role="option"]:first-child', scope).attr('id'));
-          $('[role="listbox"] [role="option"]:first-child', scope).addClass('selected');
+          $listbox.attr('tabindex', '0').focus();
+          $listbox.find('.selected', scope).removeClass('selected');
+          $listbox.attr('aria-activedescendant', $listbox.find('[role="option"]:first-child', scope).attr('id'));
+          $listbox.find('[role="option"]:first-child', scope).addClass('selected');
           input.data('realValue', input.val());
           input.val($('.selected', scope).text());
         }
@@ -271,7 +282,7 @@
       }
 
       if (e.keyCode === 9) {
-        $('[role="listbox"]', scope).remove();
+        $listbox.remove();
         return;
       }
     });

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -229,6 +229,11 @@
       $listbox.remove();
     });
 
+    $(document).on('mouseenter mouseleave', '[role=option]', function () {
+      $(this).siblings().removeClass('selected');
+      $(this).addClass('selected');
+    });
+
     // To only attach events once.
     if (input.data('eventsAttached')) {
       return;

--- a/docroot/modules/custom/mass_search/mass_search.libraries.yml
+++ b/docroot/modules/custom/mass_search/mass_search.libraries.yml
@@ -1,3 +1,5 @@
 google-cse:
   js:
     js/mass_search.google_cse.js: {}
+  dependencies:
+    - core/once

--- a/docroot/themes/custom/mass_theme/templates/includes/molecules-banner-search.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/molecules-banner-search.html.twig
@@ -8,7 +8,7 @@
 {% block content %}
 <form class="ma__search-banner__form" action="https://search.mass.gov/">
   <div class="ma__search-banner__input js-suggestions-container" role="search">
-    <div class="visually-hidden js-suggestions-help" role="status"  aria-live="polite"></div>
+    <div class="visually-hidden js-suggestions-help" role="status"  aria-live="assertive"></div>
     <label for="banner-search" class="ma__search-banner__label">Search terms</label>
     <input
         id="banner-search"

--- a/docroot/themes/custom/mass_theme/templates/includes/molecules-banner-search.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/molecules-banner-search.html.twig
@@ -15,6 +15,9 @@
         name="q"
         class="ma__header-search__input"
         autocomplete="off"
+        aria-autocomplete="both"
+        role="combobox"
+        aria-own="suggestions-list"
         placeholder="Search Mass.gov"
         data-suggest=""
         type="text" />

--- a/docroot/themes/custom/mass_theme/templates/includes/molecules-header-search.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/molecules-header-search.html.twig
@@ -10,13 +10,16 @@
 <section class="ma__header-search">
   <form action="https://search.mass.gov/" class="ma__form js-header-search-form">
     <div role="search" class="ma__suggestions-container js-suggestions-container ma__search-banner__form {{ searchFormId }}">
-      <div class="visually-hidden js-suggestions-help" role="status"  aria-live="polite"></div>
+      <div class="visually-hidden js-suggestions-help" role="status"  aria-live="assertive"></div>
       <label for="header-search" class="ma__header-search__label">Search terms</label>
       <input
           id="header-search"
           name="q"
           class="ma__header-search__input"
           autocomplete="off"
+          aria-autocomplete="both"
+          role="combobox"
+          aria-own="suggestions-list"
           placeholder="Search Mass.gov"
           data-suggest=""
           type="text" />


### PR DESCRIPTION
**Description:**
Autocomplete for search working as described here.
https://rawgit.com/w3c/aria-practices/master/aria-practices-DeletedSectionsArchive.html#autocomplete

Except for this part, because Google CSE needs a letter to show suggestions (one option would be to have a default list of suggestions, although the ticket does not specify what to do in this case).
> With focus in an empty text box, press Down Arrow, Up Arrow, Alt + Down Arrow, or Alt + Up Arrow to display the entire list of choices. Focus remains in the text box and no choice is highlighted.

**Jira:** (Skip unless you are MA staff)
DP-3188


**To Test (applicable instructions from [this link](https://rawgit.com/w3c/aria-practices/master/aria-practices-DeletedSectionsArchive.html#autocomplete)) :**
- With the drop-down list of choices displayed, move the mouse pointer over an item in the list to highlight it. The text box value is not modified when the mouse is used to highlight a choice. Clicking on the highlighted choice will close the drop-down and update the text box with the selected choice.
- With focus in an empty text box, type any letter. If any of the available choices begin with the letter typed, those choices are displayed in a drop down. If the letter typed does not match any of the available choices the drop-down list is not displayed.
- With focus in text box with an existing value type additional letters. As the user types letters the list of choices is filtered so that only those that begin with the typed letters are displayed.
  - Until the user presses the arrow keys to highlight a particular choice, only the typed letters are displayed in the text box.
  - In an editable auto-complete, if no choices match the letter(s) typed, the drop down list closes.
  - In a non-editable auto-complete, any letters that do not result in a match from the list are ignored. The drop down list of choices remains static until the user presses:
    - Escape to clear the text field
    - Backspace to remove some of the letters previously typed
    - An additional letter that results in a valid list of choices.
   - Navigation through the list of choices and display of the highlighted choice in the text box works as described above.
- With focus in a text box, press Escape
  - If there is no text in the text box, pressing Escape closes the drop-down if it is displayed.
  - For an editable autocomplete that has text in the text box that was both typed by the user and auto-completed by highlighting a choice using the keyboard, the auto-completed portion of the text is cleared and the user typed characters remain in the text box. The drop-down list is closed. To completely clear the text box contents the user must use the backspace key to remove the typed characters. This is how the Google search box in the Firefox UI works. Recommend that pressing the Escape key again completely clears the text box rather than relying on only the backspace key.
  - For a non-editable auto-complete that has text in the text box that was both typed by the user and auto-completed by highlighting a choice using the keyboard, pressing Escape closes the drop-down list and leaves the current choice in the text box.
  - For an editable or non-editable auto complete with text in the text box that was typed by the user and the mouse is highlighting a choice in the drop down (keyboard navigation was NOT used), pressing Escape closes the drop down and leaves the typed text displayed in the text box. Need to consider if pressing Escape again should clear the typed text. The user must press the Down arrow or Alt + Down arrow or click the associated icon to invoke the drop-down list of choices again. 


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
