### PR TITLE
Hotfix/0.319.2 Chunk URLs in our custom purger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.319.2] - April 21, 2022
 
 ### Changed
-- DP-24428: Chunk URLs in our custom purger
+- DP-24428: Chunk URLs in our custom purger.
 
 ## [0.319.1] - April 5, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [0.319.0] - April 5, 2022
+## [0.319.2] - April 21, 2022
+
+### Changed
+- DP-24428: Chunk URLs in our custom purger
+
+## [0.319.1] - April 5, 2022
 
 ### Fixed
 - DP-24237: json_encode() needs numeric indices without holes (custom Akamai purger)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.319.2] - April 21, 2022
 
 ### Changed
-- DP-24428: Chunk URLs in our custom purger.
+- DP-24428: Chunk URLs in our custom purger
 
 ## [0.319.1] - April 5, 2022
 


### PR DESCRIPTION
**Description:**
Send 6 URLs at a time to Akamai because of their braindead idea that purge requests need to run through the edge worker.


**Jira:** (Skip unless you are MA staff)
DP-24428


**To Test:**
- [ ] On staging, run these commands
  -  `drush entity:save media  865706` to populate the queue
  -   ` drush pqb` to browse queue. Make sure there are a couple invalidations of type 'Url'
  -  `drush pqw --finish` to work the queue. Look for 100% successes. 
  -  ` drush pqb` should show an empty queue.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
