### PR TITLE
Fix ahoy pull (devs getting latest DB)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -37,3 +37,5 @@ web_environment:
 hooks:
   pre-start:
     - exec-host: echo "No output is shown during the first container build. It may take a minute to install Tugboat, CircleCI, and GitHub CLI tools."
+  post-stop:
+    - exec-host: echo "The database has been reset to a pristine state. If you didn't mean this, next time use ddev pause instead."

--- a/.ddev/docker-compose.dbmass.yaml
+++ b/.ddev/docker-compose.dbmass.yaml
@@ -20,10 +20,6 @@ services:
       MYSQL_DATABASE: circle
       MYSQL_RANDOM_ROOT_PASSWORD: 1
     command: --max_allowed_packet=32M --innodb_flush_method=O_DIRECT --tmp_table_size=16M --query_cache_size=16M --innodb-flush-log-at-trx-commit=2  --innodb_buffer_pool_size=500M --innodb_log_buffer_size=64M --skip-innodb_doublewrite --innodb_log_file_size=64M
-    volumes:
-      - dbmass:/var/lib/mysql
   web:
     links:
       - dbmass:dbmass
-volumes:
-  dbmass:

--- a/changelogs/DP-24691.yml
+++ b/changelogs/DP-24691.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix ahoy pull for developers
+    issue: DP-24691


### PR DESCRIPTION
We never had a volume before DDEV so I don't think the reduced persistence will be an issue. Folks can use `ddev pause​​​​​​​` to shut down containers without losing WIP.

**Jira:** (Skip unless you are MA staff)
DP-24691


**To Test:**
- [ ] Assure that `ahoy pull` gets latest content


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
