### PR TITLE
Dp 25052 offer option on info details page to not include table of contents

### DIFF
--- a/changelogs/DP-25052.yml
+++ b/changelogs/DP-25052.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Uses field_hide_table_of_contents to hide Table of Contents on Info Details.
+    issue: DP-25052

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -77,6 +78,7 @@ third_party_settings:
         - field_date_published
         - field_info_details_last_updated
         - field_page_template
+        - field_hide_table_of_contents
         - field_primary_parent
         - field_organizations
         - field_data_flag
@@ -278,7 +280,7 @@ content:
             selector: ''
   field_date_published:
     type: datetime_default
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -349,6 +351,13 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_hide_table_of_contents:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_image_credit:
     type: string_textfield
     weight: 7
@@ -379,7 +388,7 @@ content:
     third_party_settings: {  }
   field_info_details_last_updated:
     type: datetime_default
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -432,7 +441,7 @@ content:
     third_party_settings: {  }
   field_page_template:
     type: options_select
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_view_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.default.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -163,6 +164,16 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 8
+    region: content
+  field_hide_table_of_contents:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 28
     region: content
   field_image_credit:
     type: string

--- a/conf/drupal/config/core.entity_view_display.node.info_details.link_and_description.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.link_and_description.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -64,6 +65,7 @@ hidden:
   field_details_enable_fields: true
   field_english_version: true
   field_footnotes: true
+  field_hide_table_of_contents: true
   field_image_credit: true
   field_info_detail_overview: true
   field_info_details_date_publishe: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.link_only.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -64,6 +65,7 @@ hidden:
   field_details_enable_fields: true
   field_english_version: true
   field_footnotes: true
+  field_hide_table_of_contents: true
   field_image_credit: true
   field_info_detail_overview: true
   field_info_details_date_publishe: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.listing.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.listing.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -115,6 +116,7 @@ hidden:
   field_details_enable_fields: true
   field_english_version: true
   field_footnotes: true
+  field_hide_table_of_contents: true
   field_image_credit: true
   field_info_detail_overview: true
   field_info_details_date_publishe: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.teaser.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -97,6 +98,7 @@ hidden:
   field_details_enable_fields: true
   field_english_version: true
   field_footnotes: true
+  field_hide_table_of_contents: true
   field_image_credit: true
   field_image_credits: true
   field_info_detail_overview: true

--- a/conf/drupal/config/core.entity_view_display.node.info_details.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.info_details.title_short_desc.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.info_details.field_details_enable_fields
     - field.field.node.info_details.field_english_version
     - field.field.node.info_details.field_footnotes
+    - field.field.node.info_details.field_hide_table_of_contents
     - field.field.node.info_details.field_image_credit
     - field.field.node.info_details.field_info_detail_overview
     - field.field.node.info_details.field_info_details_date_publishe
@@ -71,6 +72,7 @@ hidden:
   field_details_enable_fields: true
   field_english_version: true
   field_footnotes: true
+  field_hide_table_of_contents: true
   field_image_credit: true
   field_info_detail_overview: true
   field_info_details_date_publishe: true

--- a/conf/drupal/config/field.field.node.info_details.field_hide_table_of_contents.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_hide_table_of_contents.yml
@@ -10,7 +10,7 @@ field_name: field_hide_table_of_contents
 entity_type: node
 bundle: info_details
 label: 'Hide table of contents'
-description: ''
+description: 'A table of contents will appear if there are 3 or more sections and is recommended. If your sections are small and the page will be more usable without it, check this box to hide the table of contents.'
 required: false
 translatable: false
 default_value:

--- a/conf/drupal/config/field.field.node.info_details.field_hide_table_of_contents.yml
+++ b/conf/drupal/config/field.field.node.info_details.field_hide_table_of_contents.yml
@@ -1,0 +1,23 @@
+uuid: 6f28a373-271e-46e5-8739-15f73ff18bd1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_table_of_contents
+    - node.type.info_details
+id: node.info_details.field_hide_table_of_contents
+field_name: field_hide_table_of_contents
+entity_type: node
+bundle: info_details
+label: 'Hide table of contents'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/field.storage.node.field_hide_table_of_contents.yml
+++ b/conf/drupal/config/field.storage.node.field_hide_table_of_contents.yml
@@ -1,0 +1,18 @@
+uuid: a126515d-a05a-49ca-8eb8-b1816501a080
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hide_table_of_contents
+field_name: field_hide_table_of_contents
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
@@ -138,8 +138,7 @@
 {% block pageContent %}
 
   {{ content.field_info_details_sections }}
-
-
+  
   {{ content.field_contact }}
 
   {% if node.field_footnotes[0].value %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details.html.twig
@@ -113,13 +113,17 @@
       {% endblock %}
     {% endembed %}
   {% endif %}
-  {% include "@organisms/by-template/sticky-toc.twig" with {
-    "stickyTOC": {
-      "title": "Table of Contents"|t,
-      "parent": "#main-content",
-      "sections": ".ma__information-details__content h2"
-    }
-  } %}
+
+  {% if not node.field_hide_table_of_contents.value %}
+    {% include "@organisms/by-template/sticky-toc.twig" with {
+      "stickyTOC": {
+        "title": "Table of Contents"|t,
+        "parent": "#main-content",
+        "sections": ".ma__information-details__content h2"
+      }
+    } %}
+  {% endif %}
+
   {{ pre_content }}
 {% endblock %}
 {% if node.field_info_details_header_media.isempty == false %}
@@ -132,7 +136,10 @@
 {% endif %}
 
 {% block pageContent %}
+
   {{ content.field_info_details_sections }}
+
+
   {{ content.field_contact }}
 
   {% if node.field_footnotes[0].value %}


### PR DESCRIPTION
**Description:**
Uses field_hide_table_of_contents to hide Table of Contents on Info Details.

**Jira:** (Skip unless you are MA staff)
DP-25052


**To Test:**
- [ ] Choose an info_details page.
- [ ] View it, and notice it has "Table of Contents".
- [ ] Edit the info_details page.
- [ ] Check "Hide table of contents"
- [ ] Save
- [ ] View it, and notice it doesn't have "Table of Contents".


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
