### PR TITLE
DP-25233 Increase Tugboat upload limit

### DIFF
--- a/.ddev/php/my-php.ini
+++ b/.ddev/php/my-php.ini
@@ -3,3 +3,8 @@ memory_limit=-1
 
 # We only support xdebug locally.
 xdebug.client_port=9003
+
+# We match Acquia's default settings:
+# https://docs.acquia.com/cloud-platform/manage/php/
+upload_max_filesize=256M
+post_max_size=256M

--- a/.ddev/php/my-php.ini
+++ b/.ddev/php/my-php.ini
@@ -1,2 +1,5 @@
+# We allow unlimited memory on locals only.
 memory_limit=-1
+
+# We only support xdebug locally.
 xdebug.client_port=9003

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -64,7 +64,11 @@ services:
         - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
         - sudo apt update
         - sudo apt install yarn
-        - echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/my-php.ini
+        # These match Acquia default settings.
+        # See .ddev/php/my-php.ini for local configuration.
+        - echo "memory_limit=128M" >> /usr/local/etc/php/conf.d/my-php.ini
+        - echo "upload_max_filesize=256M" >> /usr/local/etc/php/conf.d/my-php.ini
+        - echo "post_max_size=256M" >> /usr/local/etc/php/conf.d/my-php.ini
 
         # Link the document root to the expected path.
         - ln -snf "${TUGBOAT_ROOT}/docroot" "${DOCROOT}"

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -64,9 +64,10 @@ services:
         - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
         - sudo apt update
         - sudo apt install yarn
-        # These match Acquia default settings.
         # See .ddev/php/my-php.ini for local configuration.
-        - echo "memory_limit=128M" >> /usr/local/etc/php/conf.d/my-php.ini
+        # We have a 256M limit set at Acquia via their UI / API.
+        - echo "memory_limit=256M" >> /usr/local/etc/php/conf.d/my-php.ini
+        # These match Acquia default settings.
         - echo "upload_max_filesize=256M" >> /usr/local/etc/php/conf.d/my-php.ini
         - echo "post_max_size=256M" >> /usr/local/etc/php/conf.d/my-php.ini
 

--- a/changelogs/DP-25233.yml
+++ b/changelogs/DP-25233.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Increase Tugboat upload limit
+    issue: DP-25233


### PR DESCRIPTION
**Description:**

- Sets the Tugboat PHP upload limit to match Acquia.
- Reduces the PHP memory limit to also match Acquia. Otherwise, we could test on tugboat environments but actually be exceeding our memory budget. I was surprised to not see this being set in settings.php for Acquia, so I'm assuming we're actually using the Acquia default of 128MB? If not, we can change this and document.

<img width="701" alt="image" src="https://user-images.githubusercontent.com/255023/176060601-b86a7928-19f2-413a-b856-916c42e2ac73.png">

**Jira:** (Skip unless you are MA staff)
DP-25233


**To Test:**
- [ ] Log into the Tugboat environment. Images greater than 2MB should be able to be uploaded. You can try the Organization content type at https://pr1623-feitfqe6u7c9dayhi793orlgburf0jzm.tugboatqa.com/node/add/org_page
- [ ] When merged, this will require a rebuild of develop to affect other PRs.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
