### PR TITLE
DP-24221 Fix ddev binding to reserved port 88

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -7,8 +7,8 @@ dbimage: massgov/mysql-sanitized:super
 omit_containers:
   - db
 disable_settings_management: true
-#Avoid conflict on port 80. This is rarely used anyway.
-router_http_port: "88"
+# Avoid conflict on port 80. This is rarely used anyway.
+router_http_port: "81"
 router_https_port: "443"
 xdebug_enabled: false
 project_tld: local

--- a/changelogs/DP-24221.yml
+++ b/changelogs/DP-24221.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Fix ddev binding to reserved port 88
+    issue: DB-24221


### PR DESCRIPTION
**Description:**

Port 88 is in use on macOS 12.2, breaking `ddev start`.


**Jira:** (Skip unless you are MA staff)
DP-24221


**To Test:**
- [ ] Pull this branch, and run `ddev restart`


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
