### PR TITLE
DP-23508 Check Dotenv is present before loading classes

### DIFF
--- a/changelogs/DP-23508-3.yml
+++ b/changelogs/DP-23508-3.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Don't load Dotenv package on Acquia environments
+    issue: DP-23508

--- a/early.composer.php
+++ b/early.composer.php
@@ -8,6 +8,7 @@
 
 use Dotenv\Dotenv;
 use Dotenv\Exception\InvalidPathException;
+use Webmozart\PathUtil\Path;
 
 loadEnv();
 
@@ -15,11 +16,15 @@ loadEnv();
  * Load any .env file. See /.env.example.
  */
 function loadEnv() {
-  $dotenv = new Dotenv(\Webmozart\PathUtil\Path::join(__DIR__, '.ddev'));
-  try {
-    $dotenv->load();
-  }
-  catch (InvalidPathException $e) {
-    // Do nothing. Only local dev environments have .env files.
+  // The Dotenv package is only included on development environments.
+  /** @noinspection ClassConstantCanBeUsedInspection */
+  if (class_exists('\Dotenv\Dotenv')) {
+    $dotenv = new Dotenv(Path::join(__DIR__, '.ddev'));
+    try {
+      $dotenv->load();
+    }
+    catch (InvalidPathException $e) {
+      // Do nothing. Only local dev environments have .env files.
+    }
   }
 }


### PR DESCRIPTION
**Description:**
Acquia environments are being set up with `--no-dev`, but our dotenv setup was unconditionally loading the class.


**Jira:** (Skip unless you are MA staff)
DP-23508


**To Test:**
- [ ] Andrew will deploy this to Acquia's test environment to confirm it builds.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
