### PR TITLE
DP-24018 promo page header fix

### DIFF
--- a/changelogs/DP-24018.yml
+++ b/changelogs/DP-24018.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix the halfImage check bug that results in overlapping content on promo page.
+    issue: DP-24018

--- a/composer.json
+++ b/composer.json
@@ -247,7 +247,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-24018-fix-key-message-margin",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -247,7 +247,7 @@
         "friends-of-behat/mink-debug-extension": "^2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-24018-fix-key-message-margin",
+        "massgov/mayflower-artifacts": "dev-develop",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c98e2889a37763ae0373cf065ac7183",
+    "content-hash": "20fd7bdad928ef57407b4bfbb21224a7",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12130,16 +12130,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-24018-fix-key-message-margin",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "eb785f334e04e80f94570147bac9ea5415a37053"
+                "reference": "db4f7db2c3b75ee6923b45e54a8d6f507aabedab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/eb785f334e04e80f94570147bac9ea5415a37053",
-                "reference": "eb785f334e04e80f94570147bac9ea5415a37053",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/db4f7db2c3b75ee6923b45e54a8d6f507aabedab",
+                "reference": "db4f7db2c3b75ee6923b45e54a8d6f507aabedab",
                 "shasum": ""
             },
             "require": {
@@ -12159,9 +12159,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-24018-fix-key-message-margin"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2022-02-03T18:42:07+00:00"
+            "time": "2022-02-03T20:25:13+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20fd7bdad928ef57407b4bfbb21224a7",
+    "content-hash": "5c98e2889a37763ae0373cf065ac7183",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12130,16 +12130,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-24018-fix-key-message-margin",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "97e45c405cc99005630771d4fdf1c99dc53ee1ec"
+                "reference": "eb785f334e04e80f94570147bac9ea5415a37053"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/97e45c405cc99005630771d4fdf1c99dc53ee1ec",
-                "reference": "97e45c405cc99005630771d4fdf1c99dc53ee1ec",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/eb785f334e04e80f94570147bac9ea5415a37053",
+                "reference": "eb785f334e04e80f94570147bac9ea5415a37053",
                 "shasum": ""
             },
             "require": {
@@ -12159,9 +12159,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-24018-fix-key-message-margin"
             },
-            "time": "2022-01-27T15:11:38+00:00"
+            "time": "2022-02-03T18:42:07+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fixed: https://pr1331-mgvfpec2jfu0ptkdgbjorskdehn5bylq.tugboat.qa/respectfully

<img width="1186" alt="Screen Shot 2022-02-02 at 4 18 34 PM" src="https://user-images.githubusercontent.com/5789411/152411187-493ac1ea-e108-4763-a606-4998f6ea7357.png">

The margin top is set correctly