### PR TITLE
Disable Akamai purger except on Stage and Prod

### DIFF
--- a/changelogs/DP-23589.yml
+++ b/changelogs/DP-23589.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Disable Akamai purger via mass_caching_purge_purgers_alter().
+    issue: DP-23589

--- a/conf/drupal/config/akamai.settings.yml
+++ b/conf/drupal/config/akamai.settings.yml
@@ -1,5 +1,5 @@
 version: v3
-disabled: true
+disabled: false
 storage_method: key
 rest_api_url: 'https://akab-scfxscl2ys2hcaan-n6et7sdwlp7feiy5.luna.akamaiapis.net'
 client_token: akamai_client_token

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -13,7 +13,7 @@ use Drupal\redirect\Entity\Redirect;
 
 /**
  * Acquia Purger and Akamai need conditional disable, so we use plugin alter.
- * This alter is added by a patch to purge module.
+ * This alter is added by a patch to purge module https://www.drupal.org/project/purge/issues/2757155#comment-14335663
  *
  * @param array $definitions
  *   All plugin definitions.

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -12,16 +12,29 @@ use Drupal\path_alias\PathAliasInterface;
 use Drupal\redirect\Entity\Redirect;
 
 /**
- * Acquia Purger has no other way to disable, so we use plugin alter.
+ * Acquia Purger and Akamai need conditional disable, so we use plugin alter.
+ * This alter is added by a patch to purge module.
  *
  * @param array $definitions
  *   All plugin definitions.
  */
 function mass_caching_purge_purgers_alter(array &$definitions): void {
-  if (empty(getenv('AH_SITE_ENVIRONMENT'))) {
-    // We are not in an Acquia env. Make their purgers capable of nothing.
-    if (isset($definitions['acquia_purge'])) {
-      $definitions['acquia_purge']['types'] = [];
+  // Start with disabled for both purgers.
+  $akamai = $acquia_purge = FALSE;
+
+  $env = getenv('AH_SITE_ENVIRONMENT');
+  if ($env) {
+    // We are in an Acquia env.
+    $acquia_purge = TRUE;
+    if (in_array($env, ['test', 'prod'])) {
+      $akamai = TRUE;
+    }
+  }
+
+  foreach (['akamai', 'acquia_purge'] as $name) {
+    if (!$$name && isset($definitions[$name])) {
+      // To disable a purger, make it capable of nothing.
+      $definitions[$name]['types'] = [];
     }
   }
 }

--- a/docroot/modules/custom/mass_caching/mass_caching.module
+++ b/docroot/modules/custom/mass_caching/mass_caching.module
@@ -13,7 +13,9 @@ use Drupal\redirect\Entity\Redirect;
 
 /**
  * Acquia Purger and Akamai need conditional disable, so we use plugin alter.
- * This alter is added by a patch to purge module https://www.drupal.org/project/purge/issues/2757155#comment-14335663
+ *
+ * This alter is added by a patch to purge module. See
+ * https://www.drupal.org/project/purge/issues/2757155#comment-14335663.
  *
  * @param array $definitions
  *   All plugin definitions.


### PR DESCRIPTION
**Description:**
Change how we disable Akamai since old way gave an exception during deployment and anytime we work the purge queue outside of stage and prod


**Jira:** (Skip unless you are MA staff)
DP-23555


**To Test:**
- [ ] None, as these purgers can't be trivially enabled locally anymore. If PR is green, its good.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
