### PR TITLE
DP-23546: Fix Questionable Parent Reports view filtering by labels

### DIFF
--- a/changelogs/DP-23546.yml
+++ b/changelogs/DP-23546.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed questionable parent report view labels filter.
+    issue: DP-23546

--- a/conf/drupal/config/views.view.parent_reports.yml
+++ b/conf/drupal/config/views.view.parent_reports.yml
@@ -28,10 +28,10 @@ dependencies:
     - node.type.topic_page
     - taxonomy.vocabulary.label
   content:
-    - 'taxonomy_term:label:520cee6c-a522-48f9-b8ed-19c70da50059'
-    - 'taxonomy_term:label:db32f42f-9bfe-40e0-b344-4d79bc312d70'
-    - 'taxonomy_term:label:d3d9afd1-9504-4b19-b2d8-027dbf180cf2'
     - 'taxonomy_term:label:484e388f-acea-4cf9-8b3c-9267e960cb31'
+    - 'taxonomy_term:label:520cee6c-a522-48f9-b8ed-19c70da50059'
+    - 'taxonomy_term:label:d3d9afd1-9504-4b19-b2d8-027dbf180cf2'
+    - 'taxonomy_term:label:db32f42f-9bfe-40e0-b344-4d79bc312d70'
   module:
     - entity_hierarchy
     - mass_superset

--- a/conf/drupal/config/views.view.parent_reports.yml
+++ b/conf/drupal/config/views.view.parent_reports.yml
@@ -3355,10 +3355,10 @@ display:
           admin_label: ''
           operator: or
           value:
-            85838: 85838
-            85837: 85837
-            85839: 85839
-            85840: 85840
+            85886: 85886
+            85896: 85896
+            85891: 85891
+            85881: 85881
           group: 1
           exposed: false
           expose:

--- a/conf/drupal/config/views.view.parent_reports.yml
+++ b/conf/drupal/config/views.view.parent_reports.yml
@@ -64,7 +64,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           disable_automatic_base_fields: false
           replica: false
           query_comment: ''


### PR DESCRIPTION
**Description:**
Fixed the label uuids in the view to match Prod.


**Jira:** (Skip unless you are MA staff)
DP-23546


**To Test:**
- Login to the site.
- Go to /admin/structure/views/view/parent_reports/edit/page_3.
- Verify the labels are properly selected in the unexposed Label(s) filter.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
