### PR TITLE
DP-24573: Add organization metadata to campaign landing pages

### DIFF
--- a/changelogs/DP-24573.yml
+++ b/changelogs/DP-24573.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add organization metadata to campaign landing pages.
+    issue: DP-24573

--- a/conf/drupal/config/core.entity_form_display.node.campaign_landing.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.campaign_landing.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.campaign_landing.field_reusable_label
     - field.field.node.campaign_landing.field_sections
     - field.field.node.campaign_landing.field_short_title
+    - field.field.node.campaign_landing.field_state_organization_tax
     - node.type.campaign_landing
     - workflows.workflow.campaign_landing_page
   module:
@@ -374,6 +375,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_state_organization_tax:
+    type: entity_reference_autocomplete
+    weight: 3
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 61
@@ -383,7 +394,7 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 9
+    weight: 4
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -435,7 +446,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_view_display.node.campaign_landing.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.campaign_landing.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.campaign_landing.field_reusable_label
     - field.field.node.campaign_landing.field_sections
     - field.field.node.campaign_landing.field_short_title
+    - field.field.node.campaign_landing.field_state_organization_tax
     - node.type.campaign_landing
   module:
     - entity_reference_revisions
@@ -156,6 +157,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_state_organization_tax:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 15
     region: content
 hidden:
   field_primary_parent: true

--- a/conf/drupal/config/core.entity_view_display.node.campaign_landing.link_and_description.yml
+++ b/conf/drupal/config/core.entity_view_display.node.campaign_landing.link_and_description.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.campaign_landing.field_reusable_label
     - field.field.node.campaign_landing.field_sections
     - field.field.node.campaign_landing.field_short_title
+    - field.field.node.campaign_landing.field_state_organization_tax
     - node.type.campaign_landing
   module:
     - user
@@ -27,7 +28,12 @@ id: node.campaign_landing.link_and_description
 targetEntityType: node
 bundle: campaign_landing
 mode: link_and_description
-content: {  }
+content:
+  extra_org_feedback_form:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
 hidden:
   content_moderation_control: true
   field_campaign_landing_metatags: true
@@ -46,5 +52,6 @@ hidden:
   field_reusable_label: true
   field_sections: true
   field_short_title: true
+  field_state_organization_tax: true
   langcode: true
   links: true

--- a/conf/drupal/config/core.entity_view_display.node.campaign_landing.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.campaign_landing.link_only.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.campaign_landing.field_reusable_label
     - field.field.node.campaign_landing.field_sections
     - field.field.node.campaign_landing.field_short_title
+    - field.field.node.campaign_landing.field_state_organization_tax
     - node.type.campaign_landing
   module:
     - user
@@ -27,7 +28,12 @@ id: node.campaign_landing.link_only
 targetEntityType: node
 bundle: campaign_landing
 mode: link_only
-content: {  }
+content:
+  extra_org_feedback_form:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
 hidden:
   content_moderation_control: true
   field_campaign_landing_metatags: true
@@ -46,5 +52,6 @@ hidden:
   field_reusable_label: true
   field_sections: true
   field_short_title: true
+  field_state_organization_tax: true
   langcode: true
   links: true

--- a/conf/drupal/config/core.entity_view_display.node.campaign_landing.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.campaign_landing.teaser.yml
@@ -20,6 +20,7 @@ dependencies:
     - field.field.node.campaign_landing.field_reusable_label
     - field.field.node.campaign_landing.field_sections
     - field.field.node.campaign_landing.field_short_title
+    - field.field.node.campaign_landing.field_state_organization_tax
     - node.type.campaign_landing
   module:
     - user
@@ -32,6 +33,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: -20
+    region: content
+  extra_org_feedback_form:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
     region: content
   links:
     settings: {  }
@@ -55,4 +61,5 @@ hidden:
   field_reusable_label: true
   field_sections: true
   field_short_title: true
+  field_state_organization_tax: true
   langcode: true

--- a/conf/drupal/config/field.field.node.campaign_landing.field_state_organization_tax.yml
+++ b/conf/drupal/config/field.field.node.campaign_landing.field_state_organization_tax.yml
@@ -1,0 +1,29 @@
+uuid: 56fcbd88-6233-4690-80b8-c6edf6375a42
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_state_organization_tax
+    - node.type.campaign_landing
+    - taxonomy.vocabulary.user_organization
+id: node.campaign_landing.field_state_organization_tax
+field_name: field_state_organization_tax
+entity_type: node
+bundle: campaign_landing
+label: Groups
+description: 'Choose SiteImprove groups in which to show this content. This field will be soon phased out in favor of using the Organization(s) field.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      user_organization: user_organization
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/metatag.metatag_defaults.node__campaign_landing.yml
+++ b/conf/drupal/config/metatag.metatag_defaults.node__campaign_landing.yml
@@ -11,3 +11,4 @@ tags:
   twitter_cards_image: '[node:field_header:entity:field_image:social_media]'
   twitter_cards_description: '[node:field_meta_description]'
   twitter_cards_type: summary_large_image
+  mg_stakeholder_org: '[node:field_state_organization_tax:entity:name]'


### PR DESCRIPTION
**Description:**
Added missing field_state_organization_tax:entity, configured metatag.


**Jira:** (Skip unless you are MA staff)
DP-24573


**To Test:**
- [ ] Edit any Promotional Page
- [ ] On the right side choose a Term from Groups and save the node
- [ ] Verify you see "mg_stakeholder_org" metatag


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
