### PR TITLE
Dp 25081 bug organization of blog author appearing twice

### DIFF
--- a/changelogs/DP-25081.yml
+++ b/changelogs/DP-25081.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Organizations was printing twice on authors info on News full.
+    issue: DP-25081

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3401,7 +3401,7 @@ function mass_theme_preprocess_node_news_full(&$variables) {
     $variables['author_url'] = $author->toUrl();
     $variables['author_info'] =
       $author_title .
-      ($author_title ? ', ' :  '') .
+      ($author_title ? ', ' : '') .
       $author_all_orgs;
 
     $cache_tags = array_merge($cache_tags, $author->getCacheTags());

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3399,11 +3399,10 @@ function mass_theme_preprocess_node_news_full(&$variables) {
 
     $variables['author'] = $full_name;
     $variables['author_url'] = $author->toUrl();
-    $variables['author_info'] = $author_title;
-    if ($author_title) {
-      $variables['author_info'] .= ', ' . $author_all_orgs;
-    }
-    $variables['author_info'] .= $author_all_orgs;
+    $variables['author_info'] =
+      $author_title .
+      ($author_title ? ', ' :  '') .
+      $author_all_orgs;
 
     $cache_tags = array_merge($cache_tags, $author->getCacheTags());
   }


### PR DESCRIPTION
**Description:**
The organization value was appearing twice on Author's information on the sidebar, on full News type Blog.

**Jira:** (Skip unless you are MA staff)
DP-25081


**To Test:**
- [ ] Edit any news.
- [ ] Select type blogpost
- [ ] Add an author
- [ ] Save
- [ ] Notice the Author organization is not appearing twice on the sidebar


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
