### PR TITLE
DP-23302: Prevent unpublish of a page with published children

### DIFF
--- a/changelogs/DP-23302.yml
+++ b/changelogs/DP-23302.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added validation to nodes to only allow nodes without children to be unpublished or trashed.
+    issue: DP-23302

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -44,6 +44,9 @@ function mass_validation_entity_type_alter(array &$entity_types) {
       $type->addConstraint('PreventEditGovLink');
       $type->addConstraint('PreventEmptyStateOrg');
       $type->addConstraint('BinderDownloadsOrPages');
+      if ($type_name == 'node') {
+        $type->addConstraint('UnpublishParent');
+      }
     }
   }
 }

--- a/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarning.php
+++ b/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarning.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\mass_validation\Information;
+
+use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\entity_hierarchy\Information\ChildEntityWarning;
+use PNX\NestedSet\Node;
+
+/**
+ * Defines a value object for a child entity warning.
+ *
+ * @see entity_hierarchy_form_alter()
+ */
+class MassChildEntityWarning extends ChildEntityWarning {
+
+  /**
+   * Gets render array for child entity list.
+   *
+   * @return array
+   *   Render array.
+   */
+  public function getList() {
+    $child_labels = [];
+    $build = ['#theme' => 'item_list'];
+    foreach ($this->relatedEntities as $node) {
+      if (!$this->relatedEntities->contains($node) || $node == $this->parent) {
+        continue;
+      }
+      $child_labels[] = $this->relatedEntities->offsetGet($node)->toLink()->toString()->__toString();
+    }
+    $build['$build#items'] = array_unique($child_labels);
+    $build['#items'] = array_map("unserialize", array_unique(array_map("serialize", $child_labels)));
+    $this->cache->applyTo($build);
+    return $build;
+  }
+
+}

