### PR TITLE
Added fix for translated canonical URLs - DP-23575

### DIFF
--- a/changelogs/DP-23575.yml
+++ b/changelogs/DP-23575.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed canonical URLs for translated content.
+    issue: DP-23575

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -112,7 +112,7 @@ function mass_translations_element_info_alter(array &$info) {
  * Implements hook_pathauto_alias_alter().
  */
 function mass_translations_pathauto_alias_alter(&$alias, array &$context) {
-  // For nodes, set the default language to undefined to allow aliases to be used in canonical links.
+  // For nodes, set the context language to undefined to allow aliases to be used in canonical links.
   if ($context['module'] == 'node' && $context['language'] != 'en') {
     $context['language'] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
   } else {

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -116,7 +116,7 @@ function mass_translations_pathauto_alias_alter(&$alias, array &$context) {
   if ($context['module'] == 'node' && $context['language'] != 'en') {
     $context['language'] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
   } else {
-    // Set default pathauto alias language to English to prevent duplicate aliases.
+    // Set the context pathauto alias language to English to prevent duplicate aliases. This is especially important for documents.
     $context['language'] = 'en';
   }
 }

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -115,7 +115,8 @@ function mass_translations_pathauto_alias_alter(&$alias, array &$context) {
   // For nodes, set the context language to undefined to allow aliases to be used in canonical links.
   if ($context['module'] == 'node' && $context['language'] != 'en') {
     $context['language'] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
-  } else {
+  }
+  else {
     // Set the context pathauto alias language to English to prevent duplicate aliases. This is especially important for documents.
     $context['language'] = 'en';
   }

--- a/docroot/modules/custom/mass_translations/mass_translations.module
+++ b/docroot/modules/custom/mass_translations/mass_translations.module
@@ -112,8 +112,13 @@ function mass_translations_element_info_alter(array &$info) {
  * Implements hook_pathauto_alias_alter().
  */
 function mass_translations_pathauto_alias_alter(&$alias, array &$context) {
-  // Set language of all aliases to undefined to allow aliases to remain independent of language.
-  $context['language'] = 'en';
+  // For nodes, set the default language to undefined to allow aliases to be used in canonical links.
+  if ($context['module'] == 'node' && $context['language'] != 'en') {
+    $context['language'] = LanguageInterface::LANGCODE_NOT_SPECIFIED;
+  } else {
+    // Set default pathauto alias language to English to prevent duplicate aliases.
+    $context['language'] = 'en';
+  }
 }
 
 /**

--- a/docroot/modules/custom/mass_translations/tests/ExistingSite/ServiceDetailsTranslationTest.php
+++ b/docroot/modules/custom/mass_translations/tests/ExistingSite/ServiceDetailsTranslationTest.php
@@ -111,6 +111,20 @@ class ServiceDetailsTranslationTest extends ExistingSiteBase {
   }
 
   /**
+   * Check that the page has an aliased canonical URL.
+   */
+  public function testHasAliasedCanonicalLink() {
+    $this->drupalLogin($this->editor);
+    $entity = $this->getContent();
+    $translation = $this->getTranslation($entity);
+    $this->drupalGet($translation->toUrl());
+    $this->assertEquals(200, $this->getSession()->getStatusCode(), 'Entity page was loadable');
+    $page = $this->getSession()->getPage();
+    $element = $page->find('css', 'link[rel="canonical"]')->getText();
+    $this->assertStringNotContainsString('/node/', $element, 'Unaliased canonical URL found on translated page');
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function tearDown() {


### PR DESCRIPTION
**Description:**
This fixes canonical URLs for translated content by setting the context language to 'und.' This fix will continue to set documents to English, but nodes will be set to use 'und' if the language context is not English.


**Jira:** (Skip unless you are MA staff)
DP-23575

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
