### PR TITLE
DP-23572: Add new Updated date field to Events and migrate last modified date as value

### DIFF
--- a/changelogs/DP-23572.yml
+++ b/changelogs/DP-23572.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added an Updated date field to the Event content type and migrated the node changed date into the field.
+    issue: DP-23572

--- a/composer.json
+++ b/composer.json
@@ -309,7 +309,8 @@
                 "Batch is dependent on the order of query string parameters (https://www.drupal.org/project/drupal/issues/2879023)": "https://www.drupal.org/files/issues/2021-08-24/2879023-34.patch",
                 "3075454 - combine fields filter doesn't recognise taxonomy description field":  "https://www.drupal.org/files/issues/2019-08-20/3075454-3.patch",
                 "2993688 - Views relationships with multi-valued entity reference fields invalidate Distinct query option": "https://www.drupal.org/files/issues/2021-04-16/2993688-69.patch",
-                "Store table drag object in the table data" : "patches/DP-23411_store-object-in-draggable-table.patch"
+                "Store table drag object in the table data" : "patches/DP-23411_store-object-in-draggable-table.patch",
+                "2329253 - Allow the ChangedItem to skip updating when synchronizing (f.e. when migrating)": "https://www.drupal.org/files/issues/2021-09-29/2329253-drupal-allow-changeditem-skipping-78-9.3.patch"
             },
             "ckeditor/liststyle": {
                 "Change code from styles to type": "https://www.drupal.org/files/issues/2019-01-02/ckeditor_liststyle-styles-to-type-2874952-4-do-not-test.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05f890fd51328f190e98ac7a2468c011",
+    "content-hash": "ff4bca9b9bf4d87622ffa37c140c993d",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",

--- a/conf/drupal/config/core.entity_form_display.node.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.event.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - image.style.thumbnail
     - node.type.event
     - workflows.workflow.editorial
@@ -107,6 +108,7 @@ third_party_settings:
         - field_event_time
         - field_event_date
         - field_event_posted_date
+        - field_updated_date
         - field_event_public_testimony
         - field_primary_parent
         - field_organizations
@@ -419,7 +421,7 @@ content:
     type: datetime_datelist
     region: content
   field_event_public_testimony:
-    weight: 127
+    weight: 128
     settings:
       size: 60
       placeholder: ''
@@ -591,13 +593,13 @@ content:
     type: text_textarea
     region: content
   field_intended_audience:
-    weight: 130
+    weight: 131
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_organizations:
-    weight: 129
+    weight: 130
     settings:
       match_operator: CONTAINS
       size: 60
@@ -607,7 +609,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_primary_parent:
-    weight: 128
+    weight: 129
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -618,7 +620,7 @@ content:
     type: entity_reference_hierarchy_autocomplete
     region: content
   field_reusable_label:
-    weight: 131
+    weight: 132
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -644,6 +646,33 @@ content:
       match_limit: 10
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_updated_date:
+    weight: 127
+    settings:
+      date_order: YMD
+      time_type: '12'
+      increment: 1
+    third_party_settings:
+      conditional_fields:
+        9d86eb40-59ba-4c31-b947-8400e07e0337:
+          dependee: field_event_type_list
+          settings:
+            state: visible
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: public_meeting
+            effect: show
+            effect_options: {  }
+            selector: ''
+          entity_type: node
+          bundle: event
+    type: datetime_datelist
     region: content
   moderation_state:
     type: moderation_state_default

--- a/conf/drupal/config/core.entity_view_display.node.event.agenda.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.agenda.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - entity_reference_revisions
@@ -158,4 +159,5 @@ hidden:
   field_reusable_label: true
   field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true

--- a/conf/drupal/config/core.entity_view_display.node.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - datetime
@@ -334,6 +335,15 @@ content:
     settings:
       link: true
     third_party_settings: {  }
+  field_updated_date:
+    weight: 34
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+    region: content
   links:
     weight: 1
     region: content

--- a/conf/drupal/config/core.entity_view_display.node.event.link_and_description.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.link_and_description.yml
@@ -34,8 +34,11 @@ dependencies:
     - field.field.node.event.field_event_you_will_need
     - field.field.node.event.field_intended_audience
     - field.field.node.event.field_organizations
+    - field.field.node.event.field_primary_parent
     - field.field.node.event.field_reusable_label
+    - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - user
@@ -83,7 +86,10 @@ hidden:
   field_event_you_will_need: true
   field_intended_audience: true
   field_organizations: true
+  field_primary_parent: true
   field_reusable_label: true
+  field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true
   links: true

--- a/conf/drupal/config/core.entity_view_display.node.event.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.link_only.yml
@@ -34,8 +34,11 @@ dependencies:
     - field.field.node.event.field_event_you_will_need
     - field.field.node.event.field_intended_audience
     - field.field.node.event.field_organizations
+    - field.field.node.event.field_primary_parent
     - field.field.node.event.field_reusable_label
+    - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - user
@@ -83,7 +86,10 @@ hidden:
   field_event_you_will_need: true
   field_intended_audience: true
   field_organizations: true
+  field_primary_parent: true
   field_reusable_label: true
+  field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true
   links: true

--- a/conf/drupal/config/core.entity_view_display.node.event.minutes.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.minutes.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - entity_reference_revisions
@@ -158,4 +159,5 @@ hidden:
   field_reusable_label: true
   field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true

--- a/conf/drupal/config/core.entity_view_display.node.event.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.teaser.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - user
@@ -94,4 +95,5 @@ hidden:
   field_reusable_label: true
   field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true

--- a/conf/drupal/config/core.entity_view_display.node.event.token.yml
+++ b/conf/drupal/config/core.entity_view_display.node.event.token.yml
@@ -38,6 +38,7 @@ dependencies:
     - field.field.node.event.field_reusable_label
     - field.field.node.event.field_short_title
     - field.field.node.event.field_state_organization_tax
+    - field.field.node.event.field_updated_date
     - node.type.event
   module:
     - datetime_range
@@ -234,4 +235,5 @@ hidden:
   field_reusable_label: true
   field_short_title: true
   field_state_organization_tax: true
+  field_updated_date: true
   langcode: true

--- a/conf/drupal/config/field.field.node.event.field_updated_date.yml
+++ b/conf/drupal/config/field.field.node.event.field_updated_date.yml
@@ -1,0 +1,21 @@
+uuid: 89c32fa2-7041-4ed8-a5ea-9e8d14bb5a7d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_updated_date
+    - node.type.event
+  module:
+    - datetime
+id: node.event.field_updated_date
+field_name: field_updated_date
+entity_type: node
+bundle: event
+label: 'Updated date'
+description: 'If you need to display an updated date on the meeting notice, enter it here. This date does not change automatically, it must be manually defined.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/drupal/config/field.storage.node.field_updated_date.yml
+++ b/conf/drupal/config/field.storage.node.field_updated_date.yml
@@ -1,0 +1,20 @@
+uuid: 1a813f4b-cdb6-43cd-ba39-112355e6cd08
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_updated_date
+field_name: field_updated_date
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\taxonomy\Entity\Term;
 
@@ -633,5 +634,63 @@ function mass_content_deploy_org_page_section_migration(&$sandbox) {
   $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
   if ($sandbox['#finished'] >= 1) {
     return t('All Organization node data has migrated to Organization Sections.');
+  }
+}
+
+/**
+ * Set default value for the updated date field on events.
+ */
+function mass_content_deploy_event_updated_date(&$sandbox) {
+  $_ENV['MASS_FLAGGING_BYPASS'] = TRUE;
+
+  $query = \Drupal::entityQuery('node');
+  $query->condition('type', 'event');
+  $query->condition('nid', 609571);
+
+  if (empty($sandbox)) {
+    // Get a list of all nodes of type event.
+    $sandbox['progress'] = 0;
+    $sandbox['current'] = 0;
+    $count = clone $query;
+    $sandbox['max'] = $count->count()->execute();
+  }
+
+  $batch_size = 50;
+
+  $nids = $query->condition('nid', $sandbox['current'], '>')
+    ->sort('nid')
+    ->range(0, $batch_size)
+    ->execute();
+
+  $memory_cache = \Drupal::service('entity.memory_cache');
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  $nodes = $node_storage->loadMultiple($nids);
+
+  foreach ($nodes as $node) {
+    $sandbox['current'] = $node->id();
+    // Set the updated date for events.
+    $timestamp = $node->getChangedTime();
+    // Convert the timestamp to the proper date format including timezone.
+    $date_time = DrupalDatetime::createFromTimestamp((int)$timestamp);
+    $date_time->setTimezone(new \Datetimezone('EST'));
+    $updated_date = \Drupal::service('date.formatter')->format($date_time->getTimestamp() , 'custom', 'Y-m-d\TH:i:s');
+    // Set the value of the new field.
+    $node->set('field_updated_date', $updated_date);
+    // Save the node.
+    // Save without updating the last modified date. This requires a core patch
+    // from the issue: https://www.drupal.org/project/drupal/issues/2329253.
+    $node->setSyncing(TRUE);
+    $node->save();
+
+    $sandbox['progress']++;
+  }
+
+  $memory_cache->deleteAll();
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['progress'] / $sandbox['max']);
+  if ($sandbox['#finished'] >= 1) {
+    return t('All Event "Updated date" fields have been set.');
   }
 }

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -645,6 +645,8 @@ function mass_content_deploy_event_updated_date(&$sandbox) {
 
   $query = \Drupal::entityQuery('node');
   $query->condition('type', 'event');
+  // Only update public meeting events.
+  $query->condition('field_event_type_list', 'public_meeting');
 
   if (empty($sandbox)) {
     // Get a list of all nodes of type event.

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -672,9 +672,9 @@ function mass_content_deploy_event_updated_date(&$sandbox) {
     // Set the updated date for events.
     $timestamp = $node->getChangedTime();
     // Convert the timestamp to the proper date format including timezone.
-    $date_time = DrupalDatetime::createFromTimestamp((int)$timestamp);
+    $date_time = DrupalDatetime::createFromTimestamp((int) $timestamp);
     $date_time->setTimezone(new \Datetimezone('EST'));
-    $updated_date = \Drupal::service('date.formatter')->format($date_time->getTimestamp() , 'custom', 'Y-m-d\TH:i:s');
+    $updated_date = \Drupal::service('date.formatter')->format($date_time->getTimestamp(), 'custom', 'Y-m-d\TH:i:s');
     // Set the value of the new field.
     $node->set('field_updated_date', $updated_date);
     // Save the node.

--- a/docroot/modules/custom/mass_content/mass_content.deploy.php
+++ b/docroot/modules/custom/mass_content/mass_content.deploy.php
@@ -645,7 +645,6 @@ function mass_content_deploy_event_updated_date(&$sandbox) {
 
   $query = \Drupal::entityQuery('node');
   $query->condition('type', 'event');
-  $query->condition('nid', 609571);
 
   if (empty($sandbox)) {
     // Get a list of all nodes of type event.

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -2796,6 +2796,7 @@ function mass_theme_preprocess_node_event(&$variables) {
     'contact' => ['field_event_contact_general'],
     'type' => ['field_event_type_list'],
     'posted_date' => ['field_event_posted_date'],
+    'updated_date' => ['field_updated_date'],
   ];
 
   // Determines which field names to use from the map.
@@ -2823,8 +2824,14 @@ function mass_theme_preprocess_node_event(&$variables) {
 
   if (Helper::isFieldPopulated($node, $fields['posted_date']) && $is_public_meeting) {
     $postedDate = Helper::getMayflowerDate($node->{$fields['posted_date']}->value, ['date_format' => 'F j, Y']);
-    // Converting epoch to DateTime requires '@'.
-    $changedDate = Helper::getMayflowerDate('@' . $node->getChangedTime(), ['date_format' => 'F j, Y']);
+    // Use the value of field_updated_date as the changedDate value.
+    if (Helper::isFieldPopulated($node, $fields['posted_date'])) {
+      $changedDate = Helper::getMayflowerDate($node->{$fields['updated_date']}->value, ['date_format' => 'F j, Y']);
+    }
+    else {
+      // Otherwise, display the posted date as last modified.
+      $changedDate = $postedDate;
+    }
 
     array_shift($postedDate);
     array_shift($changedDate);


### PR DESCRIPTION
**Description:**
- Added the core patch to skip new revisions and last modified date modifications when updating nodes in the auto parent assigning queue logic.
- Added new "Updated date" field to the Event content type and a deploy hook to populate the new field with the Event node changed date.


**Jira:** (Skip unless you are MA staff)
DP-23572


**To Test:**
- Login and visit and edit an Event node.
- Verify the last modified date did not change.
- Verify that the Updated date field value matches the Last modified date.
- View the Event node.
- Verify the "Updated date" field value is displayed after  "Last Modified:".


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