--- a/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
+++ b/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\mass_validation\Information;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\entity_hierarchy\Information\ChildEntityWarningBuilder;
+
+/**
+ * Defines a class for building a list of child entity warnings.
+ */
+class MassChildEntityWarningBuilder extends ChildEntityWarningBuilder {
+
+  /**
+   * Gets warning about child entities before deleting a parent.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $parent
+   *   Parent to be deleted.
+   *
+   * @return \Drupal\mass_validation\Information\MassChildEntityWarning[]
+   *   Array of warning value objects.
+   */
+  public function buildChildEntityWarnings(ContentEntityInterface $parent) {
+    $return = [];
+    if ($fields = $this->parentCandidate->getCandidateFields($parent)) {
+      $cache = new CacheableMetadata();
+      foreach ($fields as $field_name) {
+        /** @var \PNX\NestedSet\NestedSetInterface $storage */
+        $storage = $this->nestedSetStorageFactory->get($field_name, $parent->getEntityTypeId());
+        $nodeKey = $this->nodeKeyFactory->fromEntity($parent);
+        $children = $storage->findChildren($nodeKey);
+        if ($parent_node = $storage->findParent($nodeKey)) {
+          $children[] = $parent_node;
+        }
+        $entities = $this->treeNodeMapper->loadAndAccessCheckEntitysForTreeNodes($parent->getEntityTypeId(), $children, $cache);
+        $return[] = new MassChildEntityWarning($entities, $cache, $parent_node);
+      }
+    }
+    return $return;
+  }
+
+}

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraint.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraint.php
@@ -21,6 +21,6 @@ class UnpublishParentConstraint extends Constraint {
    *
    * @var string
    */
-  public $message = 'This content cannot be unpublished because it is a parent.';
+  public $message = 'This content cannot be unpublished or trashed because it is a parent of ';
 
 }

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraint.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraint.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\mass_validation\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Entity Reference valid reference constraint.
+ *
+ * Verifies that referenced entities are valid.
+ *
+ * @Constraint(
+ *   id = "UnpublishParent",
+ *   label = @Translation("Unpublish parent without children", context = "Validation")
+ * )
+ */
+class UnpublishParentConstraint extends Constraint {
+
+  /**
+   * The default violation message.
+   *
+   * @var string
+   */
+  public $message = 'This content cannot be unpublished because it is a parent.';
+
+}

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\mass_validation\Plugin\Validation\Constraint;
+
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\entity_hierarchy\Information\ChildEntityWarningBuilder;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Checks if an entity has a parent before unpublishing.
+ */
+class UnpublishParentConstraintValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    if (!isset($entity)) {
+      return;
+    }
+
+    $moderation_state = $entity->get('moderation_state')->value;
+    $unpublished_states = ['unpublished', 'trash'];
+    if (in_array($moderation_state, $unpublished_states)) {
+      if ($children = \Drupal::service('class_resolver')
+        ->getInstanceFromDefinition(ChildEntityWarningBuilder::class)
+        ->buildChildEntityWarnings($entity)) {
+        foreach ($children as $child) {
+          $items = $child->getList()['#items'];
+          if (!empty($items)) {
+            $items_string = implode(', ', $items);
+            $message = new PluralTranslatableMarkup(
+              count($items),
+              $constraint->message . ' 1 child: ' . $items_string,
+              $constraint->message . ' @count children: ' . $items_string);
+            $this->context->addViolation($message);
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
@@ -3,7 +3,7 @@
 namespace Drupal\mass_validation\Plugin\Validation\Constraint;
 
 use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
-use Drupal\entity_hierarchy\Information\ChildEntityWarningBuilder;
+use Drupal\mass_validation\Information\MassChildEntityWarningBuilder;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -24,7 +24,7 @@ class UnpublishParentConstraintValidator extends ConstraintValidator {
     $unpublished_states = ['unpublished', 'trash'];
     if (in_array($moderation_state, $unpublished_states)) {
       if ($children = \Drupal::service('class_resolver')
-        ->getInstanceFromDefinition(ChildEntityWarningBuilder::class)
+        ->getInstanceFromDefinition(MassChildEntityWarningBuilder::class)
         ->buildChildEntityWarnings($entity)) {
         foreach ($children as $child) {
           $items = $child->getList()['#items'];
@@ -32,8 +32,8 @@ class UnpublishParentConstraintValidator extends ConstraintValidator {
             $items_string = implode(', ', $items);
             $message = new PluralTranslatableMarkup(
               count($items),
-              $constraint->message . ' 1 child: ' . $items_string,
-              $constraint->message . ' @count children: ' . $items_string);
+              $constraint->message . '1 child: ' . $items_string,
+              $constraint->message . '@count children: ' . $items_string);
             $this->context->addViolation($message);
           }
         }

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\Tests\mass_validation\ExistingSite;
+
+use Drupal\mass_content_moderation\MassModeration;
+use Drupal\user\Entity\User;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+use weitzman\LoginTrait\LoginTrait;
+
+/**
+ * Class UnpublishParentConstraintTest.
+ */
+class UnpublishParentConstraintTest extends ExistingSiteBase {
+
+  use LoginTrait;
+
+  private $user;
+
+  /**
+   * Create the user.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $user = User::create(['name' => $this->randomMachineName()]);
+    $user->addRole('editor');
+    $user->activate();
+    $user->save();
+    $this->user = $user;
+  }
+
+  /**
+   * Assert that the validation works properly.
+   */
+  public function testUnpublishParentValidation() {
+    $node_parent_org = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Parent Organization',
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::PUBLISHED,
+    ]);
+    $node_child_org_1 = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child Organization 1',
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::PUBLISHED,
+      'field_primary_parent' => $node_parent_org->id(),
+    ]);
+
+    $this->drupalLogin($this->user);
+    $this->visit($node_parent_org->toUrl()->toString() . '/edit');
+    $this->assertEquals($this->getSession()->getStatusCode(), 200);
+    $page = $this->getSession()->getPage();
+    $page->selectFieldOption('edit-moderation-state-0-state', 'Unpublished');
+    $page->pressButton('edit-submit');
+    $page_contents = $page->getContent();
+    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 1 child:';
+    $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
+    $node_child_org_2 = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child Organization 2',
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::PUBLISHED,
+      'field_primary_parent' => $node_parent_org->id(),
+    ]);
+    $this->visit($node_parent_org->toUrl()->toString() . '/edit');
+    $page = $this->getSession()->getPage();
+    $page->selectFieldOption('edit-moderation-state-0-state', 'Trash');
+    $page->pressButton('edit-submit');
+    $page_contents = $page->getContent();
+    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 2 children:';
+    $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
+  }
+
+}


### PR DESCRIPTION
**Description:**
Added validation to nodes to check for parents with similar logic as deleting a parent node. It checks for unpublished or trash moderation state and checks for children. If children are found, it adds a violation.


**Jira:** (Skip unless you are MA staff)
DP-23302


**To Test:**
- Login and go to /admin/content?type_1=org_page.
- Edit one or more organizations to assign one other org as the “Parent page” value.
- Edit the parent organization.
- Change the status to “Unpublished” and save.
- Verify you get a form error that says you can’t unpublish the node because it has children with a list of the child titles.
- Change the status to “Trash” and save.
- Verify you get the same message.
- Change the status to “Published” and save.
- Verify the node saves without error.
- Edit an organization without children.
- Change the status to “Unpublished” and save.
- Verify the node saves without error.
- Change the status to “Trash” and save.
- Verify the node saves without error.


![Uploading unpublish_parent_message_links.png…]()


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
