### PR TITLE
Fix nightly security check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,8 +457,8 @@ jobs:
 
   pending_security:
     working_directory: /tmp/code
-    docker:
-      - image: cimg/php:7.4-node
+    executor:
+      name: base
     steps:
       - attach_workspace: {at: /tmp}
       - ddev_install_run
@@ -1102,7 +1102,7 @@ workflows:
               only:
                 - develop
 
-  # Nightly pm:security, runs at 2:00AM EST.
+  # Nightly pm:security and pm:security-php.
   nightly_pending_security:
     jobs:
       - build
@@ -1110,8 +1110,9 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "05 07 * * *"
+          cron: "05 13 * * *"
           filters:
               branches:
                   only:
                       - develop
+                      - feature/DP-23184_nightly-security-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,9 +1109,8 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "50 18 * * *"
+          cron: "05 07 * * *"
           filters:
               branches:
                   only:
                       - develop
-                      - feature/DP-23184_nightly-security-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1114,3 +1114,4 @@ workflows:
               branches:
                   only:
                       - develop
+                      - feature/DP-23184_nightly-security-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,7 +1109,7 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "05 07 * * *"
+          cron: "40 14 * * *"
           filters:
               branches:
                   only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1110,9 +1110,8 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "05 13 * * *"
+          cron: "05 07 * * *"
           filters:
               branches:
                   only:
                       - develop
-                      - feature/DP-23184_nightly-security-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1034,7 +1034,6 @@ workflows:
             branches:
               only:
                 - develop
-                - rollback-mysql-upgrade
 
   # Usually triggered by drush ma:backstop.
   backstop_ad_hoc:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1109,7 +1109,7 @@ workflows:
           requires: [build]
     triggers:
       - schedule:
-          cron: "40 14 * * *"
+          cron: "50 18 * * *"
           filters:
               branches:
                   only:

--- a/changelogs/DP-23184.yml
+++ b/changelogs/DP-23184.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix nightly security check
+    issue: DP-23184


### PR DESCRIPTION

**Jira:** (Skip unless you are MA staff)
DP-23184


**To Test:**
- [ ] Make sure [this pipeline](https://app.circleci.com/pipelines/github/massgov/openmass/13129/workflows/e3f96aec-cd27-4acb-a3a2-21524ad1718e/jobs/53837) completed (i.e. you get a sensible result when calling drush pm:security). It doesnt matter if the pipeline passes or fails. This ticket just lets the job complete again - it broke with change to ddev.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
