### PR TITLE
Added check for org page view mode in hook_node_view - DP-23200

### DIFF
--- a/changelogs/DP-23200.yml
+++ b/changelogs/DP-23200.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed issue causing How To pages to fail Behat testing.
+    issue: DP-23200

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -358,7 +358,7 @@ function _mass_fields_prepare_link_field_build(array &$field_build) {
 function mass_fields_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
   $entityTypeManager = \Drupal::entityTypeManager();
 
-  if ($entity->getEntityTypeId() == 'node' && $entity->bundle() == 'org_page') {
+  if ($entity->getEntityTypeId() == 'node' && $entity->bundle() == 'org_page' && $view_mode == 'full') {
     $org_page_sections_data = _mass_fields_get_org_page_sections_data($entity);
   }
 


### PR DESCRIPTION
**Description:**
This resolves a 500 error we were seeing on the "How-to Pages should not have any vulnerabilities" scenario in Behat.

**Jira:** (Skip unless you are MA staff)
DP-23200


**To Test:**
- [ ] Check that Behat tests pass


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
