### PR TITLE
Add Akamai purger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@
 AC_API2_KEY=your-long-string-here
 AC_API2_SECRET=your-long-string-here
 
+#Akamai. Only needed if you are doing CDN work
+AKAMAI_ACCESS_TOKEN=
+AKAMAI_CLIENT_TOKEN=
+AKAMAI_CLIENT_SECRET=
+
+
 # New Relic API settings. Ask a release manager for the key.
 MASS_NEWRELIC_APPLICATION=46704875
 MASS_NEWRELIC_KEY=your-long-key-here

--- a/changelogs/DP-23555.yml
+++ b/changelogs/DP-23555.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add Akamai purger
+    issue: DP-23555

--- a/composer.json
+++ b/composer.json
@@ -208,6 +208,7 @@
         "drupal/rabbit_hole": "^1",
         "drupal/real_aes": "^2",
         "drupal/redirect": "^1",
+        "drupal/reverse_proxy_header": "^1",
         "drupal/route_iframes": "^2.0",
         "drupal/scheduled_transitions": "2.x-dev",
         "drupal/schema_metatag": "^1",

--- a/composer.json
+++ b/composer.json
@@ -358,7 +358,8 @@
                 "Can't edit user profile because password policy validates even when password unchanged": "https://www.drupal.org/files/issues/2020-03-19/password_policy-empty-password-skip-validation-2971079-37.patch"
             },
             "drupal/purge": {
-                "Remove exception during first run in p:queue-work (https://www.drupal.org/project/purge/issues/3101392)": "https://www.drupal.org/files/issues/2019-12-16/empty.patch"
+                "Remove exception during first run in p:queue-work (https://www.drupal.org/project/purge/issues/3101392)": "https://www.drupal.org/files/issues/2019-12-16/empty.patch",
+                "Add alter hooks for plugin definitions - purger, queue, queuer (https://www.drupal.org/project/purge/issues/2757155#comment-14335663)": "https://www.drupal.org/files/issues/2021-12-10/alters.diff"
             },
             "drupal/redirect": {
                 "Add an intermediate redirect": "https://www.drupal.org/files/issues/2020-07-31/tmp.diff"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa266d77354a5c33df5d259331b75a83",
+    "content-hash": "a02818b2dedb9ab719e0b818be67e09f",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -8726,6 +8726,54 @@
             "homepage": "https://www.drupal.org/project/redirect",
             "support": {
                 "source": "https://git.drupalcode.org/project/redirect"
+            }
+        },
+        {
+            "name": "drupal/reverse_proxy_header",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/reverse_proxy_header.git",
+                "reference": "1.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/reverse_proxy_header-1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": "342d7ba62399880e7ff1a7e3134ee6e1f0faa78e"
+            },
+            "require": {
+                "drupal/core": "^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "1.0.0",
+                    "datestamp": "1612787235",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Lysenko",
+                    "homepage": "https://www.drupal.org/user/3648128"
+                },
+                {
+                    "name": "bohart",
+                    "homepage": "https://www.drupal.org/user/289861"
+                }
+            ],
+            "description": "Provides an ability to use the specific HTTP header name to determine the client IP.",
+            "homepage": "https://www.drupal.org/project/reverse_proxy_header",
+            "support": {
+                "source": "https://git.drupalcode.org/project/reverse_proxy_header"
             }
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc5c5132416d5b4931adffc4a4042271",
+    "content-hash": "fa266d77354a5c33df5d259331b75a83",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -8395,17 +8395,17 @@
         },
         {
             "name": "drupal/purge",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/purge.git",
-                "reference": "8.x-3.0"
+                "reference": "8.x-3.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.0.zip",
-                "reference": "8.x-3.0",
-                "shasum": "e7113e9927dbdbbd5c2f4edc2649a14676e14f34"
+                "url": "https://ftp.drupal.org/files/projects/purge-8.x-3.2.zip",
+                "reference": "8.x-3.2",
+                "shasum": "eb025762097e5435d11f8b5bcb1b0ef32a6b72fe"
             },
             "require": {
                 "drupal/core": "^8.7.7 || ^9",
@@ -8414,8 +8414,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-3.0",
-                    "datestamp": "1590744318",
+                    "version": "8.x-3.2",
+                    "datestamp": "1633428281",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/conf/drupal/config/akamai.settings.yml
+++ b/conf/drupal/config/akamai.settings.yml
@@ -1,0 +1,24 @@
+version: v3
+disabled: true
+storage_method: key
+rest_api_url: 'https://akab-scfxscl2ys2hcaan-n6et7sdwlp7feiy5.luna.akamaiapis.net'
+client_token: akamai_client_token
+client_secret: akamai_client_secret
+access_token: akamai_access_token
+edgerc_path: ''
+edgerc_section: default
+basepath: 'https://stage.mass.gov'
+timeout: 5
+domain:
+  production: false
+  staging: true
+action_v3:
+  delete: false
+  invalidate: true
+log_requests: true
+edge_cache_tag_header: false
+purge_urls_with_hostname: false
+edgescape_support: false
+_core:
+  default_config_hash: wbD9a1lSFlzefyZbT7berzkarufh5L0yc5p0e9pywE4
+edge_cache_tag_header_blacklist: {  }

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -5,6 +5,7 @@ module:
   actions_permissions: 0
   address: 0
   admin_toolbar: 0
+  akamai: 0
   allowed_formats: 0
   asset_cache_bust: 0
   auto_entitylabel: 0
@@ -211,8 +212,8 @@ module:
   video_embed_field: 0
   video_embed_media: 0
   view_mode_page: 0
-  views_ajax_history: 0
   views_aggregator: 0
+  views_ajax_history: 0
   views_autocomplete_filters: 0
   views_bulk_operations: 0
   views_custom_cache_tag: 0

--- a/conf/drupal/config/key.key.akamai_access_token.yml
+++ b/conf/drupal/config/key.key.akamai_access_token.yml
@@ -1,0 +1,17 @@
+uuid: de160b99-ae65-4c75-990a-323711a63e3c
+langcode: en
+status: true
+dependencies: {  }
+id: akamai_access_token
+label: 'Akamai Access Token'
+description: N/A
+key_type: encryption
+key_type_settings:
+  key_size: 0
+key_provider: env
+key_provider_settings:
+  env_variable: AKAMAI_ACCESS_TOKEN
+  strip_line_breaks: true
+  base64_encoded: false
+key_input: none
+key_input_settings: {  }

--- a/conf/drupal/config/key.key.akamai_client_secret.yml
+++ b/conf/drupal/config/key.key.akamai_client_secret.yml
@@ -1,0 +1,17 @@
+uuid: d3b09afd-a4cd-4d06-912f-cdc0597eab0c
+langcode: en
+status: true
+dependencies: {  }
+id: akamai_client_secret
+label: 'Akamai Client Secret'
+description: ''
+key_type: encryption
+key_type_settings:
+  key_size: 0
+key_provider: env
+key_provider_settings:
+  env_variable: AKAMAI_CLIENT_SECRET
+  strip_line_breaks: true
+  base64_encoded: false
+key_input: none
+key_input_settings: {  }

--- a/conf/drupal/config/key.key.akamai_client_token.yml
+++ b/conf/drupal/config/key.key.akamai_client_token.yml
@@ -1,0 +1,17 @@
+uuid: f829ec23-c509-4ad2-bed9-45b99da332e5
+langcode: en
+status: true
+dependencies: {  }
+id: akamai_client_token
+label: 'Akamai Client Token'
+description: ''
+key_type: encryption
+key_type_settings:
+  key_size: 0
+key_provider: env
+key_provider_settings:
+  env_variable: AKAMAI_CLIENT_TOKEN
+  strip_line_breaks: true
+  base64_encoded: false
+key_input: none
+key_input_settings: {  }

--- a/conf/drupal/config/purge.logger_channels.yml
+++ b/conf/drupal/config/purge.logger_channels.yml
@@ -27,3 +27,14 @@ channels:
       - 0
       - 2
       - 3
+  -
+    id: purger_akamai_20fe5b998e
+    grants:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7

--- a/conf/drupal/config/purge.plugins.yml
+++ b/conf/drupal/config/purge.plugins.yml
@@ -7,6 +7,10 @@ purgers:
     order_index: 3
     instance_id: 5565233d1d
     plugin_id: massgov_cloudflare
+  -
+    order_index: 4
+    instance_id: 20fe5b998e
+    plugin_id: akamai
 queuers:
   -
     plugin_id: manual

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -12,13 +12,12 @@ use Drupal\path_alias\PathAliasInterface;
 use Drupal\redirect\Entity\Redirect;
 
 /**
- * // Acquia Purger has no other way to disable, so we use plugin alter.
+ * Acquia Purger has no other way to disable, so we use plugin alter.
  *
- * @param $definitions
- * @return void
- *
+ * @param array $definitions
+ *   All plugin definitions.
  */
-function mass_caching_purge_purgers_alter(&$definitions) {
+function mass_caching_purge_purgers_alter(array &$definitions): void {
   if (empty(getenv('AH_SITE_ENVIRONMENT'))) {
     // We are not in an Acquia env. Make their purgers capable of nothing.
     if (isset($definitions['acquia_purge'])) {

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -12,6 +12,22 @@ use Drupal\path_alias\PathAliasInterface;
 use Drupal\redirect\Entity\Redirect;
 
 /**
+ * // Acquia Purger has no other way to disable, so we use plugin alter.
+ *
+ * @param $definitions
+ * @return void
+ *
+ */
+function mass_caching_purge_purgers_alter(&$definitions) {
+  if (empty(getenv('AH_SITE_ENVIRONMENT'))) {
+    // We are not in an Acquia env. Make their purgers capable of nothing.
+    if (isset($definitions['acquia_purge'])) {
+      $definitions['acquia_purge']['types'] = [];
+    }
+  }
+}
+
+/**
  * Implements hook_file_insert().
  *
  * Purge the file's path when a file is created.

--- a/docroot/sites/default/settings.acquia.php
+++ b/docroot/sites/default/settings.acquia.php
@@ -29,6 +29,7 @@ if (file_exists($secrets_file)) {
  * Loads global secrets.
  *
  * - Used by TFA's encryption profile'.
+ * - Used by Akamai module's Key module integration.
  */
 $secrets_file_global = '/home/massgov/.app/secrets.settings.php';
 if (file_exists($secrets_file_global)) {
@@ -104,6 +105,10 @@ if(isset($_ENV['AH_SITE_ENVIRONMENT'])) {
       $config['stage_file_proxy.settings']['origin'] = FALSE;
       $config['media_entity_download.settings']['external_file_storage'] = 0;
       $settings['mass_caching.hosts'] = ['edit.mass.gov', 'www.mass.gov'];
+
+      $config['akamai.settings']['disabled'] = FALSE;
+      $config['akamai.settings']['basepath'] = 'www.mass.gov';
+
       break;
     case 'test':
       $settings['mass_caching.hosts'] = [

--- a/docroot/sites/default/settings.acquia.php
+++ b/docroot/sites/default/settings.acquia.php
@@ -114,7 +114,7 @@ if(isset($_ENV['AH_SITE_ENVIRONMENT'])) {
       $settings['mass_caching.hosts'] = ['edit.mass.gov', 'www.mass.gov'];
 
       $config['akamai.settings']['disabled'] = FALSE;
-      $config['akamai.settings']['basepath'] = 'www.mass.gov';
+      $config['akamai.settings']['basepath'] = 'https://www.mass.gov';
 
       break;
     case 'test':

--- a/docroot/sites/default/settings.acquia.php
+++ b/docroot/sites/default/settings.acquia.php
@@ -43,9 +43,16 @@ if (file_exists($secrets_file_global)) {
  */
 if (!$cli && ($is_prod || $is_mass_gov)) {
   if ($_SERVER['HTTP_MASS_CDN_FWD'] !== getenv('MASS_CDN_TOKEN')) {
-    throw new AccessDeniedHttpException('Only requests sent through Cloudflare CDN are allowed.');
+    throw new AccessDeniedHttpException('Only requests sent through the CDN are allowed.');
   }
 }
+
+/**
+ * Set the HTTP header name which stores real client IP. Harmless if not provided.
+ * See https://www.drupal.org/project/reverse_proxy_header.
+ */
+$settings['reverse_proxy_header'] = 'True-Client-IP';
+
 
 /**
  * Load Acquia-specific services.

--- a/docroot/sites/default/settings.acquia.php
+++ b/docroot/sites/default/settings.acquia.php
@@ -115,6 +115,7 @@ if(isset($_ENV['AH_SITE_ENVIRONMENT'])) {
         'stage.mass.gov',
         'edit.stage.mass.gov',
       ];
+      $config['akamai.settings']['disabled'] = FALSE;
       break;
     case 'dev':
       $settings['mass_caching.hosts'] = [
@@ -133,3 +134,5 @@ if(function_exists('newrelic_add_custom_parameter') && !$cli) {
   newrelic_add_custom_parameter('backend_url', $_SERVER['REQUEST_URI']);
   newrelic_add_custom_parameter('request_id', $_SERVER['HTTP_X_REQUEST_ID']);
 }
+
+

--- a/docroot/sites/default/settings.tugboat.php
+++ b/docroot/sites/default/settings.tugboat.php
@@ -1,5 +1,8 @@
 <?php
 
+// Turn on Akamai purger, for QA.
+$config['akamai.settings']['disabled'] = FALSE;
+
 /**
  * Password protect Tugboat environments.
  *

--- a/docroot/sites/default/settings.tugboat.php
+++ b/docroot/sites/default/settings.tugboat.php
@@ -1,8 +1,5 @@
 <?php
 
-// Turn on Akamai purger, for QA.
-$config['akamai.settings']['disabled'] = FALSE;
-
 /**
  * Password protect Tugboat environments.
  *


### PR DESCRIPTION
**Description:**
To get this to work locally, you need to create a `setting.local.php` and add there `$config['akamai.settings']['disabled'] = FALSE;`. In addition, you need to add 3 env variables to your .env file (see .env.example changes). See Moshe for values.

Also adds handing of Akamai's True-Client-IP http header


**Jira:** (Skip unless you are MA staff)
DP-23555


**To Test:**
- [ ] Run `drush pqe` to empty the queue
- [ ] Edit a document node. Run `drush pqb` to browse the queue. Notice some URL validations. Those are the ones are configured  to go to Akamai.
- [ ] Run `drush pqw` to process the queue and send invalidations to Akamai (the tag ones are handled by our massgov_cloudflare purger but we have always swallowed those and not sent them along). If there were no shown errors, we succeeded. An outputted table shows this as well.
- [ ] Run `drush pqb` again and confirm that all invalidations are gone.

**To Do:**
- [ ] Add 3 values to global secrets file at Acquia.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
