### PR TITLE
DP-23763 remove unpublished from the validation

### DIFF
--- a/changelogs/DP-23763.yml
+++ b/changelogs/DP-23763.yml
@@ -37,5 +37,7 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Unpublished children of a node are ignored on its validation on save.
+  - description: |-
+      - Unpublished children of a node are ignored when unpublishing a parent.
+      - A node cannot be published if its parent is not published.
     issue: DP-23763

--- a/changelogs/DP-23763.yml
+++ b/changelogs/DP-23763.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Unpublished children of a node are ignored on its validation on save.
+    issue: DP-23763

--- a/composer.json
+++ b/composer.json
@@ -312,7 +312,8 @@
                 "2993688 - Views relationships with multi-valued entity reference fields invalidate Distinct query option": "https://www.drupal.org/files/issues/2021-04-16/2993688-69.patch",
                 "Store table drag object in the table data" : "patches/DP-23411_store-object-in-draggable-table.patch",
                 "2329253 - Allow the ChangedItem to skip updating when synchronizing (f.e. when migrating)": "https://www.drupal.org/files/issues/2021-09-29/2329253-drupal-allow-changeditem-skipping-78-9.3.patch",
-                "Avoid warnings when getting permissions for roles that do not have permissions and are not administrators": "patches/DP-23561-avoid-warnings-on-roles-without-permissions.patch"
+                "Avoid warnings when getting permissions for roles that do not have permissions and are not administrators": "patches/DP-23561-avoid-warnings-on-roles-without-permissions.patch",
+                "2845144 - User can't reference unpublished content even when they have access to it" : "https://www.drupal.org/files/issues/2021-06-09/2845144_52.patch"
             },
             "ckeditor/liststyle": {
                 "Change code from styles to type": "https://www.drupal.org/files/issues/2019-01-02/ckeditor_liststyle-styles-to-type-2874952-4-do-not-test.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61c85f47920406839e98d4e3a3d1b212",
+    "content-hash": "7cace5e5d3bab05ac5e697b5dc84d286",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -6743,24 +6743,12 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "davidseth",
-                    "homepage": "https://www.drupal.org/user/254857"
-                },
-                {
-                    "name": "itamair",
-                    "homepage": "https://www.drupal.org/user/1179076"
-                },
-                {
                     "name": "phayes",
                     "homepage": "https://www.drupal.org/user/47098"
                 },
                 {
                     "name": "plopesc",
                     "homepage": "https://www.drupal.org/user/282415"
-                },
-                {
-                    "name": "zzolo",
-                    "homepage": "https://www.drupal.org/user/147331"
                 }
             ],
             "description": "Stores geographic and location data (points, lines, and polygons).",

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -46,6 +46,7 @@ function mass_validation_entity_type_alter(array &$entity_types) {
       $type->addConstraint('BinderDownloadsOrPages');
       if ($type_name == 'node') {
         $type->addConstraint('UnpublishParent');
+        $type->addConstraint('PublishChildWithUnpublishedParent');
       }
     }
   }

