### PR TITLE
Dp 25153 fix taking a screenshot before mobile menu has animated

### DIFF
--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -52,6 +52,7 @@ module.exports = async function (page, scenario, vp) {
 
     // Zero delay on CSS transitions.
     jQuery("head").append('<style id="no-more-css-transitions" type="text/css"> * { transition-duration: 0s !important } </style>');
+    jQuery("head").append('<style id="new-animations" type="text/css">*:before, *:after { transition-duration: 0s !important; }</style>');
 
     // Immediately complete any in-progress animations.
     jQuery(':animated').finish();

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -49,6 +49,10 @@ module.exports = async function (page, scenario, vp) {
   await page.evaluate(function (url) {
     // Disable jQuery animation for any future calls.
     jQuery.fx.off = true;
+
+    // Zero delay on CSS transitions.
+    jQuery("head").append('<style id="no-more-css-transitions" type="text/css"> * { transition-duration: 0s !important } </style>');
+
     // Immediately complete any in-progress animations.
     jQuery(':animated').finish();
 

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -51,8 +51,7 @@ module.exports = async function (page, scenario, vp) {
     jQuery.fx.off = true;
 
     // Zero delay on CSS transitions.
-    jQuery("head").append('<style id="no-more-css-transitions" type="text/css"> * { transition-duration: 0s !important } </style>');
-    jQuery("head").append('<style id="new-animations" type="text/css">*:before, *:after { transition-duration: 0s !important; }</style>');
+    jQuery("head").append('<style type="text/css"> *, *:before, *:after { transition-duration: 0s !important } </style>');
 
     // Immediately complete any in-progress animations.
     jQuery(':animated').finish();

--- a/changelogs/DP-25153.yml
+++ b/changelogs/DP-25153.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Add rule to remove animations by setting the transition-duration to 0s.
+    issue: DP-25153


### PR DESCRIPTION
**Description:**
- Adds a rule to remove animations by setting the transition duration to 0s.

**Jira:** (Skip unless you are MA staff)
DP-25153

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
