### PR TITLE
DP-24431-fix-org-nav-mobile-position

### DIFF
--- a/changelogs/DP-24431.yml
+++ b/changelogs/DP-24431.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix organization navigation overlapped by main nav on mobile, and fix its positioning logic.
+    issue: DP-24431

--- a/composer.json
+++ b/composer.json
@@ -252,7 +252,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-24431-fix-org-nav-mobile-position",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "2.6.0",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -252,7 +252,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-24431-fix-org-nav-mobile-position",
         "monolog/monolog": "2.6.0",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c40a9388539ce2251ec147e0bacc6f5b",
+    "content-hash": "25bb73944d386e54c5a8edb6629dca85",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11524,16 +11524,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-24431-fix-org-nav-mobile-position",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "11a63f9616fe839c13797e6d4adc1f33df7ac84d"
+                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/11a63f9616fe839c13797e6d4adc1f33df7ac84d",
-                "reference": "11a63f9616fe839c13797e6d4adc1f33df7ac84d",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dcf81ed183f168750b06c98bdf91558ed42ee520",
+                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520",
                 "shasum": ""
             },
             "require": {
@@ -11553,9 +11553,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-24431-fix-org-nav-mobile-position"
             },
-            "time": "2022-07-19T17:20:07+00:00"
+            "time": "2022-07-22T15:18:43+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22366,5 +22366,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4b2de46094a775c02b8279497efd6f4",
+    "content-hash": "76d0ae41d08a01a7f60f78202d504b65",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11528,16 +11528,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-24431-fix-org-nav-mobile-position",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520"
+                "reference": "cee0440b2302d9e545325299cbd506a1aaed60e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dcf81ed183f168750b06c98bdf91558ed42ee520",
-                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/cee0440b2302d9e545325299cbd506a1aaed60e0",
+                "reference": "cee0440b2302d9e545325299cbd506a1aaed60e0",
                 "shasum": ""
             },
             "require": {
@@ -11557,9 +11557,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-24431-fix-org-nav-mobile-position"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2022-07-22T15:18:43+00:00"
+            "time": "2022-07-26T06:04:57+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22370,5 +22370,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76d0ae41d08a01a7f60f78202d504b65",
+    "content-hash": "d4b2de46094a775c02b8279497efd6f4",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11528,16 +11528,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-24431-fix-org-nav-mobile-position",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "11a63f9616fe839c13797e6d4adc1f33df7ac84d"
+                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/11a63f9616fe839c13797e6d4adc1f33df7ac84d",
-                "reference": "11a63f9616fe839c13797e6d4adc1f33df7ac84d",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dcf81ed183f168750b06c98bdf91558ed42ee520",
+                "reference": "dcf81ed183f168750b06c98bdf91558ed42ee520",
                 "shasum": ""
             },
             "require": {
@@ -11557,9 +11557,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-24431-fix-org-nav-mobile-position"
             },
-            "time": "2022-07-19T17:20:07+00:00"
+            "time": "2022-07-22T15:18:43+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22370,5 +22370,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Link to MF https://github.com/massgov/mayflower/pull/1654

Before: https://www.mass.gov/orgs/alcoholic-beverages-control-comm
After: https://pr1666-dej9upemzgmqdfbkw5yo9dgqcgj6fkey.tugboatqa.com/orgs/alcoholic-beverages-control-commission

To Test:
- [ ] visit an org page on mobile (or resize the window to a mobile view)
- [ ] open the org nav
- [ ] see if the issue described in the ticket is fixed 
