### PR TITLE
Dp 22990/simplify cd deploy in new workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,25 @@ jobs:
           root: ..
           paths: [code]
 
+  build_with_latest_mayflower:
+    working_directory: ~/project/code
+    docker:
+      - image: cimg/php:7.4-node
+    steps:
+      - checkout
+      - *restore_composer_cache
+      - run: {name: 'Composer install', command: 'composer install --no-interaction --optimize-autoloader'}
+      - run:
+          name: Update Mayflower to latest develop
+          command: composer require massgov/mayflower-artifacts:dev-develop --update-with-dependencies
+      - *save_composer_cache
+      - run:
+          name: Install node modules
+          command: yarn install
+      - persist_to_workspace:
+          root: ..
+          paths: [code]
+
   push_acquia:
     working_directory: ~/project/code
     docker:
@@ -1038,13 +1057,13 @@ workflows:
           auto-approve: true
 
 
-# Nightly deploy develop branch to the CD environment, runs at 11:00PM EST.
+# Nightly deploy develop branch (with the latest Mayflower develop branch) to the CD environment, runs at 11:00PM EST.
   deploy_cd:
     jobs:
-      - build
+      - build_with_latest_mayflower
       - deploy:
           name: deploy-cd-refresh-db
-          requires: [build]
+          requires: [build_with_latest_mayflower]
           target: cd
           refresh-db: "--refresh-db"
       - crawl:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -577,72 +577,6 @@ workflows:
             branches:
               <<: *branch_ignore
 
-  # Automation for deploy to CD environment and create a branch with Mayflower and Mass develop branch by using mayflower_develop_branch.
-  # This only happens on Thursday night 11 p.m. ETS to allow us to review Mayflower in Drupal on Mondays.
-  mayflower_dev_branch:
-    jobs:
-      - build
-      - mayflower_develop_branch:
-          requires: [build]
-    triggers:
-      - schedule:
-          cron: "00 04 * * 5"
-          filters:
-            branches:
-              only:
-                - develop
-
-  # Automation for deploy to CD environment and create a branch with Mayflower and Mass develop branch by using mayflower_dev branch only.
-  deploy_mayflower_cd:
-    jobs:
-      - build:
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - push_acquia:
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - test:
-          name: test-phpunit
-          command: phpunit
-          requires: [build]
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - test:
-          name: test-behat
-          command: behat
-          requires: [build]
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - deploy:
-          name: deploy-cd-refresh-db
-          requires:
-            - build
-            - push_acquia
-          refresh-db: "--refresh-db"
-          target: cd
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - crawl:
-          name: crawl-cd-900
-          requires: [deploy-cd-refresh-db]
-          samples: 900
-          target: cd
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
-      - backstop:
-          name: backstop-cd
-          requires: [deploy-cd-refresh-db]
-          target: cd
-          reference: prod
-          filters:
-            branches:
-              only: /^mayflower-dev-.*/
 
   # This is to automate the creation of the release branch.
   # The cron time needs to be updated every Fall/Spring for daylight saving time.
@@ -1104,7 +1038,7 @@ workflows:
           auto-approve: true
 
 
-# Daily deploy to the CD environment, runs at 11:00PM EST. Except for Thursday night the deploy_mayflower_cd uses the CD environment instead.
+# Nightly deploy develop branch to the CD environment, runs at 11:00PM EST.
   deploy_cd:
     jobs:
       - build
@@ -1124,7 +1058,7 @@ workflows:
           reference: prod
     triggers:
       - schedule:
-          cron: "00 04 * * 0,1,2,3,4,6"
+          cron: "00 04 * * *"
           filters:
             branches:
               only:

--- a/changelogs/DP-22990.yml
+++ b/changelogs/DP-22990.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update circleCI to remove unused mayflower testing jobs and allow nightly deployment to CD with latest mayflower and openmass develop branches.
+    issue: DP-22990

--- a/scripts/ma-mayflower-develop.php
+++ b/scripts/ma-mayflower-develop.php
@@ -1,7 +1,9 @@
 <?php
 
 /**
- * Use the Mayflower develop branch as way to test beforehand the integration with Mass repository.
+ * Archived:
+ * This script is no longer in use as openmass develop branch always point to the latest Mayflower in our new workflow.
+ * This was used for cutting a branch in openmass to test the latest of Mayflower develop branch beforehand the integration with Mass repository.
  */
 
 


### PR DESCRIPTION
We no longer need to rely on Thursday night deploy_mayflower_cd to pull in the latest Mayflower develop branch into openmass, since with the new process we are doing that before every openmass PR merge. I cleaned up all the unnessary tasks in circle, archived the php function used in the old process.  I added a job to build with the latest mayflower develop branch for the nightly CD deployment, to catch any Mayflower changes in develop that doesn’t have a corresponding openmass PR but potentially could impact openmass. 

**With this change, Circle will deploy openmass develop branch (with the latest Mayflower develop branch) to the CD environment, every night at 11:00PM EST.**

https://massgov.atlassian.net/jira/software/c/projects/DP/boards/69?modal=detail&selectedIssue=DP-22990