### PR TITLE
Fix jump link target margin top setting that blocks page content

### DIFF
--- a/changelogs/DP-25803.yml
+++ b/changelogs/DP-25803.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix TOC jump link target margin top that blocks page content.
+    issue: DP-25803

--- a/composer.json
+++ b/composer.json
@@ -253,7 +253,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-25803-toc-jump-target-fix",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -253,7 +253,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-25803-toc-jump-target-fix",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fcd99bf683f947c6c410ea4fe599c7a",
+    "content-hash": "023f206dd1fa9c7e82e675eaa576b2d1",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11755,16 +11755,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-25803-toc-jump-target-fix",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "eba482b8b8ddb066e998e530857ac9fca30d867e"
+                "reference": "fd6d9ae26b0888e0cea356cb77effcdc1d0a8a0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/eba482b8b8ddb066e998e530857ac9fca30d867e",
-                "reference": "eba482b8b8ddb066e998e530857ac9fca30d867e",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/fd6d9ae26b0888e0cea356cb77effcdc1d0a8a0c",
+                "reference": "fd6d9ae26b0888e0cea356cb77effcdc1d0a8a0c",
                 "shasum": ""
             },
             "require": {
@@ -11784,9 +11784,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25803-toc-jump-target-fix"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2022-09-07T16:40:57+00:00"
+            "time": "2022-09-13T06:18:15+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22801,5 +22801,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "023f206dd1fa9c7e82e675eaa576b2d1",
+    "content-hash": "1fcd99bf683f947c6c410ea4fe599c7a",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -11755,16 +11755,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-25803-toc-jump-target-fix",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "d31f0c570d140554e80c796e89bf385643bcad09"
+                "reference": "eba482b8b8ddb066e998e530857ac9fca30d867e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d31f0c570d140554e80c796e89bf385643bcad09",
-                "reference": "d31f0c570d140554e80c796e89bf385643bcad09",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/eba482b8b8ddb066e998e530857ac9fca30d867e",
+                "reference": "eba482b8b8ddb066e998e530857ac9fca30d867e",
                 "shasum": ""
             },
             "require": {
@@ -11784,9 +11784,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25803-toc-jump-target-fix"
             },
-            "time": "2022-08-17T18:57:51+00:00"
+            "time": "2022-09-07T16:40:57+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fixed:
  - description: Fix TOC jump link target margin top that blocks page content.
    issue: DP-25803

MF PR: https://github.com/massgov/mayflower/pull/1671

UAT: https://pr1705-381nyswfgu8hukfupnaudpw1jctcekgc.tugboatqa.com/info-details/report-a-data-breach#how-massachusetts-residents-report-a-data-breach-