### PR TITLE
Mayflower/dp 23427 mayflower version 11.19.1

### DIFF
--- a/changelogs/DP-23427.yml
+++ b/changelogs/DP-23427.yml
@@ -1,0 +1,46 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description:  |-
+        Updated Mayflower version to 11.19.1.
+          - DP-22939: Implmenting responsive images. (MF#1545)
+          - DP-23082: Add half image option for Key messages. (MF#1538)
+          - DP-23317: Adjusted vertical spacing, prevent alert header to wrap on smaller screensizes. (MF#1547)
+          - DP-23427: Add a style variant to allow wrapping on mobile. (MF#1557)
+    issue: DP-23427

--- a/composer.json
+++ b/composer.json
@@ -235,7 +235,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "11.19.1",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "152266cd2d23d1650edb42cc9370e408",
+    "content-hash": "891edb167410686e592b9ad657f362bd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -11457,16 +11457,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "11.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "46f014bb33dddaa5163564e2c4ee8f15ba9c4066"
+                "reference": "2929c9cab136c2031646b865df0b4f112583d08b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/46f014bb33dddaa5163564e2c4ee8f15ba9c4066",
-                "reference": "46f014bb33dddaa5163564e2c4ee8f15ba9c4066",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/2929c9cab136c2031646b865df0b4f112583d08b",
+                "reference": "2929c9cab136c2031646b865df0b4f112583d08b",
                 "shasum": ""
             },
             "require": {
@@ -11486,9 +11486,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/11.19.1"
             },
-            "time": "2021-11-09T16:56:30+00:00"
+            "time": "2021-11-16T16:01:24+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -20521,8 +20521,7 @@
         "drupal/security_review": 20,
         "drupal/views_aggregator": 10,
         "drupal/views_taxonomy_term_name_into_id": 15,
-        "furf/jquery-ui-touch-punch": 20,
-        "massgov/mayflower-artifacts": 20
+        "furf/jquery-ui-touch-punch": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
Changed:
  - description:  |-
        Updated Mayflower version to 11.19.1.
          - DP-22939: Implmenting responsive images. (MF#1545)
          - DP-23082: Add half image option for Key messages. (MF#1538)
          - DP-23317: Adjusted vertical spacing, prevent alert header to wrap on smaller screensizes. (MF#1547)
          - DP-23427: Add a style variant to allow wrapping on mobile. (MF#1557)
    issue: DP-23427