### PR TITLE
DP-24242 Stem search queries in All Collections view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -253,7 +253,8 @@
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1",
-        "vlucas/phpdotenv": "^2.4"
+        "vlucas/phpdotenv": "^2.4",
+        "wamania/php-stemmer": "^3.0"
     },
     "require-dev": {
         "behat/behat": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a39ebcb252caecdcb54eb169c850b945",
+    "content-hash": "bf5ef72269a826c17771a910ce7e4e89",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -17350,6 +17350,228 @@
             "time": "2020-05-02T13:38:00+00:00"
         },
         {
+            "name": "voku/portable-ascii",
+            "version": "1.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-ascii.git",
+                "reference": "80953678b19901e5165c56752d087fc11526017c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
+                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+            },
+            "suggest": {
+                "ext-intl": "Use Intl for transliterator_transliterate() support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable ASCII library - performance optimized (ascii) string functions for php.",
+            "homepage": "https://github.com/voku/portable-ascii",
+            "keywords": [
+                "ascii",
+                "clean",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-ascii/issues",
+                "source": "https://github.com/voku/portable-ascii/tree/1.5.6"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-ascii",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-ascii",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-12T00:07:28+00:00"
+        },
+        {
+            "name": "voku/portable-utf8",
+            "version": "5.4.51",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/voku/portable-utf8.git",
+                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/578f5266725dc9880483d24ad0cfb39f8ce170f7",
+                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "symfony/polyfill-iconv": "~1.0",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php72": "~1.0",
+                "voku/portable-ascii": "~1.5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+            },
+            "suggest": {
+                "ext-ctype": "Use Ctype for e.g. hexadecimal digit detection",
+                "ext-fileinfo": "Use Fileinfo for better binary file detection",
+                "ext-iconv": "Use iconv for best performance",
+                "ext-intl": "Use Intl for best performance",
+                "ext-json": "Use JSON for string detection",
+                "ext-mbstring": "Use Mbstring for best performance"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "voku\\": "src/voku/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "(Apache-2.0 or GPL-2.0)"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Hamid Sarfraz",
+                    "homepage": "http://pageconfig.com/"
+                },
+                {
+                    "name": "Lars Moelleken",
+                    "homepage": "http://www.moelleken.org/"
+                }
+            ],
+            "description": "Portable UTF-8 library - performance optimized (unicode) string functions for php.",
+            "homepage": "https://github.com/voku/portable-utf8",
+            "keywords": [
+                "UTF",
+                "clean",
+                "php",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "issues": "https://github.com/voku/portable-utf8/issues",
+                "source": "https://github.com/voku/portable-utf8/tree/5.4.51"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/portable-utf8",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-utf8",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-02T01:58:49+00:00"
+        },
+        {
+            "name": "wamania/php-stemmer",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wamania/php-stemmer.git",
+                "reference": "eab7b93465eb3d5da372806c8e1b01da5766aea5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wamania/php-stemmer/zipball/eab7b93465eb3d5da372806c8e1b01da5766aea5",
+                "reference": "eab7b93465eb3d5da372806c8e1b01da5766aea5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "voku/portable-utf8": "^5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Wamania\\Snowball\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Wamania",
+                    "homepage": "http://wamania.com"
+                }
+            ],
+            "description": "Native PHP Stemmer",
+            "keywords": [
+                "php",
+                "porter",
+                "stemmer"
+            ],
+            "support": {
+                "issues": "https://github.com/wamania/php-stemmer/issues",
+                "source": "https://github.com/wamania/php-stemmer/tree/v3.0.0"
+            },
+            "time": "2021-08-17T18:16:34+00:00"
+        },
+        {
             "name": "webflo/drupal-finder",
             "version": "1.2.2",
             "source": {
@@ -21898,5 +22120,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/conf/drupal/config/views.view.collection_all.yml
+++ b/conf/drupal/config/views.view.collection_all.yml
@@ -720,6 +720,8 @@ display:
               campaign_landing_page_publisher: '0'
               d2d_redirect_manager: '0'
               external_data_resource_manager: '0'
+              data_administrator: '0'
+              collection_administrator: '0'
             placeholder: ''
             autocomplete_filter: 0
             autocomplete_min_chars: '0'
@@ -727,6 +729,7 @@ display:
             autocomplete_raw_suggestion: 1
             autocomplete_raw_dropdown: 1
             autocomplete_dependent: 0
+            stem_query: 1
           is_grouped: false
           group_info:
             label: ''
@@ -940,6 +943,7 @@ display:
         - 'config:core.entity_view_display.node.news.default'
         - 'config:core.entity_view_display.node.news.link_and_description'
         - 'config:core.entity_view_display.node.news.link_only'
+        - 'config:core.entity_view_display.node.news.listing'
         - 'config:core.entity_view_display.node.news.press_teaser'
         - 'config:core.entity_view_display.node.news.teaser'
         - 'config:core.entity_view_display.node.news.token'
@@ -1145,6 +1149,7 @@ display:
         - 'config:core.entity_view_display.node.news.default'
         - 'config:core.entity_view_display.node.news.link_and_description'
         - 'config:core.entity_view_display.node.news.link_only'
+        - 'config:core.entity_view_display.node.news.listing'
         - 'config:core.entity_view_display.node.news.press_teaser'
         - 'config:core.entity_view_display.node.news.teaser'
         - 'config:core.entity_view_display.node.news.token'

--- a/conf/drupal/config/views.view.data_listing_all.yml
+++ b/conf/drupal/config/views.view.data_listing_all.yml
@@ -1031,6 +1031,7 @@ display:
             autocomplete_raw_suggestion: 1
             autocomplete_raw_dropdown: 1
             autocomplete_dependent: 0
+            stem_query: 1
           is_grouped: false
           group_info:
             label: ''

--- a/conf/drupal/config/views.view.data_listing_topic.yml
+++ b/conf/drupal/config/views.view.data_listing_topic.yml
@@ -1080,6 +1080,7 @@ display:
             autocomplete_raw_suggestion: 1
             autocomplete_raw_dropdown: 1
             autocomplete_dependent: 0
+            stem_query: 1
           is_grouped: false
           group_info:
             label: ''

--- a/docroot/modules/custom/mass_views/mass_views.module
+++ b/docroot/modules/custom/mass_views/mass_views.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Drupal\mass_views\Plugin\views\filter\StemmableCombineFilter;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -170,4 +171,11 @@ function mass_views_views_query_alter(ViewExecutable $view, QueryPluginBase $que
       _redirect_recursively_alter_query_conditions($condition_group['conditions'], $query, $key_group_conditions);
     }
   }
+}
+
+/**
+ * Implements hook_views_plugins_filter_alter().
+ */
+function mass_views_views_plugins_filter_alter(array &$plugins) {
+  $plugins['views_autocomplete_filters_combine']['class'] = StemmableCombineFilter::class;
 }

