### PR TITLE
Dp 24124 image widget crop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -189,6 +189,7 @@
         "drupal/google_tag": "^1.4",
         "drupal/handy_cache_tags": "^1.2",
         "drupal/http_response_headers": "^2",
+        "drupal/image_widget_crop": "^2.3",
         "drupal/imagick": "^1",
         "drupal/inline_entity_form": "^1",
         "drupal/jquery_ui_datepicker": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db24d570b9c1141182afd927791bd57d",
+    "content-hash": "3a8261877c90d474ee155cf67f11efa9",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -6220,6 +6220,82 @@
             "homepage": "https://www.drupal.org/project/http_response_headers",
             "support": {
                 "source": "https://git.drupalcode.org/project/http_response_headers"
+            }
+        },
+        {
+            "name": "drupal/image_widget_crop",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/image_widget_crop.git",
+                "reference": "8.x-2.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/image_widget_crop-8.x-2.3.zip",
+                "reference": "8.x-2.3",
+                "shasum": "20f9e98bd6503699576ada6f4fd4c9fd06686361"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9",
+                "drupal/crop": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "drupal/crop": "*",
+                "drupal/ctools": "3.x-dev",
+                "drupal/entity_browser": "1.x-dev",
+                "drupal/file_entity": "*",
+                "drupal/inline_entity_form": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.3",
+                    "datestamp": "1585408029",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre Mallet",
+                    "homepage": "https://github.com/woprrr",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Drupal media CI",
+                    "homepage": "https://www.drupal.org/user/3057985"
+                },
+                {
+                    "name": "phenaproxima",
+                    "homepage": "https://www.drupal.org/user/205645"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                },
+                {
+                    "name": "woprrr",
+                    "homepage": "https://www.drupal.org/user/858604"
+                }
+            ],
+            "description": "Provides an interface for using the features of the Crop API.",
+            "homepage": "https://www.drupal.org/project/image_widget_crop",
+            "keywords": [
+                "Crop",
+                "Drupal",
+                "Drupal Media"
+            ],
+            "support": {
+                "source": "https://www.drupal.org/project/image_widget_crop",
+                "issues": "https://www.drupal.org/project/issues/image_widget_crop",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {

--- a/conf/drupal/config/core.entity_form_display.paragraph.image.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.default.yml
@@ -11,10 +11,10 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
-    - image
+    - image_widget_crop
     - text
 id: paragraph.image.default
 targetEntityType: paragraph
@@ -22,12 +22,22 @@ bundle: image
 mode: default
 content:
   field_image:
-    type: image_image
+    type: image_widget_crop
     weight: 0
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - tall
+        - wide
+      crop_types_required:
+        - tall
+        - wide
+      warn_multiple_usages: true
+      show_crop_area: false
+      show_default_crop: true
     third_party_settings: {  }
   field_image_administrative_title:
     type: string_textfield

--- a/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption.yml
@@ -12,10 +12,10 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
-    - image
+    - image_widget_crop
     - text
 id: paragraph.image.media_caption
 targetEntityType: paragraph
@@ -23,12 +23,20 @@ bundle: image
 mode: media_caption
 content:
   field_image:
-    type: image_image
+    type: image_widget_crop
     weight: 0
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - tall
+        - wide
+      crop_types_required: {  }
+      warn_multiple_usages: true
+      show_crop_area: false
+      show_default_crop: true
     third_party_settings: {  }
   field_image_caption:
     type: text_textarea

--- a/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption_and_display.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.image.media_caption_and_display.yml
@@ -12,11 +12,11 @@ dependencies:
     - field.field.paragraph.image.field_image_display_size
     - field.field.paragraph.image.field_image_wrapping
     - field.field.paragraph.image.field_media_display
-    - image.style.thumbnail
+    - image.style.embedded_full_width
     - paragraphs.paragraphs_type.image
   module:
     - allowed_formats
-    - image
+    - image_widget_crop
     - maxlength
     - text
 id: paragraph.image.media_caption_and_display
@@ -25,12 +25,20 @@ bundle: image
 mode: media_caption_and_display
 content:
   field_image:
-    type: image_image
+    type: image_widget_crop
     weight: 1
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: embedded_full_width
+      crop_preview_image_style: crop_thumbnail
+      crop_list:
+        - tall
+        - wide
+      crop_types_required: {  }
+      warn_multiple_usages: true
+      show_crop_area: false
+      show_default_crop: true
     third_party_settings: {  }
   field_image_administrative_title:
     type: string_textfield

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -78,6 +78,7 @@ module:
   help: 0
   http_response_headers: 0
   image: 0
+  image_widget_crop: 0
   imagick: 0
   inline_entity_form: 0
   inline_form_errors: 0

--- a/conf/drupal/config/crop.type.tall.yml
+++ b/conf/drupal/config/crop.type.tall.yml
@@ -1,0 +1,12 @@
+uuid: e2c1bf63-1b91-447e-ae25-1b09d911a950
+langcode: en
+status: true
+dependencies: {  }
+label: Tall
+id: tall
+description: 'A tall crop used for vertical banners.'
+aspect_ratio: '3:5'
+soft_limit_width: null
+soft_limit_height: null
+hard_limit_width: null
+hard_limit_height: null

--- a/conf/drupal/config/crop.type.wide.yml
+++ b/conf/drupal/config/crop.type.wide.yml
@@ -1,0 +1,12 @@
+uuid: d45a08a4-d61b-4f02-a9d7-018dcbbf7510
+langcode: en
+status: true
+dependencies: {  }
+label: Wide
+id: wide
+description: 'A wide 16:9 crop'
+aspect_ratio: '16:9'
+soft_limit_width: 400
+soft_limit_height: 225
+hard_limit_width: 160
+hard_limit_height: 90

--- a/conf/drupal/config/image.style.crop_thumbnail.yml
+++ b/conf/drupal/config/image.style.crop_thumbnail.yml
@@ -1,0 +1,17 @@
+uuid: d0cd8844-b7a0-454f-85ed-b62338e83547
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: N1S0PHZeyxfFqgzB-sDeGPaxi0dDOL8NUiP_d6WXSV0
+name: crop_thumbnail
+label: 'Crop thumbnail'
+effects:
+  8fc26706-68dc-4eb7-8121-33e3936ed55f:
+    uuid: 8fc26706-68dc-4eb7-8121-33e3936ed55f
+    id: image_scale
+    weight: 1
+    data:
+      width: 400
+      height: null
+      upscale: false

--- a/conf/drupal/config/image.style.tall_test_for_image_widget_crop.yml
+++ b/conf/drupal/config/image.style.tall_test_for_image_widget_crop.yml
@@ -1,0 +1,18 @@
+uuid: 95200311-e829-4169-ade6-a051bbd86b93
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.tall
+  module:
+    - crop
+name: tall_test_for_image_widget_crop
+label: 'Tall Test for Image Widget Crop'
+effects:
+  dd62f334-49c5-4846-9369-c16af076b728:
+    uuid: dd62f334-49c5-4846-9369-c16af076b728
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: tall
+      automatic_crop_provider: null

--- a/conf/drupal/config/image.style.wide_test_for_image_widget_crop.yml
+++ b/conf/drupal/config/image.style.wide_test_for_image_widget_crop.yml
@@ -1,0 +1,18 @@
+uuid: cbdad591-d644-4e52-84de-041810e80454
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.wide
+  module:
+    - crop
+name: wide_test_for_image_widget_crop
+label: 'Wide Test for Image Widget Crop'
+effects:
+  34c60ca3-2aa7-4297-b169-06841799e749:
+    uuid: 34c60ca3-2aa7-4297-b169-06841799e749
+    id: crop_crop
+    weight: 1
+    data:
+      crop_type: wide
+      automatic_crop_provider: null

--- a/conf/drupal/config/image_widget_crop.settings.yml
+++ b/conf/drupal/config/image_widget_crop.settings.yml
@@ -1,0 +1,12 @@
+_core:
+  default_config_hash: UYGkeE2iH3UGp9lBPsELb3VSgHz9vkMJeaGzcYwE7Uw
+settings:
+  library_url: ''
+  css_url: ''
+  crop_preview_image_style: crop_thumbnail
+  crop_list: {  }
+  crop_types_required: {  }
+  warn_multiple_usages: false
+  show_default_crop: true
+  notify_apply: false
+  notify_update: true

--- a/conf/drupal/config/views.view.all_documents.yml
+++ b/conf/drupal/config/views.view.all_documents.yml
@@ -1142,7 +1142,7 @@ display:
           exposed: true
           expose:
             operator_id: field_collections_target_id_op
-            label: 'Collections'
+            label: Collections
             description: ''
             use_operator: false
             operator: field_collections_target_id_op
@@ -3311,7 +3311,7 @@ display:
           exposed: true
           expose:
             operator_id: field_collections_target_id_op
-            label: 'Collections'
+            label: Collections
             description: ''
             use_operator: false
             operator: field_collections_target_id_op


### PR DESCRIPTION
**Description:**
Demonstrates Image Widget Crop on a paragraph image.

Create or edit an information details node, and in "Content"  and "Section Content" add an image: https://dp-24124-image-widget-crop-5vuwykbrzmqtkbexsna409qvgm5feyfg.tugboatqa.com/node/add/info_details

<img width="558" alt="image" src="https://user-images.githubusercontent.com/255023/175126647-a919114a-e37c-4cc2-8cdc-a798320b15c8.png">

Note that this uses _responsive_ image styles. You can choose which ones you must provide crops for. I haven't made either required in this demo. This shows how it's best to design based on a smaller number of aspect ratios. You could also have different crops such as "small wide" for mobile, expecting smaller dimensions for a tighter crop:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/255023/175126962-7db6bc77-36c3-4882-8117-ff637100a2fd.png">

Since we aren't reusing images, new crops need to be applied every time an image is uploaded.

Finally, each crop can have a soft limit where a warning is issued, and a hard limit for the minimum crop size. You can't resize smaller than the hard limit. With the soft limit, the crop turns red like this:

<img width="877" alt="image" src="https://user-images.githubusercontent.com/255023/175127314-1e3976a1-7222-47de-9572-51831a0842ce.png">

**Jira:** (Skip unless you are MA staff)
DP-24124


**To Test:**
- [ ] Do not merge!


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
