### PR TITLE
Fix Promo page half size image margin

### DIFF
--- a/changelogs/DP-23620.yml
+++ b/changelogs/DP-23620.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Added:
+Fixed:
   - description: Fix key message margin bottom with half image.
     issue: DP-23620

--- a/changelogs/DP-23620.yml
+++ b/changelogs/DP-23620.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Fix key message margin bottom with half image.
+    issue: DP-23620

--- a/changelogs/DP-23620.yml
+++ b/changelogs/DP-23620.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Fixed:
-  - description: Fix key message margin bottom with half image.
+  - description: Fix key message margin bottom.
     issue: DP-23620

--- a/composer.json
+++ b/composer.json
@@ -237,7 +237,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-DP-23620_Vaccine_promo_page_header_overlap_issue",
+        "massgov/mayflower-artifacts": "dev-develop",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -237,7 +237,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-DP-23620_Vaccine_promo_page_header_overlap_issue",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -11727,12 +11727,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "e011ffb65db23a11da2745fa8fd11fdd9397439d"
+                "reference": "c2f8996d12588f3ff08f0264596d4742ba181edc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e011ffb65db23a11da2745fa8fd11fdd9397439d",
-                "reference": "e011ffb65db23a11da2745fa8fd11fdd9397439d",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/c2f8996d12588f3ff08f0264596d4742ba181edc",
+                "reference": "c2f8996d12588f3ff08f0264596d4742ba181edc",
                 "shasum": ""
             },
             "require": {
@@ -11754,7 +11754,7 @@
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
                 "source": "https://github.com/massgov/mayflower-artifacts/tree/DP-23620_Vaccine_promo_page_header_overlap_issue"
             },
-            "time": "2021-12-13T18:07:10+00:00"
+            "time": "2021-12-13T20:12:13+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a02818b2dedb9ab719e0b818be67e09f",
+    "content-hash": "e0340c2cedb676e8832503d0c2af3f2c",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11723,16 +11723,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-DP-23620_Vaccine_promo_page_header_overlap_issue",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "ac1a8566588e88cf2d4891b9d72578eb3786be27"
+                "reference": "e011ffb65db23a11da2745fa8fd11fdd9397439d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/ac1a8566588e88cf2d4891b9d72578eb3786be27",
-                "reference": "ac1a8566588e88cf2d4891b9d72578eb3786be27",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e011ffb65db23a11da2745fa8fd11fdd9397439d",
+                "reference": "e011ffb65db23a11da2745fa8fd11fdd9397439d",
                 "shasum": ""
             },
             "require": {
@@ -11752,9 +11752,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/DP-23620_Vaccine_promo_page_header_overlap_issue"
             },
-            "time": "2021-12-08T19:29:41+00:00"
+            "time": "2021-12-13T18:07:10+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e0340c2cedb676e8832503d0c2af3f2c",
+    "content-hash": "a02818b2dedb9ab719e0b818be67e09f",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11723,16 +11723,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-DP-23620_Vaccine_promo_page_header_overlap_issue",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "c2f8996d12588f3ff08f0264596d4742ba181edc"
+                "reference": "d0594ec17343225ec2bfa6edccc64aee612be2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/c2f8996d12588f3ff08f0264596d4742ba181edc",
-                "reference": "c2f8996d12588f3ff08f0264596d4742ba181edc",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d0594ec17343225ec2bfa6edccc64aee612be2bc",
+                "reference": "d0594ec17343225ec2bfa6edccc64aee612be2bc",
                 "shasum": ""
             },
             "require": {
@@ -11752,9 +11752,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/DP-23620_Vaccine_promo_page_header_overlap_issue"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2021-12-13T20:12:13+00:00"
+            "time": "2021-12-13T21:37:32+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fixed:
  - description: Fix key message margin bottom with half image.
    issue: DP-23620


MF PR --> https://github.com/massgov/mayflower/pull/1571