### PR TITLE
DP-24231 Build an image instead of post-start hooks to speed up restarts

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -38,15 +38,5 @@ web_environment:
   - CLOUDFLARE_EMAIL
   - CLOUDFLARE_TOKEN
 hooks:
-  post-start:
-    # Tugboat CLI
-    - exec: curl https://dashboard.tugboat.qa/cli/linux/tugboat.tar.gz > tugboat.tar.gz
-    - exec: tar -zxf tugboat.tar.gz -C /usr/local/bin/ && rm -f tugboat.tar.gz
-    # CicleCI CLI
-    - exec: curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
-    # gh install is too slow to be enabled by default as we dont need it. Uncomment or copy to personal config if needed.
-    # - exec: curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-    # - exec: echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-    # - exec: sudo apt update
-    # - exec: sudo apt install gh
-
+  pre-start:
+    - exec-host: echo "No output is shown during the first container build. It may take a minute to install Tugboat, CircleCI, and GitHub CLI tools."

--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -1,0 +1,15 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+# Install Tugboat CLI.
+RUN curl https://dashboard.tugboat.qa/cli/linux/tugboat.tar.gz > tugboat.tar.gz && \
+  tar -zxf tugboat.tar.gz -C /usr/local/bin/ && rm -f tugboat.tar.gz
+
+# Install CircleCI CLI.
+RUN curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
+
+# Install GitHub CLI.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+  sudo apt update && \
+  sudo apt install gh


### PR DESCRIPTION
**Description:**
While testing #1388 I noticed that the tugboat CLI and other tools were downloaded on every restart. That was adding 20-30 seconds of startup time for me. By switching to a Dockerfile, docker will cache the built web image for us, even across `ddev delete`.

The only downside is ddev isn't showing output during the `docker build` process, so I left a note as a warning.

**Jira:** (Skip unless you are MA staff)
DP-24231

**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
