### PR TITLE
DP-24512 Queue worker to generate a similar titles report

### DIFF
--- a/docroot/modules/custom/mass_admin_pages/drush.services.yml
+++ b/docroot/modules/custom/mass_admin_pages/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  mass_admin_pages.similar_titles:
+    class: \Drupal\mass_admin_pages\Commands\SimilarTitles
+    arguments: ['@entity_type.manager', '@entity.memory_cache', '@state', '@queue']
+    tags:
+      - { name: drush.command }

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.install
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.install
@@ -92,7 +92,6 @@ function mass_admin_pages_update_8002() {
     ],
     'primary key' => [
       'nid',
-      'other_nid',
     ],
   ];
   /** @noinspection NullPointerExceptionInspection */

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.install
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.install
@@ -6,8 +6,95 @@
  */
 
 /**
+ * Implements hook_schema().
+ */
+function mass_admin_pages_schema() {
+  $schema['mass_admin_pages_similar_titles'] = [
+    'description' => 'Stores the similar titles report.',
+    'fields' => [
+      'nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'title' => [
+        'type' => 'varchar',
+        'size' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'other_nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'other_title' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+    ],
+    'primary key' => [
+      'nid',
+      'other_nid',
+    ],
+  ];
+
+  return $schema;
+}
+
+/**
  * Add empty update hook to trigger cache rebuild prior to config import.
  */
 function mass_admin_pages_update_8001() {
   // No-op.
+}
+
+/**
+ * Add a table to store similar titles calculations.
+ */
+function mass_admin_pages_update_8002() {
+  $schema['mass_admin_pages_similar_titles'] = [
+    'description' => 'Stores the similar titles report.',
+    'fields' => [
+      'nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'title' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'other_nid' => [
+        'type' => 'int',
+        'unsigned' => TRUE,
+        'not null' => TRUE,
+        'default' => 0,
+      ],
+      'other_title' => [
+        'type' => 'varchar',
+        'length' => 255,
+        'not null' => TRUE,
+        'default' => '',
+      ],
+      'percent' => [
+        'type' => 'float',
+        'not null' => TRUE,
+        'default' => 0,
+      ]
+    ],
+    'primary key' => [
+      'nid',
+      'other_nid',
+    ],
+  ];
+  /** @noinspection NullPointerExceptionInspection */
+  \Drupal::database()->schema()->createTable('mass_admin_pages_similar_titles', $schema['mass_admin_pages_similar_titles']);
 }

--- a/docroot/modules/custom/mass_admin_pages/src/Commands/SimilarTitles.php
+++ b/docroot/modules/custom/mass_admin_pages/src/Commands/SimilarTitles.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace Drupal\mass_admin_pages\Commands;
+
+use Drupal\Core\Cache\MemoryCache\MemoryCacheInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\State\StateInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Add nodes to be checked for similar titles to identify duplicate content.
+ */
+class SimilarTitles extends DrushCommands {
+
+  public const STATE_KEY = 'mass_admin_pages.similar_node_titles';
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  private EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * @var \Drupal\Core\Cache\MemoryCache\MemoryCacheInterface
+   */
+  private MemoryCacheInterface $entityMemoryCache;
+
+  /**
+   * @var \Drupal\Core\State\StateInterface
+   */
+  private StateInterface $state;
+
+  /**
+   * @var \Drupal\Core\Queue\QueueInterface
+   */
+  private QueueInterface $queue;
+
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, MemoryCacheInterface $entityMemoryCache, StateInterface $state, QueueFactory $queueFactory) {
+    parent::__construct();
+    $this->entityTypeManager = $entityTypeManager;
+    $this->entityMemoryCache = $entityMemoryCache;
+    $this->state = $state;
+    $this->queue = $queueFactory->get('mass_admin_pages.similar_titles');
+  }
+
+  /**
+   * @command ma:similar-titles
+   */
+  public function queue(): void {
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $m */
+    $query = $this->entityTypeManager->getStorage('node')->getQuery();
+
+    // Limit to published nodes of the given content types.
+    $query->condition($this->entityTypeManager->getDefinition('node')->getKey('bundle'), [
+      'campaign_landing',
+      'guide_page',
+      'how_to_page',
+      'info_details',
+      'location',
+      'org_page',
+      'service_details',
+      'service_page',
+      'topic_page',
+    ], 'IN');
+    $query->condition('status', 1);
+    $results = $query->execute();
+
+    // @todo We don't delete node data for nodes that have been unpublished.
+    // Load nodes in groups of 1000 so we can clear the memory cache.
+    $chunked = array_chunk($results, 1000);
+    $node_titles = [];
+    foreach ($chunked as $chunk) {
+      $nodes = $this->entityTypeManager->getStorage('node')
+        ->loadMultiple($chunk);
+      foreach($nodes as $node) {
+        $node_titles[$node->id()] = $node->label();
+      }
+
+      /** @noinspection DisconnectedForeachInstructionInspection */
+      $this->entityMemoryCache->deleteAll();
+    }
+
+    // Since we can't control for edits made after we make the comparison, we
+    // take this opportunity to load all node titles now of matching nodes, and
+    // them save them into state for use by the queue. We don't use cache as
+    // memcache has a limit of 1MB, and we expect this data to be 5-20MB.
+    $this->state->set(self::STATE_KEY, $node_titles);
+
+    // Now, queue the nodes to check. We also group this by 1000 as we don't
+    // really need to process nodes individually.
+    $queue_chunk = array_chunk($node_titles, 1000, TRUE);
+    foreach ($queue_chunk as $chunk) {
+      $this->queue->createItem($chunk);
+    }
+  }
+
+}

