### PR TITLE
DP-23549: move children message

### DIFF
--- a/changelogs/DP-23549.yml
+++ b/changelogs/DP-23549.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added help text for moving children advising users that experience may be slow.
+    issue: DP-23549

--- a/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
+++ b/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains mass_docs.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function mass_hierarchy_help($route_name, RouteMatchInterface $route_match) {
+  $output = '';
+  switch ($route_name) {
+    case 'view.change_parents.page_1':
+      $output .= '<p><strong>' . t('NOTE: Moving children in bulk is an experimental feature and is currently slow.') . '</strong>';
+      $output .= t(' It may take one minute or more before you see an indication that your move starts. In testing, we have seen it take two minutes to change the parent on 25 children. We will evaluate this after release to production to assess performance and to see if we can speed the process.') . '</p>';
+      break;
+
+    default:
+  }
+  return $output;
+}

--- a/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
+++ b/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains mass_docs.module.
+ * Contains mass_hierarchy.module.
  */
 
 use Drupal\Core\Routing\RouteMatchInterface;


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-23549


**To Test:**
- [ ] Go to the Move Children tab of any node with children.
- [ ] Check that the following help text appears: "NOTE: Moving children in bulk is an experimental feature and currently is slow. It may be 1 minute or more before you see an indication that your move starts. In testing, we have seen it take two minutes to change the parent on 25 children. We will be evaluating this after release to production to assess performance and see if we can speed the process."


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
