### PR TITLE
Dp 23630 change behavior when moving a child to an unallowed parent in the hierarchy tab

### DIFF
--- a/changelogs/DP-23630.yml
+++ b/changelogs/DP-23630.yml
@@ -1,0 +1,44 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: |-
+      Hierarchy Tab:
+      - Message box when parent-child relationships are not set correctly
+      - Changes message for wrong relationships from warning to error
+    issue: DP-23630

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.css
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.css
@@ -94,3 +94,23 @@ tbody .hierarchy-row .tabledrag-handle {
 .mass_hierarchy_cant_drag #edit-submit {
   display: none;
 }
+
+
+#hierarchy-node-wrong-bundle-alert {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -ms-transform: translateX(-50%) translateY(-50%);
+  -webkit-transform: translate(-50%,-50%);
+  transform: translate(-50%,-50%);
+}
+
+#hierarchy-node-wrong-bundle-alert--wrapper {
+  position: fixed;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background: rgba(0,0,0, 0.5);
+}

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -254,7 +254,7 @@ jQuery(document).ready(function ($) {
       ' id="' + wrongMessageId + '" ' +
       ' role="contentinfo" ' +
       ' aria-label="Status message" ' +
-      ' class="messages messages--warning ' + hierarchyMessagesClass + '"> ' +
+      ' class="messages messages--error ' + hierarchyMessagesClass + '"> ' +
         ' <h2 class="visually-hidden">Status message</h2> ' +
         message +
     '</div>';

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -234,6 +234,63 @@ jQuery(document).ready(function ($) {
     } while (true);  // eslint-disable-line
   }
 
+  // Shows an alert when there is a message saying there are wrong
+  // parent/child relationship.
+  function showAlertDueToWrongBundles() {
+    var wrongBundleAlertId = 'hierarchy-node-wrong-bundle-alert';
+
+    var alertBox =
+    '<div ' +
+      ' id="' + wrongBundleAlertId + '" ' +
+      ' role="contentinfo" ' +
+      ' aria-label="Alert" ' +
+      ' class="messages messages--error"> ' +
+      ' <h2 class="visually-hidden">Status message</h2> ' +
+      ' <div>' +
+      ' Moving this page to a parent of this content type is not allowed. ' +
+      ' Please move the row in red to a different content type. ' +
+      ' See knowledge base for more information about what types are allowed.' +
+      ' </div>' +
+      ' <div class="form-actions">' +
+      '   <div class="button" id="hierarchyDismissAlert">Got it</div>' +
+      ' </div>' +
+    '</div>';
+
+    var alertBoxWrapper =
+      '<div ' +
+      ' id="' + wrongBundleAlertId + '--wrapper" ' +
+      ' role="contentinfo" ' +
+      ' >' +
+      ' <h2 class="visually-hidden">Status message</h2> ' +
+        alertBox +
+      '</div>';
+
+    // Remove once data and class on already alerted rows
+    // that currently are not wrong.
+    $table.find('tr.hierarchy-row--alerted')
+      .not('.hierarchy-row--parent-bundle-is-wrong')
+      .removeData('jqueryOnceHierarchyAlert')
+      .removeClass('hierarchy-row--alerted');
+
+    if ($('#' + wrongBundleMessageId).length === 0) {
+      return;
+    }
+
+    // Count new rows with errors.
+    var newRowsWithErrors =
+      $table.find('tr.hierarchy-row--parent-bundle-is-wrong')
+        .once('hierarchyAlert').addClass('hierarchy-row--alerted').length;
+
+    if (!newRowsWithErrors) {
+      return;
+    }
+
+    $('main').before(alertBoxWrapper);
+    $('#hierarchyDismissAlert').click(function () {
+      $('#' + wrongBundleAlertId).parent().remove();
+    });
+  }
+
   // Abstraction to check for an error and toggle an error message.
   function checkForErrorsAndMessage($tr, checkerFn, errorClass, wrongMessageId, message) {
     var $parentRow = getParentFromRow($tr);
@@ -298,6 +355,7 @@ jQuery(document).ready(function ($) {
   function doOnDrag(event) {
     var $tr = $(event.target).closest('tr');
     parentChildRelationshipChecker($tr);
+    showAlertDueToWrongBundles();
     loadAsyncChildrenWhenChildIsDraggedInto($tr);
     removeParentClassIfRowIsNotParent();
     addParentClassOnRowsWithChildren();

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -259,6 +259,7 @@ jQuery(document).ready(function ($) {
         message +
     '</div>';
 
+    // Only create one wrong bundle message.
     if ($('#' + wrongMessageId).length === 0) {
       $table.before(messageBox);
     }


### PR DESCRIPTION
**Description:**
Hierarchy Tab:
      - Message box when parent-child relationships are not set correctly
      - Changes message for wrong relationships from a warning to an error.

**Jira:** (Skip unless you are MA staff)
DP-23630


**To Test:**
- [ ] Create a wrong relationship in the hierarchy tab.
- [ ] An alert box should appear telling you about the error, you can click "Got it" to dismiss.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
