### PR TITLE
Dp 24983 fix collection h1 encoding and pr to release branch

### DIFF
--- a/changelogs/DP-24983.yml
+++ b/changelogs/DP-24983.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Fixed:
-  - description: Avoids special characters on views page titles.
+  - description: Avoids special characters on titles for collection and data listing pages.
     issue: DP-24983

--- a/changelogs/DP-24983.yml
+++ b/changelogs/DP-24983.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Avoids special characters on views page titles.
+    issue: DP-24983

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -95,6 +95,7 @@ function mass_theme_theme_suggestions_image_style_alter(array &$suggestions, arr
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function mass_theme_theme_suggestions_views_view_alter(array &$suggestions, array $variables) {
+  /** @var \Drupal\views\ViewExecutable $view */
   $view = $variables['view'];
 
   // Allow all data listing views pages to use the same template file.

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5996,7 +5996,7 @@ function mass_theme_preprocess_file_link(&$variables) {
  */
 function mass_theme_preprocess_views_view(&$variables) {
   $view = $variables['view'];
-  $variables['title'] = $view->getTitle();
+  $variables['title'] = ['#markup' => $view->getTitle()];
   $variables['row_count'] = 0;
   $variables['filter_value'] = '';
 


### PR DESCRIPTION
**Description:**
View titles from collections and data listing pages were showing special characters once the raw filter was removed from the `docroot/themes/custom/mass_theme/templates/views/views-view--data-listing.html.twig` template.

The title was wrapped into #markup, and now it looks correctly (without using raw).

I also tested against script injection (<script></script>) and the output was safe.

![image](https://user-images.githubusercontent.com/3916979/170293526-51276e4d-b515-458b-8100-c3038dbf3c4f.png)


**Jira:** (Skip unless you are MA staff)
DP-24983


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
