### PR TITLE
DP-24884 Fix hardcoding wait and missing required field

### DIFF
--- a/changelogs/DP-24884.yml
+++ b/changelogs/DP-24884.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Fix hardcoding wait and missing required field in TemporaryUnpublishedAccessTest
+    issue: DP-24884

--- a/docroot/modules/custom/mass_content/tests/src/ExistingSiteJavascript/TemporaryUnpublishedAccessTest.php
+++ b/docroot/modules/custom/mass_content/tests/src/ExistingSiteJavascript/TemporaryUnpublishedAccessTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\mass_content\ExistingSiteJavascript;
 
 use Drupal\file\Entity\File;
-use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\user\Entity\User;
 use weitzman\DrupalTestTraits\ExistingSiteWebDriverTestBase;
 use weitzman\LoginTrait\LoginTrait;
@@ -20,14 +20,14 @@ class TemporaryUnpublishedAccessTest extends ExistingSiteWebDriverTestBase {
   use LoginTrait;
 
   /**
-   * To generate a unpbulished access link.
+   * To generate a unpublished access link.
    */
-  private function generateLink() {
+  private function generateLink(): void {
     $this->getCurrentPage()->find('css', '#edit-access-unpublished-settings summary')->click();
-    $links_count_before = count($this->getCurrentPage()->findAll('css', '#edit-access-unpublished-settings table tr'));
+    $links_count_before = count($this->getCurrentPage()->findAll('css', '#edit-access-unpublished-settings table tbody tr a:contains("Copy")'));
     $this->getCurrentPage()->pressButton('Get link');
-    $this->getSession()->wait(1000);
-    $links_count_after = count($this->getCurrentPage()->findAll('css', '#edit-access-unpublished-settings table tr'));
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $links_count_after = count($this->getCurrentPage()->findAll('css', '#edit-access-unpublished-settings table tbody tr a:contains("Copy")'));
     $this->assertEquals($links_count_before + 1, $links_count_after);
   }
 
@@ -51,6 +51,13 @@ class TemporaryUnpublishedAccessTest extends ExistingSiteWebDriverTestBase {
       'title' => 'Test',
       'field_topic_lede' => 'Short description',
       'field_topic_bg_wide' => $image,
+      'field_topic_content_cards' => Paragraph::create([
+        'type' => 'content_card_group',
+        'field_content_card_link_cards' => [
+          'uri' => 'http://test.card.example.com',
+          'title' => 'Test Card',
+        ]
+      ]),
       'field_organizations' => [$org_node],
       'moderation_state' => 'unpublished',
       'status' => 0,
@@ -83,14 +90,22 @@ class TemporaryUnpublishedAccessTest extends ExistingSiteWebDriverTestBase {
     // Ensure we have a parent page.
     $this->getCurrentPage()->fillField('Parent page', 'About the Massachusetts Court System');
     $this->getCurrentPage()->pressButton('Save');
-    $this->clickLink('Edit');
+
+    // This code used to call $this->clickLink('Edit'). However,
+    // template_preprocess_menu_local_task() adds a hidden span marked as
+    // visually hidden with the active tab labelled. Chrome refuses to click the
+    // edit link via automation, because <span> is not supposed to be a
+    // clickable element. We haven't found any core tests showing how to
+    // work around this, so instead we simply re-fetch the page.
+    // https://stackoverflow.com/questions/59669474/why-is-this-element-not-interactable-python-selenium
+    $this->drupalGet('node/' . $node->id() . '/edit');
     $this->generateLink();
 
     // Ensure we don't have a parent page.
-    $this->clickLink('Edit');
+    $this->drupalGet('node/' . $node->id() . '/edit');
     $this->getCurrentPage()->fillField('Parent page', '');
     $this->getCurrentPage()->pressButton('Save');
-    $this->clickLink('Edit');
+    $this->drupalGet('node/' . $node->id() . '/edit');
     $this->generateLink();
   }
 


### PR DESCRIPTION
**Description:**
- field_topic_content_cards is required, so adds filling that in when creating the node
- Replaces a time-based wait
- Use drupalGet() in prep for the switch to Selenium.


**Jira:** (Skip unless you are MA staff)
DP-24884


**To Test:**
- [ ] Static review and tests passing


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
