### PR TITLE
DP-9177 [a11y] Rules of Court

### DIFF
--- a/changelogs/DP-9177.yml
+++ b/changelogs/DP-9177.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Add contextual info to comp headings in rules of court.
+    issue: DP-9177

--- a/composer.json
+++ b/composer.json
@@ -248,7 +248,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-9177_a11y-rules-of-court-header",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "748b186f3a2998e564b667de992f3b99",
+    "content-hash": "31d537251471123274a49e76b2dd8663",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11412,16 +11412,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-9177_a11y-rules-of-court-header",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "cca822c322057dd6cd629db86a3e8976870c6f25"
+                "reference": "48e516e12e982f62adf63ed88beb16c372ee364b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/cca822c322057dd6cd629db86a3e8976870c6f25",
-                "reference": "cca822c322057dd6cd629db86a3e8976870c6f25",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/48e516e12e982f62adf63ed88beb16c372ee364b",
+                "reference": "48e516e12e982f62adf63ed88beb16c372ee364b",
                 "shasum": ""
             },
             "require": {
@@ -11441,9 +11441,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-9177_a11y-rules-of-court-header"
             },
-            "time": "2022-04-05T16:59:11+00:00"
+            "time": "2022-04-11T19:05:05+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -2681,9 +2681,11 @@ function mass_theme_preprocess_node_rules(&$variables) {
   // Build contact section, if field is populated.
   if (Helper::isFieldPopulated($node, $fields['contact'])) {
     // Set up options for contact list.
+    $titleContext = t(' for @title', ['@title' => $node->getTitle()]);
     $contactList_options = [
       'heading' => [
         'title' => t("Contact"),
+        'titleContext' => $titleContext,
         'id' => 'contact',
       ],
       'groups' => [
@@ -2706,6 +2708,7 @@ function mass_theme_preprocess_node_rules(&$variables) {
     $sideContent['contactList'] = Organisms::prepareContactList($node, $sidebarContacts_options);
     unset($sideContent['contactList']['compHeading']);
     $sideContent['contactList']['sidebarHeading']['title'] = t('Contact');
+    $sideContent['contactList']['sidebarHeading']['titleContext'] = $titleContext;
     $sideContent['contactList']['viewSpecific'] = TRUE;
   }
 


### PR DESCRIPTION
**Description:**

- [[MF template change](https://github.com/massgov/mayflower/pull/1617)] Make the page category info tie to the page title for assistive technology.  Screen readers announce it along with the page title.
- [Drupal change] Add contextual info to the comp headings for the contact for screen reader users.  The related already has the contextual info. Omit the event listing for now.


**Jira:** (Skip unless you are MA staff)
DP-9177


**To Test:**
- [ ] Go to **/electronic-filing-rules/qa-rules-of-court** or any rules of court page.
- [ ] Check the source for the page heading area to confirm the [MF template change](https://github.com/massgov/mayflower/pull/1617) is reflected as shown below.
```
<section class="ma__page-header ma__page-header--has-optional-content">
  <div class="ma__page-header__content">
    <div id="page-category" aria-hidden="true">
      <div class="ma__page-header__category">
        <span class="visually-hidden">This page is under the category of </span>
        Electronic Filing Rules
      </div>
      <div class="ma__page-header__subCategory">
        <span class="visually-hidden">the sub category of </span>
        subheading
      </div>
    </div>

    <h1 class="ma__page-header__title" aria-describedby="page-category">_QA rules of court</h1>
  </div>
</section>
```
- [ ] Check the comp headings "Contact" in the main and side columns in the source to see they have their contextual info as visually hidden text.
```
<h2 class="ma__comp-heading    " id="" tabindex="-1">
  Contact
  <span class="visually-hidden">  for _QA rules of court</span>
</h2>
```

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
