### PR TITLE
Output safe value for person node preview cards - DP-23964

### DIFF
--- a/changelogs/DP-23964.yml
+++ b/changelogs/DP-23964.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Output safe value for person short bio fields on org pages.
+    issue: DP-23964

--- a/docroot/themes/custom/mass_theme/templates/content/node--person--preview-card.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--person--preview-card.html.twig
@@ -89,7 +89,7 @@
 {% set is_featured_board_member = node.person_is_featured.value %}
 
 {% set name = node.field_person_first_name.value ~ ' ' ~ node.field_person_last_name.value %}
-{% set short_bio = node.field_short_bio.value %}
+{% set short_bio = node.field_short_bio.safe_value %}
 {% set role = node.field_person_role_title.value %}
 {% set show_image = true %}
 


### PR DESCRIPTION
**Description:**
Fixes errors discovered in Behat tests on org pages.


**Jira:** (Skip unless you are MA staff)
DP-23964


**To Test:**
- [ ] Check that Behat tests pass.
- [ ] Check that person nodes on org pages still display like they do on production: orgs/parkinsons-disease-registry-and-advisory-committee


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
