### PR TITLE
DP-23487 Stop accumulating Tugboat binaries in local dev.

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -40,8 +40,8 @@ web_environment:
 hooks:
   post-start:
     # Tugboat CLI
-    - exec: wget https://dashboard.tugboat.qa/cli/linux/tugboat.tar.gz
-    - exec: tar -zxf tugboat.tar.gz -C /usr/local/bin/
+    - exec: curl https://dashboard.tugboat.qa/cli/linux/tugboat.tar.gz > tugboat.tar.gz
+    - exec: tar -zxf tugboat.tar.gz -C /usr/local/bin/ && rm -f tugboat.tar.gz
     # CicleCI CLI
     - exec: curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
     # gh install is too slow to be enabled by default as we dont need it. Uncomment or copy to personal config if needed.

--- a/changelogs/DP-23487.yml
+++ b/changelogs/DP-23487.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Stop accumulating Tugboat binaries in local dev.
+    issue: DP-23487

--- a/changelogs/DP-23487.yml
+++ b/changelogs/DP-23487.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: Stop accumulating Tugboat binaries in local dev.
     issue: DP-23487


### PR DESCRIPTION
- Comments out Tugboat lines because its too slow to download
- Fixes the accumulation of Tugboat files

**Jira:** (Skip unless you are MA staff)
DP-23487


**To Test:**
- [ ] Copy and uncomment 2 tugboat lines from botton of config.yaml to a new config.personal.yml
- [ ] Remove any tugboat.tar.gz files from project root and then run `ddev restart`  and see that no tugboat.tar.gz is in root of the project.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
