### PR TITLE
Added followup fix for signees adding state orgs to existing news items - DP-24139

### DIFF
--- a/changelogs/DP-24139.yml
+++ b/changelogs/DP-24139.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed adding state org signees for existing news items.
+    issue: DP-24139

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -627,7 +627,7 @@ function mass_utility_field_widget_form_alter(&$element, FormStateInterface $for
  */
 function mass_utility_form_node_news_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   foreach ($form['field_news_signees']['widget'] as $delta => $widget) {
-    if (is_numeric($delta)) {
+    if (is_numeric($delta) && !empty($form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'])) {
       if ($original_path = $form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'][0]['value']['#default_value']) {
         $image_path = file_create_url($original_path);
         $form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'][0]['#prefix'] = '<p><div class="photo-preview"><img src=' . $image_path . '/></div></p>';

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -628,9 +628,7 @@ function mass_utility_field_widget_form_alter(&$element, FormStateInterface $for
 function mass_utility_form_node_news_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   foreach ($form['field_news_signees']['widget'] as $delta => $widget) {
     if (is_numeric($delta)) {
-      if (!empty($form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url'])) {
-        $element = $form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'][0]['value'];
-        $original_path = $element['#default_value'];
+      if ($original_path = $form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'][0]['value']['#default_value']) {
         $image_path = file_create_url($original_path);
         $form['field_news_signees']['widget'][$delta]['subform']['field_state_org_photo_url']['widget'][0]['#prefix'] = '<p><div class="photo-preview"><img src=' . $image_path . '/></div></p>';
       }

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -195,5 +195,5 @@ if(isset($_ENV['AH_SITE_ENVIRONMENT'])) {
 
 // phpunit.xml.dist sets -1 for memory_limit so just change for other cli requests.
 if (PHP_SAPI === 'cli' && ini_get('memory_limit')) {
-  ini_set('memory_limit', '1536M');
+  ini_set('memory_limit', '2048M');
 }


### PR DESCRIPTION
**Description:**
See ticket for more details

**Jira:** (Skip unless you are MA staff)
DP-24139


**To Test:**

***Existing items***
- [ ] Go to https://mass.local/news/notice-of-openings-on-the-supreme-judicial-court-standing-committee-on-pro-bono-legal-services or https://mass.local/news/jury-trials-to-resume-february-14-2022 and edit
- [ ] Add a state organization
- [ ] Edit an existing state organization

***New items***
- [ ] Create new News item
- [ ] Go to Signees tab.
- [ ] Click “Add state organization” under signees
- [ ] Type “Supreme Judicial Court” in the Related organization field.
- [ ] Select the item in auto select.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
