### PR TITLE
Added conditional field JS for events - DP-23943

### DIFF
--- a/changelogs/DP-23943.yml
+++ b/changelogs/DP-23943.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed address type conditional field validation on events.
+    issue: DP-23943

--- a/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
+++ b/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
@@ -210,4 +210,26 @@
     }
   };
 
+  /**
+   * Conditional fields on events.
+   *
+   * Make administrative area optional when unique option unchecked.
+   */
+  Drupal.behaviors.eventsConditional = {
+    attach: function (context) {
+      $('.field--name-field-event-address-type', context).change(function () {
+        var addressTypeUniqueChecked = $('#edit-field-event-address-type-unique').prop('checked') !== false;
+        $('.field--name-field-address-address').each(function() {
+          $(this).find('.administrative-area').each(function() {
+            if (!addressTypeUniqueChecked) {
+              $(this).removeAttr('required');
+            } else {
+              $(this).attr('required', 'required');
+            }
+          });
+        });
+      }).change();
+    }
+  }
+
 })(jQuery, Drupal);

--- a/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
+++ b/docroot/themes/custom/mass_admin_theme/js/conditional-fields.js
@@ -219,17 +219,18 @@
     attach: function (context) {
       $('.field--name-field-event-address-type', context).change(function () {
         var addressTypeUniqueChecked = $('#edit-field-event-address-type-unique').prop('checked') !== false;
-        $('.field--name-field-address-address').each(function() {
-          $(this).find('.administrative-area').each(function() {
+        $('.field--name-field-address-address').each(function () {
+          $(this).find('.administrative-area').each(function () {
             if (!addressTypeUniqueChecked) {
               $(this).removeAttr('required');
-            } else {
+            }
+            else {
               $(this).attr('required', 'required');
             }
           });
         });
       }).change();
     }
-  }
+  };
 
 })(jQuery, Drupal);


### PR DESCRIPTION
**Description:**
This change creates a Drupal behavior to remove the required attribute from the administrative area select field when the "Unique address" option is not selected for the "Address type" field on Events. The Conditional Fields module was not used to address this issue because it did not clear the "required" attribute for the administrative area select list. Although this seems like an old bug that since been addressed in the module, it seems to not be working in this case. Further investigation would be required to determine if a fix is required in the module that I don't think is quite worth the effort in this case, so I opted for handling this in the existing our existing conditional-fields.js file.

**Jira:** (Skip unless you are MA staff)
DP-23943


**To Test:**
- [ ] Edit an event node with a unique address field filled in.
- [ ] Remove address details and set to another address option, such as "Address from contact information item" (and also fill in "Address from contact information item")
- [ ] Save. The save should be successful. If you test in staging or another environment without this change, the save will be unsuccessful.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
