### PR TITLE
DP-23539: Move the Hierarchy tab to be to the left of the Move Child tab

### DIFF
--- a/changelogs/DP-23539.yml
+++ b/changelogs/DP-23539.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Replaced a custom entity_hierarchy patch with a version that changes the weight of the Hierarchy tab.
+    issue: DP-23539

--- a/composer.json
+++ b/composer.json
@@ -326,7 +326,7 @@
             "drupal/entity_hierarchy": {
                 "Hidden Weight field causes extra space in the form": "patches/entity_hierarchy-weight-widget-space-3245879-2.patch",
                 "Fatal error on node/{nid}/media #3034602": "https://www.drupal.org/files/issues/2021-11-25/issue-3034602_fatal_error_on_getCandidateFields.patch",
-                "Async support & save only changed, based on https://www.drupal.org/files/issues/2021-05-06/3178313-tree-editor-3.patch) but only save parent changes when saving on the children tab": "patches/DP-23411_node-hierarchy-async-support--save-only-changed.patch",
+                "Async support & save only changed, based on https://www.drupal.org/files/issues/2021-05-06/3178313-tree-editor-3.patch) but only save parent changes when saving on the children tab": "patches/DP-23411_node-hierarchy-async-support--save-only-changed-v2.patch",
                 "Enable entity_hierarchy_breadcrumb module to work on node edit routes": "patches/entity_hierarchy_breadcrumb_for_admin_routes.patch"
             },
             "drupal/geocoder": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd3627b7b891ca1aef2b909505b59fc9",
+    "content-hash": "fa7cdea816dbb8371a3b854a5c3f6cb0",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/DP-23411_node-hierarchy-async-support--save-only-changed-v2.patch
+++ b/patches/DP-23411_node-hierarchy-async-support--save-only-changed-v2.patch
@@ -248,18 +248,21 @@ index fc94005..87419e8 100644
  
    /**
 diff --git a/src/Plugin/Derivative/DynamicLocalTasks.php b/src/Plugin/Derivative/DynamicLocalTasks.php
-index bc8bd8a..e065096 100644
+index bc8bd8a..95df7b7 100644
 --- a/src/Plugin/Derivative/DynamicLocalTasks.php
 +++ b/src/Plugin/Derivative/DynamicLocalTasks.php
-@@ -80,7 +80,7 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
+@@ -80,9 +80,9 @@ class DynamicLocalTasks extends DeriverBase implements ContainerDeriverInterface
        }
        $this->derivatives["$entity_type_id.entity_hierarchy_reorder"] = [
          'route_name' => "entity.$entity_type_id.entity_hierarchy_reorder",
 -        'title' => $this->t('Children'),
 +        'title' => $this->t('Hierarchy'),
          'base_route' => "entity.$entity_type_id.canonical",
-         'weight' => 30,
+-        'weight' => 30,
++        'weight' => 40,
        ] + $base_plugin_definition;
+     }
+     return $this->derivatives;
 diff --git a/src/Routing/EntityHierarchyRouteProvider.php b/src/Routing/EntityHierarchyRouteProvider.php
 index c2174e1..e1b7b43 100644
 --- a/src/Routing/EntityHierarchyRouteProvider.php


### PR DESCRIPTION
**Description:**
Replaced a custom patch, changing the weight of the Hierarchy tab from the entity_reference module.


**Jira:** (Skip unless you are MA staff)
DP-23539


**To Test:**
- Login to the site.
- Visit a node that can be a parent (like an Organization).
- Verify the "Hierarchy" tab is to the left of the "Move Children" tab.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