--- a/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
+++ b/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
@@ -34,6 +34,8 @@ class MassChildEntityWarningBuilder extends ChildEntityWarningBuilder {
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $parent
    *   Parent to be deleted.
+   * @param bool $removeUnpublished
+   *   Ignores unpublished items.
    *
    * @return \Drupal\mass_validation\Information\MassChildEntityWarning[]
    *   Array of warning value objects.

--- a/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
+++ b/docroot/modules/custom/mass_validation/src/Information/MassChildEntityWarningBuilder.php
@@ -5,11 +5,29 @@ namespace Drupal\mass_validation\Information;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\entity_hierarchy\Information\ChildEntityWarningBuilder;
+use Drupal\mass_content_moderation\MassModeration;
+use Drupal\node\Entity\Node;
 
 /**
  * Defines a class for building a list of child entity warnings.
  */
 class MassChildEntityWarningBuilder extends ChildEntityWarningBuilder {
+
+  /**
+   * Remove children that are not published.
+   */
+  private function removeUnpublished($children) {
+    foreach ($children as $key => $child) {
+      $nid = $child->getId();
+      $node = Node::load($nid);
+      $state = $node->moderation_state[0]->value;
+
+      if ($state != MassModeration::PUBLISHED) {
+        unset($children[$key]);
+      }
+    }
+    return $children;
+  }
 
   /**
    * Gets warning about child entities before deleting a parent.
@@ -20,7 +38,7 @@ class MassChildEntityWarningBuilder extends ChildEntityWarningBuilder {
    * @return \Drupal\mass_validation\Information\MassChildEntityWarning[]
    *   Array of warning value objects.
    */
-  public function buildChildEntityWarnings(ContentEntityInterface $parent) {
+  public function buildChildEntityWarnings(ContentEntityInterface $parent, $removeUnpublished = FALSE) {
     $return = [];
     if ($fields = $this->parentCandidate->getCandidateFields($parent)) {
       $cache = new CacheableMetadata();
@@ -29,6 +47,7 @@ class MassChildEntityWarningBuilder extends ChildEntityWarningBuilder {
         $storage = $this->nestedSetStorageFactory->get($field_name, $parent->getEntityTypeId());
         $nodeKey = $this->nodeKeyFactory->fromEntity($parent);
         $children = $storage->findChildren($nodeKey);
+        $children = !$removeUnpublished ? $children : $this->removeUnpublished($children);
         if ($parent_node = $storage->findParent($nodeKey)) {
           $children[] = $parent_node;
         }

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraint.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraint.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\mass_validation\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Prevents a child to be published if its parent is unpublished.
+ *
+ * @Constraint(
+ *   id = "PublishChildWithUnpublishedParent",
+ *   label = @Translation("Prevents a child to be published if its parent is unpublished", context = "Validation")
+ * )
+ */
+class PublishChildWithUnpublishedParentConstraint extends Constraint {
+
+  /**
+   * The default violation message.
+   *
+   * @var string
+   */
+  public const MESSAGE = 'This content cannot be published because its parent is not published. Publish the parent first, or choose a different published parent.';
+
+}

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraintValidator.php
@@ -42,7 +42,7 @@ class PublishChildWithUnpublishedParentConstraintValidator extends ConstraintVal
     $parent_state = $parent->moderation_state->value;
 
     // The parent cannot be unpublished or in the trash.
-    if ($parent_state != MassModeration::UNPUBLISHED && $parent_state != MassModeration::TRASH) {
+    if ($parent_state == MassModeration::PUBLISHED) {
       return;
     }
 

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/PublishChildWithUnpublishedParentConstraintValidator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\mass_validation\Plugin\Validation\Constraint;
+
+use Drupal\mass_content_moderation\MassModeration;
+use Drupal\node\Entity\Node;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Checks if an entity has a parent before unpublishing.
+ */
+class PublishChildWithUnpublishedParentConstraintValidator extends ConstraintValidator {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($entity, Constraint $constraint) {
+    if (!isset($entity)) {
+      return;
+    }
+
+    // When trying to publish an entity.
+    if ($entity->moderation_state->value != MassModeration::PUBLISHED) {
+      return;
+    }
+
+    // If the entity has a parent.
+    if (!($entity->field_primary_parent ?? FALSE) || !($entity->field_primary_parent[0] ?? FALSE)) {
+      return;
+    }
+
+    $value = $entity->field_primary_parent[0]->getValue();
+    $target_id = $value['target_id'] ?? FALSE;
+    $parent = $target_id ? Node::load($target_id) : FALSE;
+
+    // If we can load the parent sucessfully.
+    if (!$parent) {
+      return;
+    }
+
+    $parent_state = $parent->moderation_state->value;
+
+    // The parent cannot be unpublished or in the trash.
+    if ($parent_state != MassModeration::UNPUBLISHED && $parent_state != MassModeration::TRASH) {
+      return;
+    }
+
+    $this->context->addViolation(PublishChildWithUnpublishedParentConstraint::MESSAGE);
+  }
+
+}

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
@@ -25,15 +25,15 @@ class UnpublishParentConstraintValidator extends ConstraintValidator {
     if (in_array($moderation_state, $unpublished_states)) {
       if ($children = \Drupal::service('class_resolver')
         ->getInstanceFromDefinition(MassChildEntityWarningBuilder::class)
-        ->buildChildEntityWarnings($entity)) {
-        foreach ($children as $child) {
+        ->buildChildEntityWarnings($entity, FALSE)) {
+          foreach ($children as $child) {
           $items = $child->getList()['#items'];
           if (!empty($items)) {
             $items_string = implode(', ', $items);
             $message = new PluralTranslatableMarkup(
               count($items),
-              $constraint->message . '1 child: ' . $items_string,
-              $constraint->message . '@count children: ' . $items_string);
+              $constraint->message . '1 published child: ' . $items_string,
+              $constraint->message . '@count published children: ' . $items_string);
             $this->context->addViolation($message);
           }
         }

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
@@ -25,7 +25,7 @@ class UnpublishParentConstraintValidator extends ConstraintValidator {
     if (in_array($moderation_state, $unpublished_states)) {
       if ($children = \Drupal::service('class_resolver')
         ->getInstanceFromDefinition(MassChildEntityWarningBuilder::class)
-        ->buildChildEntityWarnings($entity, FALSE)) {
+        ->buildChildEntityWarnings($entity, TRUE)) {
           foreach ($children as $child) {
           $items = $child->getList()['#items'];
           if (!empty($items)) {

--- a/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
+++ b/docroot/modules/custom/mass_validation/src/Plugin/Validation/Constraint/UnpublishParentConstraintValidator.php
@@ -26,7 +26,7 @@ class UnpublishParentConstraintValidator extends ConstraintValidator {
       if ($children = \Drupal::service('class_resolver')
         ->getInstanceFromDefinition(MassChildEntityWarningBuilder::class)
         ->buildChildEntityWarnings($entity, TRUE)) {
-          foreach ($children as $child) {
+        foreach ($children as $child) {
           $items = $child->getList()['#items'];
           if (!empty($items)) {
             $items_string = implode(', ', $items);

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/PublishChildWithUnpublishedParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/PublishChildWithUnpublishedParentConstraintTest.php
@@ -38,7 +38,7 @@ class PublishChildWithUnpublishedParentConstraintTest extends ExistingSiteBase {
       'title' => 'Test Parent',
       'field_sub_title' => $this->randomString(20),
       'uid' => $this->user->id(),
-      'moderation_state' => MassModeration::UNPUBLISHED,
+      'moderation_state' => MassModeration::DRAFT,
     ]);
 
     $childNode = $this->createNode([
@@ -49,11 +49,19 @@ class PublishChildWithUnpublishedParentConstraintTest extends ExistingSiteBase {
       'field_primary_parent' => $node_parent_org->id(),
     ]);
 
-    // Attempt to publish a child node with an unpublished parent.
+    // Edit the child node, select the moderation state to published.
     $this->drupalLogin($this->user);
     $this->drupalGet('node/' . $childNode->id());
     $this->visit($childNode->toUrl()->toString() . '/edit');
     $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::PUBLISHED);
+
+    // Attempt to publish a child node with parent in draft.
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextContains(PublishChildWithUnpublishedParentConstraint::MESSAGE);
+
+    // Attempt to publish a child node with an unpublished parent.
+    $node_parent_org->moderation_state = MassModeration::UNPUBLISHED;
+    $node_parent_org->save();
     $this->getCurrentPage()->pressButton('Save');
     $this->assertSession()->pageTextContains(PublishChildWithUnpublishedParentConstraint::MESSAGE);
 

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/PublishChildWithUnpublishedParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/PublishChildWithUnpublishedParentConstraintTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\Tests\mass_validation\ExistingSite;
+
+use Drupal\mass_content_moderation\MassModeration;
+use Drupal\mass_validation\Plugin\Validation\Constraint\PublishChildWithUnpublishedParentConstraint;
+use Drupal\user\Entity\User;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+use weitzman\LoginTrait\LoginTrait;
+
+/**
+ * Class PublishChildWithUnpublishedParentConstraintTest.
+ */
+class PublishChildWithUnpublishedParentConstraintTest extends ExistingSiteBase {
+
+  use LoginTrait;
+
+  private $user;
+
+  /**
+   * Create the user.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $user = User::create(['name' => $this->randomMachineName()]);
+    $user->addRole('editor');
+    $user->activate();
+    $user->save();
+    $this->user = $user;
+  }
+
+  /**
+   * Assert that the constraint works properly.
+   */
+  public function testNodeCannotBePublishedIfItsParentIsNotPublished() {
+    $node_parent_org = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Parent',
+      'field_sub_title' => $this->randomString(20),
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::UNPUBLISHED,
+    ]);
+
+    $childNode = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child',
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::UNPUBLISHED,
+      'field_primary_parent' => $node_parent_org->id(),
+    ]);
+
+    // Attempt to publish a child node with an unpublished parent.
+    $this->drupalLogin($this->user);
+    $this->drupalGet('node/' . $childNode->id());
+    $this->visit($childNode->toUrl()->toString() . '/edit');
+    $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::PUBLISHED);
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextContains(PublishChildWithUnpublishedParentConstraint::MESSAGE);
+
+    // Attempt to publish a child node with a trashed parent.
+    $node_parent_org->moderation_state = MassModeration::TRASH;
+    $node_parent_org->save();
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextContains(PublishChildWithUnpublishedParentConstraint::MESSAGE);
+
+    // Attempt to publish a child node with a publish parent (should work).
+    $node_parent_org->moderation_state = MassModeration::PUBLISHED;
+    $node_parent_org->save();
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextNotContains(PublishChildWithUnpublishedParentConstraint::MESSAGE);
+  }
+
+}

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -23,7 +23,6 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
     parent::setUp();
     $user = User::create(['name' => $this->randomMachineName()]);
     $user->addRole('content_team');
-    // $user->addRole('administrator');
     $user->activate();
     $user->save();
     $this->user = $user;
@@ -32,7 +31,7 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
   /**
    * Assert that the validation works properly.
    */
-  public function no_testUnpublishParentValidation() {
+  public function testUnpublishParentValidation() {
     $node_parent_org = $this->createNode([
       'type' => 'org_page',
       'title' => 'Test Parent Organization',
@@ -89,34 +88,4 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
     $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
   }
 
-  public function testSomething() {
-
-    // An unpublished parent.
-    // No other children.
-    $parent = $this->createNode([
-      'type' => 'org_page',
-      'title' => 'Test Parent Organization',
-      'field_sub_title' => $this->randomString(20),
-      'uid' => $this->user->id(),
-      'moderation_state' => MassModeration::UNPUBLISHED,
-    ]);
-
-    // A child in trash.
-    $child = $this->createNode([
-      'type' => 'org_page',
-      'title' => 'Test Child Organization - 1' . __FUNCTION__,
-      'uid' => $this->user->id(),
-      'moderation_state' => MassModeration::TRASH,
-      'field_primary_parent' => $parent->id(),
-    ]);
-
-    // We should be able to transition the child from trash to unpublished.
-    $this->drupalLogin($this->user);
-    $this->drupalGet('node/' . $child->id() . '/edit');
-    $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
-    $this->getCurrentPage()->pressButton('Save');
-    $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
-  }
-
 }
-

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -91,6 +91,8 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
 
   public function testSomething() {
 
+    // An unpublished parent.
+    // No other children.
     $parent = $this->createNode([
       'type' => 'org_page',
       'title' => 'Test Parent Organization',
@@ -99,6 +101,7 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
       'moderation_state' => MassModeration::UNPUBLISHED,
     ]);
 
+    // A child in trash.
     $child = $this->createNode([
       'type' => 'org_page',
       'title' => 'Test Child Organization - 1' . __FUNCTION__,
@@ -107,49 +110,12 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
       'field_primary_parent' => $parent->id(),
     ]);
 
-
-    // If I trash a child,
-
-    // then unpublish the parent
-
-
-    // $parent->moderation_state = MassModeration::UNPUBLISHED;
-    // $parent->save();
-
-
-
-    // which has no other children,
-
-    // I cannot transition the trashed child to unpublished because
-    // it knows that the parent is unpublished.
-
-
-    // $this->htmlOutput('AHORA!');
-
-    $this->htmlOutput();
-    $this->drupalGet('user/'. $this->user->id() . '/edit');
-    $this->htmlOutput();
-
+    // We should be able to transition the child from trash to unpublished.
     $this->drupalLogin($this->user);
     $this->drupalGet('node/' . $child->id() . '/edit');
     $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
     $this->getCurrentPage()->pressButton('Save');
-
-    $this->htmlOutput();
-
-    // $this->user->addRole('administrator');
-    // $this->user->save();
-    // $this->drupalGet('node/' . $child->id() . '/edit');
-    // $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
-    // $this->getCurrentPage()->pressButton('Save');
-    // $this->htmlOutput();
-
-
-    // $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
-
-    // die();
-
-
+    $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
   }
 
 }

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -35,39 +35,56 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
     $node_parent_org = $this->createNode([
       'type' => 'org_page',
       'title' => 'Test Parent Organization',
+      'field_sub_title' => $this->randomString(20),
       'uid' => $this->user->id(),
       'moderation_state' => MassModeration::PUBLISHED,
     ]);
-    $node_child_org_1 = $this->createNode([
+
+    $this->createNode([
       'type' => 'org_page',
-      'title' => 'Test Child Organization 1',
+      'title' => 'Test Child Organization - 1',
       'uid' => $this->user->id(),
       'moderation_state' => MassModeration::PUBLISHED,
       'field_primary_parent' => $node_parent_org->id(),
     ]);
 
+    $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child Organization - 2',
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::UNPUBLISHED,
+      'field_primary_parent' => $node_parent_org->id(),
+    ]);
+
     $this->drupalLogin($this->user);
+
+    $this->visit($node_parent_org->toUrl()->toString() . '/move-children');
+    $this->htmlOutput();
+
     $this->visit($node_parent_org->toUrl()->toString() . '/edit');
     $this->assertEquals($this->getSession()->getStatusCode(), 200);
     $page = $this->getSession()->getPage();
     $page->selectFieldOption('edit-moderation-state-0-state', 'Unpublished');
     $page->pressButton('edit-submit');
     $page_contents = $page->getContent();
-    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 1 child:';
+
+    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 1 published child:';
     $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
-    $node_child_org_2 = $this->createNode([
+
+    $this->createNode([
       'type' => 'org_page',
-      'title' => 'Test Child Organization 2',
+      'title' => 'Test Child Organization 3',
       'uid' => $this->user->id(),
       'moderation_state' => MassModeration::PUBLISHED,
       'field_primary_parent' => $node_parent_org->id(),
     ]);
+
     $this->visit($node_parent_org->toUrl()->toString() . '/edit');
     $page = $this->getSession()->getPage();
     $page->selectFieldOption('edit-moderation-state-0-state', 'Trash');
     $page->pressButton('edit-submit');
     $page_contents = $page->getContent();
-    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 2 children:';
+    $validation_text = 'This content cannot be unpublished or trashed because it is a parent of 2 published children:';
     $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
   }
 

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -22,7 +22,8 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
   protected function setUp() {
     parent::setUp();
     $user = User::create(['name' => $this->randomMachineName()]);
-    $user->addRole('editor');
+    $user->addRole('content_team');
+    // $user->addRole('administrator');
     $user->activate();
     $user->save();
     $this->user = $user;
@@ -31,7 +32,7 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
   /**
    * Assert that the validation works properly.
    */
-  public function testUnpublishParentValidation() {
+  public function no_testUnpublishParentValidation() {
     $node_parent_org = $this->createNode([
       'type' => 'org_page',
       'title' => 'Test Parent Organization',
@@ -88,4 +89,68 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
     $this->assertStringContainsString($validation_text, $page_contents, 'Validation message not found.');
   }
 
+  public function testSomething() {
+
+    $parent = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Parent Organization',
+      'field_sub_title' => $this->randomString(20),
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::UNPUBLISHED,
+    ]);
+
+    $child = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child Organization - 1' . __FUNCTION__,
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::TRASH,
+      'field_primary_parent' => $parent->id(),
+    ]);
+
+
+    // If I trash a child,
+
+    // then unpublish the parent
+
+
+    // $parent->moderation_state = MassModeration::UNPUBLISHED;
+    // $parent->save();
+
+
+
+    // which has no other children,
+
+    // I cannot transition the trashed child to unpublished because
+    // it knows that the parent is unpublished.
+
+
+    // $this->htmlOutput('AHORA!');
+
+    $this->htmlOutput();
+    $this->drupalGet('user/'. $this->user->id() . '/edit');
+    $this->htmlOutput();
+
+    $this->drupalLogin($this->user);
+    $this->drupalGet('node/' . $child->id() . '/edit');
+    $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
+    $this->getCurrentPage()->pressButton('Save');
+
+    $this->htmlOutput();
+
+    // $this->user->addRole('administrator');
+    // $this->user->save();
+    // $this->drupalGet('node/' . $child->id() . '/edit');
+    // $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
+    // $this->getCurrentPage()->pressButton('Save');
+    // $this->htmlOutput();
+
+
+    // $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
+
+    // die();
+
+
+  }
+
 }
+

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishParentConstraintTest.php
@@ -14,6 +14,11 @@ class UnpublishParentConstraintTest extends ExistingSiteBase {
 
   use LoginTrait;
 
+  /**
+   * The user to log in and test the functionality.
+   *
+   * @var \Drupal\user\Entity\User
+   */
   private $user;
 
   /**

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
@@ -14,7 +14,11 @@ class UnpublishedEntitiesCanBeReferencedTest extends ExistingSiteBase {
 
   use LoginTrait;
 
-  /** @var \Drupal\user\Entity\User */
+  /**
+   * The user to log in and test the functionality.
+   *
+   * @var \Drupal\user\Entity\User
+   */
   private $user;
 
   /**
@@ -76,4 +80,3 @@ class UnpublishedEntitiesCanBeReferencedTest extends ExistingSiteBase {
   }
 
 }
-

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
@@ -56,7 +56,8 @@ class UnpublishedEntitiesCanBeReferencedTest extends ExistingSiteBase {
 
     // We should be able to transition the child from trash to unpublished.
     // Check cotent administrators.
-    $this->user->addRole('cotent_team');
+    $this->user->addRole('content_team');
+    $this->user->save();
     $this->drupalGet('node/' . $child->id() . '/edit');
     $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
     $this->getCurrentPage()->pressButton('Save');
@@ -66,6 +67,7 @@ class UnpublishedEntitiesCanBeReferencedTest extends ExistingSiteBase {
     // We should be able to transition the child from trash to unpublished.
     // Check editors.
     $this->user->addRole('editor');
+    $this->user->save();
     $this->drupalGet('node/' . $child->id() . '/edit');
     $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
     $this->getCurrentPage()->pressButton('Save');

--- a/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
+++ b/docroot/modules/custom/mass_validation/tests/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\Tests\mass_validation\ExistingSite;
+
+use Drupal\mass_content_moderation\MassModeration;
+use Drupal\user\Entity\User;
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+use weitzman\LoginTrait\LoginTrait;
+
+/**
+ * Class UnpublishParentConstraintTest.
+ */
+class UnpublishedEntitiesCanBeReferencedTest extends ExistingSiteBase {
+
+  use LoginTrait;
+
+  /** @var \Drupal\user\Entity\User */
+  private $user;
+
+  /**
+   * Create the user.
+   */
+  protected function setUp() {
+    parent::setUp();
+    $user = User::create(['name' => $this->randomMachineName()]);
+    $user->activate();
+    $user->save();
+    $this->user = $user;
+  }
+
+  /**
+   * Test that unpublished entities can be referenced for editor & content_team.
+   */
+  public function testUnpublishedEntitiesCanBeReferenced() {
+
+    // An unpublished parent.
+    // No other children.
+    $parent = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Parent Organization',
+      'field_sub_title' => $this->randomString(20),
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::UNPUBLISHED,
+    ]);
+
+    // A child in trash.
+    $child = $this->createNode([
+      'type' => 'org_page',
+      'title' => 'Test Child Organization - 1' . __FUNCTION__,
+      'uid' => $this->user->id(),
+      'moderation_state' => MassModeration::TRASH,
+      'field_primary_parent' => $parent->id(),
+    ]);
+
+    $this->drupalLogin($this->user);
+
+    // We should be able to transition the child from trash to unpublished.
+    // Check cotent administrators.
+    $this->user->addRole('cotent_team');
+    $this->drupalGet('node/' . $child->id() . '/edit');
+    $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
+    $this->user->removeRole('cotent_team');
+
+    // We should be able to transition the child from trash to unpublished.
+    // Check editors.
+    $this->user->addRole('editor');
+    $this->drupalGet('node/' . $child->id() . '/edit');
+    $this->getCurrentPage()->selectFieldOption('Change to', MassModeration::UNPUBLISHED);
+    $this->getCurrentPage()->pressButton('Save');
+    $this->assertSession()->pageTextNotMatches('/This entity \(node: .*\) cannot be referenced./');
+    $this->user->removeRole('editor');
+  }
+
+}
+


### PR DESCRIPTION
**Description:**
      - Unpublished children of a node are ignored when unpublishing a parent.
      - A node cannot be published if its parent is not published.

### Screnshot
![image](https://user-images.githubusercontent.com/3916979/148451245-143f64d7-f009-4686-bd99-cccdb8bb8ace.png)


**Jira:** (Skip unless you are MA staff)
DP-23763


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
