### PR TITLE
Hotfix/global menu overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - If caption is empty, figcaption is not shown.
   - DP-25081: Organizations was printing twice on authors info on News full.
   - DP-25103: Fix scaffold overwriting example settings file
+  - hotfix: Fix global menu overlay
   
 ### Security
   - DP-24927: Update components causing security alerts.

--- a/composer.json
+++ b/composer.json
@@ -250,7 +250,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-25160-hotfix-header-overlay",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1"

--- a/composer.json
+++ b/composer.json
@@ -250,7 +250,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-25160-hotfix-header-overlay",
+        "massgov/mayflower-artifacts": "dev-develop",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",
         "typhonius/acquia-php-sdk-v2": "~1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83f3d882c7cf13a70eac8ed7e4b08e56",
+    "content-hash": "f82084f00346ed6e4a5470cb9a8b8d9e",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11407,16 +11407,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-25160-hotfix-header-overlay",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "c386c497eed66ccc881826cdd750ddcbc11e7fb5"
+                "reference": "dd66801a8ffd04cc402ba637fe990e849468588f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/c386c497eed66ccc881826cdd750ddcbc11e7fb5",
-                "reference": "c386c497eed66ccc881826cdd750ddcbc11e7fb5",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dd66801a8ffd04cc402ba637fe990e849468588f",
+                "reference": "dd66801a8ffd04cc402ba637fe990e849468588f",
                 "shasum": ""
             },
             "require": {
@@ -11436,9 +11436,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25160-hotfix-header-overlay"
             },
-            "time": "2022-06-13T16:09:06+00:00"
+            "time": "2022-06-15T14:11:04+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f82084f00346ed6e4a5470cb9a8b8d9e",
+    "content-hash": "83f3d882c7cf13a70eac8ed7e4b08e56",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11407,16 +11407,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-25160-hotfix-header-overlay",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "dd66801a8ffd04cc402ba637fe990e849468588f"
+                "reference": "95aab278ed05b376013f43a2a01b9261aaf60aad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dd66801a8ffd04cc402ba637fe990e849468588f",
-                "reference": "dd66801a8ffd04cc402ba637fe990e849468588f",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/95aab278ed05b376013f43a2a01b9261aaf60aad",
+                "reference": "95aab278ed05b376013f43a2a01b9261aaf60aad",
                 "shasum": ""
             },
             "require": {
@@ -11436,9 +11436,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25160-hotfix-header-overlay"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2022-06-15T14:11:04+00:00"
+            "time": "2022-06-15T17:37:48+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/themes/custom/mass_theme/templates/layout/page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/layout/page.html.twig
@@ -66,7 +66,7 @@
 <div id="top-alerts"></div>
 {% if header_version_mixed %}
   <header class="ma__header__hamburger ma__header__mixed{{ header_class }}" id="header">
-
+    <div class="menu-overlay"></div>
     <a class="ma__header__hamburger__skip-nav visually-hidden focusable" href="#main-content">
       {{ 'Skip to main content'|t }}
     </a>
@@ -90,7 +90,7 @@
   </header>
 {% else %}
   <header class="ma__header__hamburger{{ header_class }}" id="header">
-
+    <div class="menu-overlay"></div>
     <a class="ma__header__hamburger__skip-nav" href="#main-content">
       {{ 'Skip to main content'|t }}
     </a>


### PR DESCRIPTION
hotfix: Fix global menu overlay

To test:
Go to https://pr1588-doj1dh5ta4caadivnm7k8dll9nnxstx0.tugboatqa.com/ and https://pr1588-doj1dh5ta4caadivnm7k8dll9nnxstx0.tugboatqa.com/topics/historic-sites and confirm the hamburger menu overlay exist and clicking on it closes the menu. 