### PR TITLE
Allow purge logging to New Relic, and avoid lock api locks during purge - requires a drupal patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.305.3] - January 3, 2022
+
+- DP-23765 Log purge messages to New Relic and add patch to purge.
+
 ## [0.305.2] - December 16, 2021
 
   - DP-23602 Fix purging of media URLs.

--- a/composer.json
+++ b/composer.json
@@ -372,6 +372,7 @@
             "drupal/purge": {
                 "Remove exception during first run in p:queue-work (https://www.drupal.org/project/purge/issues/3101392)": "https://www.drupal.org/files/issues/2019-12-16/empty.patch",
                 "purge_drush hides errors in child drush processes (https://www.drupal.org/project/purge/issues/3219194#comment-14267327)": "https://git.drupalcode.org/project/purge/-/merge_requests/8.diff",
+                "PurgersService does not release lock if an exception is thrown (https://www.drupal.org/project/purge/issues/3219189)": "https://git.drupalcode.org/project/purge/-/merge_requests/7.diff",
                 "Add alter hooks for plugin definitions - purger, queue, queuer (https://www.drupal.org/project/purge/issues/2757155#comment-14335663)": "https://www.drupal.org/files/issues/2021-12-10/alters.diff"
             },
             "drupal/redirect": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4bf7be329edaa99a16839765461957c",
+    "content-hash": "ae03f69cf7deed83d68e09688ffa3141",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",

--- a/docroot/sites/default/services.acquia.yml
+++ b/docroot/sites/default/services.acquia.yml
@@ -9,4 +9,3 @@ parameters:
   monolog.channel_handlers:
     # Log to syslog and NewRelic
     default: ['acquia_syslog', 'acquia_newrelic']
-    purge: ['acquia_syslog']


### PR DESCRIPTION


**Jira:** (Skip unless you are MA staff)
DP-23756


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
