### PR TITLE
DP-24907: Adjust image display on decision tree content type and add to backstop

### DIFF
--- a/backstop/all.json
+++ b/backstop/all.json
@@ -20,6 +20,8 @@
   {"label": "CuratedListLinksDocs", "url": "/lists/qag-curatedlist"},
   {"label": "CuratedListPeopleContact", "url": "/lists/qag-curated-list2-people"},
   {"label": "DecisionMandate", "url": "/mandate/qag-decisionmandate", "screens": ["desktop", "mobile"]},
+  {"label": "DecisionTree", "url": "/decision-tree/qag-decisiontree", "screens": ["desktop", "mobile"]},
+  {"label": "DecisionTreeNested", "url": "/decision-tree/qa-decision-tree#s=125361&p=125361", "screens": ["desktop", "mobile"]},
   {"label": "DecisionOrder", "url": "/order/qag-decisionorder", "screens": ["desktop", "mobile"]},
   {"label": "EventGeneralPast", "url": "/event/qag-event-general-past-2018-07-24t124500-0400-2018-07-24t134500-0400", "screens": ["desktop", "mobile"]},
   {"label": "EventGeneralFuture", "url": "/event/qag-eventgeneralfuture-2018-07-25t122000-0400-2050-07-25t122000-0500", "screens": ["desktop", "tablet"]},

--- a/changelogs/DP-24907.yml
+++ b/changelogs/DP-24907.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Adjust image display on decision tree content type and add to backstop.
+    issue: DP-24907

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -690,6 +690,7 @@ class Organisms {
     // @todo determine how to handle options vs field value (check existence, order of importance, etc.)
     $pageBanner['icon'] = $options['icon'];
     $pageBanner['color'] = array_key_exists('color', $options) ? $options['color'] : '';
+    $pageBanner['size'] = array_key_exists('size', $options) ? $options['size'] : '';
     $pageBanner['underline'] = array_key_exists('underline', $options) ? $options['underline'] : FALSE;
 
     $pageBanner['title'] = $entity->{$fields['title']}->value;

--- a/docroot/themes/custom/mass_theme/overrides/css/hotfix.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/hotfix.css
@@ -54,7 +54,7 @@ body {
   Override the margin at the top of decision tre pages when there is a banner.
 */
 .ma__relationship-indicators + .decision-tree > .ma__page-banner {
-  margin-top: -11px;
+  margin-top: 5px;
 }
 
 /*


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-24907


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