--- a/docroot/modules/custom/mass_views/src/Plugin/views/filter/StemmableCombineFilter.php
+++ b/docroot/modules/custom/mass_views/src/Plugin/views/filter/StemmableCombineFilter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mass_views\Plugin\views\filter;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\views_autocomplete_filters\Plugin\views\filter\ViewsAutocompleteFiltersCombine;
+use Wamania\Snowball\StemmerManager;
+
+class StemmableCombineFilter extends ViewsAutocompleteFiltersCombine {
+
+  public function defineOptions() {
+    $options = parent::defineOptions();
+    $options['expose']['contains']['stem_query'] = ['default' => FALSE];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultExposeOptions() {
+    parent::defaultExposeOptions();
+    $this->options['expose']['stem_query'] = FALSE;
+  }
+
+  public function buildExposeForm(&$form, FormStateInterface $form_state) {
+    parent::buildExposeForm($form, $form_state);
+
+    $form['expose']['stem_query'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Stem the search query to return more inexact results'),
+      '#description' => $this->t('@todo: Link to upstream docs on the porter-stemmer algorithm'),
+      '#default_value' => $this->options['expose']['stem_query'],
+    ];
+  }
+
+  public function query() {
+    if (isset($this->options['expose']['stem_query']) && $this->options['expose']['stem_query']) {
+      $manager = new StemmerManager();
+      $this->value = $manager->stem($this->value, 'en');
+    }
+    parent::query();
+  }
+
+}


### PR DESCRIPTION
**Description:**
This is very rough, but works! Before this branch searching for `content filters`:

<img width="1246" alt="Screen Shot 2022-03-09 at 8 17 17 PM" src="https://user-images.githubusercontent.com/255023/157568397-b79a6242-8924-4f4a-9c6b-1a77f14ef5f7.png">

On this branch:

<img width="1243" alt="Screen Shot 2022-03-09 at 8 17 01 PM" src="https://user-images.githubusercontent.com/255023/157568426-df2122a2-1398-47d6-83c8-2a99b77e0762.png">

It'd been a while since I wrote a Views plugin, so of course I started with "let's decorate the string filter plugin". Then I ran into the Views class hierarchy twice! Once, to make it work for the Combine filter, then again to make it work for views autocomplete filters. So really, I'd like this to be a contrib module, but it would require some work to make it work with all the different classes in the tree.

**Jira:** (Skip unless you are MA staff)
DP-24242


**To Test:**
- [ ] Play around with searches and compare to production. Let's see if they're better or worse.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
