### PR TITLE
Use develop from Mayflower artifacts.

### DIFF
--- a/changelogs/DP-23386.yml
+++ b/changelogs/DP-23386.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Use develop from Mayflower artifacts.
+    issue: DP-23386

--- a/composer.json
+++ b/composer.json
@@ -235,7 +235,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "11.18.0",
+        "massgov/mayflower-artifacts": "dev-develop",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83000a42e037f6e94c1f6d701e91b45b",
+    "content-hash": "152266cd2d23d1650edb42cc9370e408",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11457,16 +11457,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "11.18.0",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "1c447e7ef097d747fdbd0f3af9fa9e7372b4cff3"
+                "reference": "46f014bb33dddaa5163564e2c4ee8f15ba9c4066"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/1c447e7ef097d747fdbd0f3af9fa9e7372b4cff3",
-                "reference": "1c447e7ef097d747fdbd0f3af9fa9e7372b4cff3",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/46f014bb33dddaa5163564e2c4ee8f15ba9c4066",
+                "reference": "46f014bb33dddaa5163564e2c4ee8f15ba9c4066",
                 "shasum": ""
             },
             "require": {
@@ -11486,9 +11486,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.18.0"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2021-11-08T21:26:23+00:00"
+            "time": "2021-11-09T16:56:30+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
**Description:**
We merged code yesterday without pointing to its required Mayflower branch so OpenMass isn't releasable until this is merged.  This PR makes us point to `massgov/mayflower-artifacts:dev-develop`

This is needed before we can cut a new OpenMass release branch from current develop. We were not able to release yesterday.


**Jira:** (Skip unless you are MA staff)
DP-23386

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
