### PR TITLE
DP-25124 Use focal point for paragraph images

### DIFF
--- a/conf/drupal/config/core.entity_form_display.paragraph.image.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.default.yml
@@ -11,10 +11,10 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
-    - image
+    - focal_point
     - text
 id: paragraph.image.default
 targetEntityType: paragraph
@@ -22,12 +22,14 @@ bundle: image
 mode: default
 content:
   field_image:
-    type: image_image
+    type: image_focal_point
     weight: 0
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
   field_image_administrative_title:
     type: string_textfield

--- a/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption.yml
@@ -12,10 +12,10 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
-    - image
+    - focal_point
     - text
 id: paragraph.image.media_caption
 targetEntityType: paragraph
@@ -23,12 +23,14 @@ bundle: image
 mode: media_caption
 content:
   field_image:
-    type: image_image
+    type: image_focal_point
     weight: 0
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
   field_image_caption:
     type: text_textarea

--- a/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption_and_display.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption_and_display.yml
@@ -12,11 +12,11 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
     - allowed_formats
-    - image
+    - focal_point
     - maxlength
     - text
 id: paragraph.image.media_caption_and_display
@@ -25,12 +25,14 @@ bundle: image
 mode: media_caption_and_display
 content:
   field_image:
-    type: image_image
+    type: image_focal_point
     weight: 1
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: {  }
   field_image_administrative_title:
     type: string_textfield


### PR DESCRIPTION
**Description:**

A demo environment showing Focal Point in paragraphs.


**Jira:** (Skip unless you are MA staff)
DP-25124

Create or edit an information details node, and in "Content"  and "Section Content" add an image: https://pr1602-ro72rqfbsb5gjt4kjwg4qmtjw1l7lfew.tugboatqa.com/node/add/info_details

<img width="771" alt="image" src="https://user-images.githubusercontent.com/255023/175106931-36ac2197-5e58-486d-ad9e-135d7301cf46.png">

<img width="705" alt="image" src="https://user-images.githubusercontent.com/255023/175107065-582b5f47-e0b9-4253-be82-a3202b135f65.png">

When uploading a file, by default the focal point is set to 50,50:

<img width="550" alt="image" src="https://user-images.githubusercontent.com/255023/175107176-314e26af-aacc-4062-80fe-421900f54e3c.png">

"Preview" renders all site image styles. It looks like the modal positioning is broken until you scroll, but this is likely due to other issues in the admin theme.

I like how you can see a larger preview, and how you can see the preview without saving. Here's where I've put the focal point in the upper left:

<img width="1050" alt="image" src="https://user-images.githubusercontent.com/255023/175107559-c7a6c4d7-88a9-452b-abaa-86090b9eed37.png">

In this case, we're not reusing images so the focal point needs to be specified each time an image is uploaded.

**To Test:**
- [ ] Do not merge!


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
