### PR TITLE
Fix revision view page via bug in moderation status block

### DIFF
--- a/changelogs/DP-25326.yml
+++ b/changelogs/DP-25326.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix revision view page via bug in moderation status block
+    issue: DP-25326

--- a/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
+++ b/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Drupal\mass_workbench_ui\Plugin\Block;

--- a/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
+++ b/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Drupal\mass_workbench_ui\Plugin\Block;
 

--- a/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
+++ b/docroot/modules/custom/mass_workbench_ui/src/Plugin/Block/WorkbenchModerationCurrentState.php
@@ -5,6 +5,7 @@ namespace Drupal\mass_workbench_ui\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\ContentEntityBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -65,15 +66,8 @@ class WorkbenchModerationCurrentState extends BlockBase implements ContainerFact
     /** @var \Drupal\node\Entity\Node $node */
     $node = $this->routeMatch->getParameter('node');
     $nodeStorage = $this->entityTypeManager->getStorage('node');
-    if (ctype_digit($node)) {
-      $node = $nodeStorage->load($node);
-    }
 
-    if ($revision = $this->routeMatch->getParameter('node_revision')) {
-      $node = $nodeStorage->loadRevision($revision);
-    }
-
-    if ($node) {
+    if (is_a($node, ContentEntityBase::class)) {
       $block = [
         '#markup' => "Current moderation state: " . $node->moderation_state->value,
       ];


### PR DESCRIPTION
**Description:**
- Removes the block from revision page. Its not wanted there.
- $node is an object not an int so use $node->id()


**Jira:** (Skip unless you are MA staff)
DP-25326


**To Test:**
- [ ] Visit a revision page and see no error. You can create a revision locally or test on Tugboat.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
