### PR TITLE
Update ahoy pull so it works with latest Docker Desktop and DDEV.

### DIFF
--- a/changelogs/DP-24000.yml
+++ b/changelogs/DP-24000.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Update Ahoy pull for latest DDEV
+    issue: DP-24000

--- a/docker.ahoy.yml
+++ b/docker.ahoy.yml
@@ -12,7 +12,7 @@ commands:
   stop:
     cmd: ddev pause "$@"
   pull:
-    cmd: ahoy down && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml pull && ahoy up
+    cmd: ddev delete --omit-snapshot -y && ahoy up
   refresh:
     cmd: ahoy exec "scripts/ma-refresh-local -dpo && vendor/bin/drush sql:sanitize -y"
   updatedb:

--- a/docker.ahoy.yml
+++ b/docker.ahoy.yml
@@ -12,7 +12,7 @@ commands:
   stop:
     cmd: ddev pause "$@"
   pull:
-    cmd: ahoy down && docker-compose -f .ddev/.ddev-docker-compose-full.yaml pull && ahoy up
+    cmd: ahoy down && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml pull && ahoy up
   refresh:
     cmd: ahoy exec "scripts/ma-refresh-local -dpo && vendor/bin/drush sql:sanitize -y"
   updatedb:


### PR DESCRIPTION
**Description:**
Please update to latest DDEV before using this. Updating Docker Desktop is not necessary.


**Jira:** (Skip unless you are MA staff)
https://massgov.atlassian.net/browse/DP-24000


**To Test:**
- [ ] Update DDEV and run `ahoy pull` successfully

**Communication**
- [ ] After merge, announce in SSR channel: "Due to recent changes in Docker Desktop, please update DDEV in order to keep using `ahoy pull`. See https://ddev.readthedocs.io/en/stable/#installation."

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