--- a/docroot/modules/custom/mass_admin_pages/src/Commands/SimilarTitles.php
+++ b/docroot/modules/custom/mass_admin_pages/src/Commands/SimilarTitles.php
@@ -54,13 +54,7 @@ class SimilarTitles extends DrushCommands {
 
     // Limit to published nodes of the given content types.
     $query->condition($this->entityTypeManager->getDefinition('node')->getKey('bundle'), [
-      'campaign_landing',
-      'guide_page',
       'how_to_page',
-      'info_details',
-      'location',
-      'org_page',
-      'service_details',
       'service_page',
       'topic_page',
     ], 'IN');

--- a/docroot/modules/custom/mass_admin_pages/src/Plugin/QueueWorker/SimilarTitlesWorker.php
+++ b/docroot/modules/custom/mass_admin_pages/src/Plugin/QueueWorker/SimilarTitlesWorker.php
@@ -68,7 +68,9 @@ class SimilarTitlesWorker extends QueueWorkerBase implements ContainerFactoryPlu
         }
         $matching_characters = similar_text($title, $compare_title, $percent);
         if ($percent > 80) {
-          $this->database->upsert('mass_admin_pages_similar_titles')->fields([
+          $this->database->upsert('mass_admin_pages_similar_titles')
+            ->key('nid')
+            ->fields([
             'nid' => $nid,
             'title' => $title,
             'other_nid' => $compare_nid,

--- a/docroot/modules/custom/mass_admin_pages/src/Plugin/QueueWorker/SimilarTitlesWorker.php
+++ b/docroot/modules/custom/mass_admin_pages/src/Plugin/QueueWorker/SimilarTitlesWorker.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\mass_admin_pages\Plugin\QueueWorker;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\State\StateInterface;
+use Drupal\mass_admin_pages\Commands\SimilarTitles;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @see \Drupal\mass_admin_pages\Commands\SimilarTitles
+ *
+ * @QueueWorker(
+ *   id="mass_admin_pages.similar_titles",
+ *   title=@Translation("Similar Titles"),
+ * )
+ */
+class SimilarTitlesWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * @var mixed
+   */
+  private $node_titles;
+
+  /**
+   * @var \Drupal\Core\Database\Connection
+   */
+  private Connection $database;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, StateInterface $state, Connection $database) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->node_titles = $state->get(SimilarTitles::STATE_KEY);
+    $this->database = $database;
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('state'),
+      $container->get('database')
+    );
+  }
+
+  /**
+   * Process the queue item of ~1000 nodes.
+   *
+   * This is somewhat of an expensive operation because we have to compare every
+   * single node against every single other node. We could consider filtering
+   * this list, such as only comparing in one direction (new to old), accepting
+   * that similar_text() gives different non-comparable results when you flip
+   * its arguments around.
+   *
+   * @param $data
+   *
+   * @return void
+   */
+  public function processItem($data) {
+    foreach ($data as $nid => $title) {
+      foreach ($this->node_titles as $compare_nid => $compare_title) {
+        if ($nid === $compare_nid) {
+          continue;
+        }
+        $matching_characters = similar_text($title, $compare_title, $percent);
+        if ($percent > 80) {
+          $this->database->upsert('mass_admin_pages_similar_titles')->fields([
+            'nid' => $nid,
+            'title' => $title,
+            'other_nid' => $compare_nid,
+            'other_title' => $compare_title,
+            'percent' => $percent,
+          ])->execute();
+        }
+        else {
+          $this->database->delete('mass_admin_pages_similar_titles')->condition('nid', $nid);
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
**Description:**
This PR cleans up some work I did locally to generate a report of similar titles. With removing content types we initially included, this is much faster and smaller of a report, so _perhaps_ using a queue like this is a bit overengineered. However, it still took my laptop ~5 minutes to process the queue, with three different queue workers running, so perhaps not!


**Jira:** (Skip unless you are MA staff)
DP-24512


**To Test:**
- [ ] I will provide an export of the generated table in the Jira ticket. Otherwise, this is not mergable.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
