### PR TITLE
Mayflower/dp 23328 mayflower version 11.17.0

### DIFF
--- a/changelogs/DP-23328.yml
+++ b/changelogs/DP-23328.yml
@@ -1,0 +1,48 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: |-
+          Updated Mayflower version to 11.17.0.
+            - DP-22210: Fixing focus issues when navigating with keyboard. (MF #1490)
+            - DP-22215: Replace googlemaps with leaftlet map, remove filter logic. (MF #1430)
+            - DP-22679: Adjust focus order between the menu button and the menu container when the menu is open. (MF #1479)
+            - DP-22679: Add a feature to close Google Translate option container with ESC key. (MF #1479)
+            - DP-22680: Add focus trap to the global menu dropdown. (MF #1479)
+            - DP-23268: Fix main nav overlay positioning. (MF #1539)
+    issue: DP-23328

--- a/composer.json
+++ b/composer.json
@@ -235,7 +235,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "11.17.0",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "152266cd2d23d1650edb42cc9370e408",
+    "content-hash": "9881f8da1cd033317bdfe49bf9185eb7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11457,16 +11457,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "11.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "1182b79e1a8f52e65e1425c67f41c57c502ed680"
+                "reference": "d2584e15aa793359f4f2065d6682c2721a03fec1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/1182b79e1a8f52e65e1425c67f41c57c502ed680",
-                "reference": "1182b79e1a8f52e65e1425c67f41c57c502ed680",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d2584e15aa793359f4f2065d6682c2721a03fec1",
+                "reference": "d2584e15aa793359f4f2065d6682c2721a03fec1",
                 "shasum": ""
             },
             "require": {
@@ -11486,9 +11486,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.17.0"
             },
-            "time": "2021-11-01T14:00:27+00:00"
+            "time": "2021-11-01T18:44:39+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -20521,8 +20521,7 @@
         "drupal/security_review": 20,
         "drupal/views_aggregator": 10,
         "drupal/views_taxonomy_term_name_into_id": 15,
-        "furf/jquery-ui-touch-punch": 20,
-        "massgov/mayflower-artifacts": 20
+        "furf/jquery-ui-touch-punch": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Changed:
  - description: |-
          Updated Mayflower version to 11.17.0.
            - DP-22210: Fixing focus issues when navigating with keyboard. (MF #1490)
            - DP-22215: Replace googlemaps with leaftlet map, remove filter logic. (MF #1430)
            - DP-22679: Adjust focus order between the menu button and the menu container when the menu is open. (MF #1479)
            - DP-22679: Add a feature to close Google Translate option container with ESC key. (MF #1479)
            - DP-22680: Add focus trap to the global menu dropdown. (MF #1479)
            - DP-23268: Fix main nav overlay positioning. (MF #1539)
    issue: DP-23328