### PR TITLE
DP-23538: Fix of the Scheduled Transition tab style issue

### DIFF
--- a/changelogs/DP-23538.yml
+++ b/changelogs/DP-23538.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed the missing Schedule Transitions tab on custom and views local task pages.
+    issue: DP-23538

--- a/docroot/modules/custom/mass_content/mass_content.services.yml
+++ b/docroot/modules/custom/mass_content/mass_content.services.yml
@@ -8,3 +8,8 @@ services:
   mass_content.log_in_links_builder:
     class: Drupal\mass_content\LogInLinksBuilder
     arguments: ['@descendant_manager']
+  mass_content.route_subscriber:
+    class: Drupal\mass_content\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+    weight: 200

--- a/docroot/modules/custom/mass_content/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/mass_content/src/Routing/RouteSubscriber.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\mass_content\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('view.change_parents.page_1')) {
+      // Entity access check expects the parameter to be upconverted.
+      $options = $route->getOptions();
+      $options['parameters']['node']['type'] = 'entity:node';
+      $route->setOptions($options);
+    }
+  }
+
+}

--- a/docroot/modules/custom/mass_content_api/mass_content_api.services.yml
+++ b/docroot/modules/custom/mass_content_api/mass_content_api.services.yml
@@ -9,3 +9,9 @@ services:
   descendant_manager:
     class: Drupal\mass_content_api\DescendantManager
     arguments: ['@descendant.storage', '@descendant.extractor']
+
+  mass_content_api.route_subscriber:
+    class: Drupal\mass_content_api\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }
+    weight: 200

--- a/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/LinkingPageController.php
@@ -86,7 +86,7 @@ class LinkingPageController extends ControllerBase {
       ],
       '#empty' => $this->t('No pages link here.'),
     ];
-    $nid = $this->requestStack->getCurrentRequest()->attributes->get('node');
+    $nid = $this->requestStack->getCurrentRequest()->attributes->get('node')->id();
     $children = $this->descendantManager->getImpact($nid, 'node');
 
     $used_links = [];

--- a/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
+++ b/docroot/modules/custom/mass_content_api/src/Controller/MediaLinkingPageController.php
@@ -86,7 +86,7 @@ class MediaLinkingPageController extends ControllerBase {
       ],
       '#empty' => $this->t('No pages link here.'),
     ];
-    $media_id = $this->requestStack->getCurrentRequest()->attributes->get('media');
+    $media_id = $this->requestStack->getCurrentRequest()->attributes->get('media')->id();
     $children = $this->descendantManager->getImpact($media_id, 'media');
     $used_links = [];
     if (!empty($children)) {

--- a/docroot/modules/custom/mass_content_api/src/Routing/RouteSubscriber.php
+++ b/docroot/modules/custom/mass_content_api/src/Routing/RouteSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\mass_content_api\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('mass_content_api.descendant_controller_linking_page')) {
+      // Entity access check expects the parameter to be upconverted.
+      $options = $route->getOptions();
+      $options['parameters']['node']['type'] = 'entity:node';
+      $route->setOptions($options);
+    }
+    if ($route = $collection->get('mass_content_api.descendant_controller_media_linking_page')) {
+      // Entity access check expects the parameter to be upconverted.
+      $options = $route->getOptions();
+      $options['parameters']['media']['type'] = 'entity:media';
+      $route->setOptions($options);
+    }
+  }
+
+}


### PR DESCRIPTION
**Description:**
Fixed the missing Schedule Transitions tab on custom and views local task pages.


**Jira:** (Skip unless you are MA staff)
DP-23538


**To Test:**
- Login to the site.
- Visit a node.
- Click through the local task tabs.
- Verify the "Scheduled Transitions" tab text is visible for each tab.
- Visit a media item.
- Click through the local task tabs.
- Verify the "Scheduled Transitions" tab text is visible for each tab.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
