### PR TITLE
Dp 23905 qafix  hide  social links  and  offered by  from the right column on service pages

### DIFF
--- a/changelogs/DP-23905.yml
+++ b/changelogs/DP-23905.yml
@@ -37,5 +37,8 @@
 #    issue: DP-19843
 #
 Added:
-  - description: Service paragraph theming.
+  - description: |-
+      - Service paragraph theming.
+        - Remove social links from right sidebar.
+        - Remove Offered by links from right sidebar.
     issue: DP-23905

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
@@ -138,10 +138,6 @@
 {% set introSidebar = introSidebar ?: true %}
 
 {% block sidebarIntro %}
-  {% if introSidebar.logo %}
-    {% set image = introSidebar.logo %}
-    {% include "@atoms/09-media/image.twig" %}
-  {% endif %}
 {% endblock %}
 
 {% block pageContent %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
@@ -142,12 +142,6 @@
     {% set image = introSidebar.logo %}
     {% include "@atoms/09-media/image.twig" %}
   {% endif %}
-  {% if introSidebar.social %}
-    {% set sidebarHeading = introSidebar.social.sidebarHeading %}
-    {% set sidebarHeading = sidebarHeading|merge({'level': level }) %}
-    {% set iconLinks = introSidebar.social.iconLinks|merge({'compHeading' : sidebarHeading }) %}
-    {% include "@molecules/icon-links.twig" %}
-  {% endif %}
 {% endblock %}
 
 {% block pageContent %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--service-page.html.twig
@@ -148,9 +148,6 @@
     {% set iconLinks = introSidebar.social.iconLinks|merge({'compHeading' : sidebarHeading }) %}
     {% include "@molecules/icon-links.twig" %}
   {% endif %}
-  {% if node.field_service_offered_by is not empty %}
-    {{ content.field_service_offered_by|merge({'#level': level }) }}
-  {% endif %}
 {% endblock %}
 
 {% block pageContent %}


### PR DESCRIPTION
**Description:**
      - Service paragraph theming.
          - Remove social links from the right sidebar.
          - Remove Offered by links from the right sidebar.


**Jira:** (Skip unless you are MA staff)
DP-23905


**To Test:**
- [ ] Check any service page with "social links" and notice it doesn't render the "social links" on the right sidebar.
- [ ] Check any service page with "offered by" and notice it doesn't render the "offered by" on the right sidebar.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
