### PR TITLE
Pin portainer, fix DB persistence

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -37,5 +37,3 @@ web_environment:
 hooks:
   pre-start:
     - exec-host: echo "No output is shown during the first container build. It may take a minute to install Tugboat, CircleCI, and GitHub CLI tools."
-  post-stop:
-    - exec-host: echo "The database has been reset to a pristine state. If you didn't mean this, next time use ddev pause instead."

--- a/.ddev/docker-compose.dbmass.yaml
+++ b/.ddev/docker-compose.dbmass.yaml
@@ -20,6 +20,10 @@ services:
       MYSQL_DATABASE: circle
       MYSQL_RANDOM_ROOT_PASSWORD: 1
     command: --max_allowed_packet=32M --innodb_flush_method=O_DIRECT --tmp_table_size=16M --query_cache_size=16M --innodb-flush-log-at-trx-commit=2  --innodb_buffer_pool_size=500M --innodb_log_buffer_size=64M --skip-innodb_doublewrite --innodb_log_file_size=64M
+    volumes:
+      - dbmass:/var/lib/mysql
   web:
     links:
       - dbmass:dbmass
+volumes:
+  dbmass:

--- a/.ddev/docker-compose.portainer.yaml
+++ b/.ddev/docker-compose.portainer.yaml
@@ -7,7 +7,8 @@ services:
     # This is the name of the container. It is recommended to follow the same
     # name convention used in the main docker-compose.yml file.
     container_name: ddev-${DDEV_SITENAME}-portainer
-    image: portainer/portainer
+    # Pin to 1.x due to https://github.com/portainer/portainer/issues/4305
+    image: portainer/portainer:1.24.2
     command: --no-auth -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/changelogs/DP-25527.yml
+++ b/changelogs/DP-25527.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Pin portainer in local development env
+    issue: DP-25527

--- a/changelogs/DP-25527.yml
+++ b/changelogs/DP-25527.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Pin portainer in local development env
+  - description: In local development, pin portainer and fix DB persistence
     issue: DP-25527

--- a/docker.ahoy.yml
+++ b/docker.ahoy.yml
@@ -13,8 +13,8 @@ commands:
     cmd: ddev pause "$@"
   pull:
     // Container+Volume deletion, then image deletion, then start.
-    // cmd: ddev delete -Oy && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all && ahoy up
-    cmd: ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build --no-cache --pull dbmass
+    cmd: ddev delete --omit-snapshot -y && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all && ahoy up
+    // cmd: ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build --no-cache --pull dbmass
   refresh:
     cmd: ahoy exec "scripts/ma-refresh-local -dpo && vendor/bin/drush sql:sanitize -y"
   updatedb:

--- a/docker.ahoy.yml
+++ b/docker.ahoy.yml
@@ -12,9 +12,8 @@ commands:
   stop:
     cmd: ddev pause "$@"
   pull:
-    // Container+Volume deletion, then image deletion, then start.
+    # Container+Volume deletion, then image deletion, then start (db fetch happens at end).
     cmd: ddev delete --omit-snapshot -y && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all && ahoy up
-    // cmd: ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build --no-cache --pull dbmass
   refresh:
     cmd: ahoy exec "scripts/ma-refresh-local -dpo && vendor/bin/drush sql:sanitize -y"
   updatedb:

--- a/docker.ahoy.yml
+++ b/docker.ahoy.yml
@@ -12,7 +12,9 @@ commands:
   stop:
     cmd: ddev pause "$@"
   pull:
-    cmd: ddev stop && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all && ahoy up
+    // Container+Volume deletion, then image deletion, then start.
+    // cmd: ddev delete -Oy && ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml down --rmi all && ahoy up
+    cmd: ~/.ddev/bin/docker-compose -f .ddev/.ddev-docker-compose-full.yaml build --no-cache --pull dbmass
   refresh:
     cmd: ahoy exec "scripts/ma-refresh-local -dpo && vendor/bin/drush sql:sanitize -y"
   updatedb:


### PR DESCRIPTION
**Jira:** (Skip unless you are MA staff)
DP-25527


**To Test:**
- [ ] Portainer should start, instead of error upon `ddev start` or `ahoy up`
- [ ] When you `ddev restart` you no longer get a fresh DB. It has any changes you made.

**To Announce in #ssr channel:**
In `develop`, it is no longer necessary to use `ddev pause`. Your database will be preserved now across ddev restarts. In order to get a new database, continue to use `ahoy pull`

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
