### PR TITLE
Dp 23691 investigate 500 errors on mass.gov

### DIFF
--- a/changelogs/DP-23691.yml
+++ b/changelogs/DP-23691.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Checks field_section_long_form_content is not null before trying to access any methods.
+    issue: DP-23691

--- a/docroot/modules/custom/mass_map/src/Controller/MapController.php
+++ b/docroot/modules/custom/mass_map/src/Controller/MapController.php
@@ -222,7 +222,7 @@ class MapController extends ControllerBase {
           $section_paragraph = current($this->entityTypeManager->getStorage('paragraph')
             ->loadByProperties($section_properties));
           // If the content field is not empty, proceed.
-          if (!$section_paragraph->field_section_long_form_content->isEmpty()) {
+          if ($section_paragraph->field_section_long_form_content ?? FALSE && !$section_paragraph->field_section_long_form_content->isEmpty()) {
             // Get the content field value.
             $field_section_long_form_content = $section_paragraph->get('field_section_long_form_content')
               ->getValue();

--- a/docroot/modules/custom/mass_views/src/Plugin/views/field/OrgPageCountBase.php
+++ b/docroot/modules/custom/mass_views/src/Plugin/views/field/OrgPageCountBase.php
@@ -43,6 +43,7 @@ class OrgPageCountBase extends NumericField {
     $subQuery->addExpression("COUNT($this->pseudoTableAlias.id)", $this->pseudoFieldName);
     $subQuery->condition("$this->pseudoTableAlias.parent_type", 'paragraph');
     $subQuery->condition("$this->pseudoTableAlias.type", $this->paragraphBundle);
+    $subQuery->groupBy('parent_id');
 
     $relationship = $this->relationship ?: 'paragraphs_item_field_data';
 


### PR DESCRIPTION
**Description:**
- Fixes a MySQL syntax when using aggregation functions on a SELECT and not using GROUP BY on fields that are not aggregagted.
- Fixes an issue with a paragraph field process that assumes it has a specific field and does a check over that field, but that field is not always present, so I just expand the checks over the existence of that field before executing methods on it.

**Jira:** (Skip unless you are MA staff)
DP-23691



---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
