### PR TITLE
DP-24808 Add list tag for news list on org pages

### DIFF
--- a/changelogs/DP-24808.yml
+++ b/changelogs/DP-24808.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: News listing on org pages should update when a new news item is posted.
+    issue: DP-24808

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -523,6 +523,7 @@ class Organisms {
     $pressList = [];
     $moreLink = '';
     $i = 0;
+    $cache_tags[] = 'node_list:news';
 
     // Get field values.
     $field_values = $entity->get($field);

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\block\Entity\Block;
+use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\Component\Utility\Html;
@@ -5113,19 +5114,16 @@ function mass_theme_preprocess_paragraph__org_news(&$variables) {
           [
             'path' => '@organisms/by-author/press-listing.twig',
             'data' => [
-              'pressListing' => Organisms::preparePressListing($paragraph, 'field_org_featured_news_items', $pressListing_options, $secondaryItems, $cache_tags),
+              'pressListing' => $press_listing,
             ],
           ],
         ],
       ];
 
-      // Bubble cache tag to the current render. Based on https://www.drupal.org/project/drupal/issues/2557815.
+      // Bubble cache tag to the current render. Based on template_preprocess_pager()
       // Needed until core implements https://www.drupal.org/project/drupal/issues/3028976
-      $renderer = \Drupal::service('renderer');
-      if ($renderer->hasRenderContext()) {
-        $build = ['#cache' => ['tags' => ['node_list:news']]];
-        $renderer->render($build);
-      }
+      (new CacheableMetadata())->addCacheTags($cache_tags)
+        ->applyTo($variables);
     }
   }
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5118,6 +5118,14 @@ function mass_theme_preprocess_paragraph__org_news(&$variables) {
           ],
         ],
       ];
+
+      // Bubble cache tag to the current render. Based on https://www.drupal.org/project/drupal/issues/2557815.
+      // Needed until core implements https://www.drupal.org/project/drupal/issues/3028976
+      $renderer = \Drupal::service('renderer');
+      if ($renderer->hasRenderContext()) {
+        $build = ['#cache' => ['tags' => ['node_list:news']]];
+        $renderer->render($build);
+      }
     }
   }
 }


### PR DESCRIPTION
**Description:**
Add cache tag for the list. When a new news item is posted, all org pages will be invalidated. 


**Jira:** (Skip unless you are MA staff)
DP-24808


**To Test:**
- [x] Enable `http.response.debug_cacheability_headers: true` in `services.local.yml`
- [x] Run `drush cr`
- [x] Run `curl -v https://mass.local/orgs/executive-office-for-administration-and-finance > /dev/null`
- [x] Verify that `node_list:news` shows up in the `x-drupal-cache-tags` header.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
