### PR TITLE
Add new mailchimp text format and use to formail mails

### DIFF
--- a/.ddev/.env.example
+++ b/.ddev/.env.example
@@ -16,7 +16,8 @@ AKAMAI_CLIENT_SECRET=
 
 # Enable Mailchimp instead of Mailhog when using Local Dev.
 # MASS_MAILCHIMP=1
-# MANDRILL_API_KEY=ask-a-coworker
+# Also set the following in a secrets.settings.php file
+# $config['mailchimp_transactional.settings']['mailchimp_transactional_api_key'] = [KEY];
 
 # New Relic API settings. Ask a release manager for the key.
 MASS_NEWRELIC_APPLICATION=46704875

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,16 @@
+## [0.321.1] - May 12, 2022
 
+### Changed
+- DP-24906: Add new mailchimp text format and use to formail mails
 
 ## [0.321.0] - May 10, 2022
 
 ### Added
   - DP-17093: Upgrade from Mandrill to Mailchimp Transaction module
-  - DP-24109: Adds collections to the following content types.
-  - News
-  - Event
-  - Promotional page
-  - Topic Page
-Adds templates for listing display for the added content types.
+  - DP-24109: Adds collections to the several content types.
   - DP-24432: Add "Did you find" feedback form to promotional page.
   - DP-24477: Add focal point to banner images on certain content types.
-  
+
 ### Changed
   - DP-23216: Adjust required field in org page component "what would you like to do".
   - DP-24080: Move entity usage processing to a queue.
@@ -20,7 +18,7 @@ Adds templates for listing display for the added content types.
   - DP-24669: Add user.mail to config_ignore.
   - DP-24690: Upgrade config_ignore module
   - DP-9273: Set image links' images in org page as decorative.
-  
+
 ### Fixed
   - DP-24273: Accessiblity improvements to in-page alerts.
   - DP-24350: Fix feedback button position and display when using Google Translate.
@@ -29,24 +27,24 @@ Adds templates for listing display for the added content types.
   - DP-24691: Fix ahoy pull for developers
   - DP-24698: Fix Backstop failing when Tugboat is suspended
   - DP-24731: More specific conditions for GTM.
-  
+
 ### Security
   - DP-24814: Quick node clone module update.
-  
+
 
 ## [0.320.0] - April 26, 2022
 
 ### Removed
   - DP-23217: Remove outdated fields from org_pages
-  
+
 ### Added
   - DP-23508: Support switching PHP versions during Acquia deployments
-  
+
 ### Changed
   - DP-24125: Improve cache hit rate for dynamic page cache
   - DP-24363: Update entity_hierarchy and its patch to allow enabling of webprofiler.
   - DP-24545: 6 weeks links duration for unpublished access links.
-  
+
 ### Fixed
   - DP-24335: Fix hamburger menu horizontal scrolling in IOS.
   - DP-24420: Ensure to have build info on View Page Controller before getting the view title.
@@ -54,10 +52,10 @@ Adds templates for listing display for the added content types.
   - DP-24527: Fixing the problem with link in Service Page banner not formating correctly.
   - DP-24557: Fixes null method exceptions on decisions when media entities are deleted
   - DP-24657: Sends taxonomy term id to the collection_all_media view.
-  
+
 ### Security
   - DP-24632: Drupal core security updates.
-  
+
 ## [0.319.2] - April 21, 2022
 
 ### Changed

--- a/conf/drupal/config/filter.format.mailchimp.yml
+++ b/conf/drupal/config/filter.format.mailchimp.yml
@@ -1,0 +1,21 @@
+uuid: 021ec5bc-3572-4ff0-a5ca-c0d6805adc7f
+langcode: en
+status: true
+dependencies: {  }
+name: Mailchimp
+format: mailchimp
+weight: 0
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 150

--- a/conf/drupal/config/mailchimp_transactional.settings.yml
+++ b/conf/drupal/config/mailchimp_transactional.settings.yml
@@ -3,7 +3,7 @@ _core:
 mailchimp_transactional_from_name: Massgov
 mailchimp_transactional_from_email: no-reply@digital.mass.gov
 mailchimp_transactional_subaccount: null
-mailchimp_transactional_filter_format: restricted_html
+mailchimp_transactional_filter_format: mailchimp
 mailchimp_transactional_track_opens: false
 mailchimp_transactional_track_clicks: false
 mailchimp_transactional_url_strip_qs: true

--- a/conf/drupal/config/mailsystem.settings.yml
+++ b/conf/drupal/config/mailsystem.settings.yml
@@ -3,4 +3,4 @@ _core:
 theme: current
 defaults:
   sender: mailchimp_transactional_mail
-  formatter: mailchimp_transactional_mail
+  formatter: mass_mail

--- a/conf/drupal/config/mailsystem.settings.yml
+++ b/conf/drupal/config/mailsystem.settings.yml
@@ -2,5 +2,5 @@ _core:
   default_config_hash: IhwTepsVwtbtbcT5GzQKhCXDCRvbk3MNkWqPiuiZ10s
 theme: current
 defaults:
-  sender: mailchimp_transactional_mail
+  sender: mass_mail
   formatter: mass_mail

--- a/conf/drupal/config/user.role.developer.yml
+++ b/conf/drupal/config/user.role.developer.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.basic_html
     - filter.format.full_html
+    - filter.format.mailchimp
     - filter.format.restricted_html
     - filter.format.rules_of_court_section
     - node.type.action
@@ -441,6 +442,7 @@ permissions:
   - 'use media_states transition unpublish'
   - 'use text format basic_html'
   - 'use text format full_html'
+  - 'use text format mailchimp'
   - 'use text format restricted_html'
   - 'use text format rules_of_court_section'
   - 'view action revisions'

--- a/docroot/modules/custom/mass_utility/src/Plugin/Mail/MassMail.php
+++ b/docroot/modules/custom/mass_utility/src/Plugin/Mail/MassMail.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\mass_utility\Plugin\Mail;
+
+use Drupal\mailchimp_transactional\Plugin\Mail\Mail;
+
+/**
+ * Allow Drupal mailsystem to use Mailchimp Transactional when sending emails.
+ *
+ * @Mail(
+ *   id = "mass_mail",
+ *   label = @Translation("Mass mailer"),
+ *   description = @Translation("Mass customized - sends the message through Mailchimp Transactional.")
+ * )
+ */
+class MassMail extends Mail {
+
+  public function format(array $message) {
+    // Join the body array into one string.
+    if (is_array($message['body'])) {
+      // Do nothing. The parent adds weird '&#13;' at end of many lines.
+      $message['body'] = implode("\n\n", $message['body']);
+    }
+
+    return $message;
+  }
+
+}


### PR DESCRIPTION
**Description:**
- The Pathologic text filter is living up to its name. It is making relative links out of our absolute links which is helpful in a browser but unhelpful in an email. Create a new mailchimp text filter that doesnt include it.
- The mailchimp_transactional mailsystem is adding unwanted encoded characters at end of lines. Override its format() method in a new mail plugin.


**Jira:** (Skip unless you are MA staff)
DP-24906


**To Test:**
- [ ] Reenable the secret key on stage and send a test New User email. Also a password reset email since that was how the ticket came into us.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
