### PR TITLE
DP-25848 TEST

### DIFF
--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -60,9 +60,9 @@
    * @return {string}
    *   The last value of the input field.
    */
-  function extractLastTerm(terms) {
-    return autocomplete.splitValues(terms).pop();
-  }
+  // function extractLastTerm(terms) {
+  //   return autocomplete.splitValues(terms).pop();
+  // }
 
   /**
    * The search handler is called before a search is performed.
@@ -75,16 +75,16 @@
    * @return {bool}
    *   Whether to perform a search or not.
    */
-  function searchHandler(event) {
-    var options = autocomplete.options;
-    var term = autocomplete.extractLastTerm(event.target.value);
-    // Abort search if the first character is in firstCharacterBlacklist.
-    if (term.length > 0 && options.firstCharacterBlacklist.indexOf(term[0]) !== -1) {
-      return false;
-    }
-    // Only search when the term is at least the minimum length.
-    return term.length >= options.minLength;
-  }
+  // function searchHandler(event) {
+  //   var options = autocomplete.options;
+  //   var term = autocomplete.extractLastTerm(event.target.value);
+  //   // Abort search if the first character is in firstCharacterBlacklist.
+  //   if (term.length > 0 && options.firstCharacterBlacklist.indexOf(term[0]) !== -1) {
+  //     return false;
+  //   }
+  //   // Only search when the term is at least the minimum length.
+  //   return term.length >= options.minLength;
+  // }
 
   /**
    * JQuery UI autocomplete source callback.
@@ -234,8 +234,6 @@
   //       $autocomplete.autocomplete(autocomplete.options)
   //     .each(function () {
   //       $(this).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
-  //       console.log("REANDER ITEMS");
-  //       console.log(autocomplete.options.renderItem);
   //     });
   //     }
   //   },

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -20,34 +20,34 @@
    * @return {Array}
    *   Array of values, split by comma.
    */
-  function autocompleteSplitValues(value) {
-    // We will match the value against comma-separated terms.
-    var result = [];
-    var quote = false;
-    var current = '';
-    var valueLength = value.length;
-    var character;
+  // function autocompleteSplitValues(value) {
+  //   // We will match the value against comma-separated terms.
+  //   var result = [];
+  //   var quote = false;
+  //   var current = '';
+  //   var valueLength = value.length;
+  //   var character;
 
-    for (var i = 0; i < valueLength; i++) {
-      character = value.charAt(i);
-      if (character === '"') {
-        current += character;
-        quote = !quote;
-      }
-      else if (character === ',' && !quote) {
-        result.push(current.trim());
-        current = '';
-      }
-      else {
-        current += character;
-      }
-    }
-    if (value.length > 0) {
-      result.push($.trim(current));
-    }
+  //   for (var i = 0; i < valueLength; i++) {
+  //     character = value.charAt(i);
+  //     if (character === '"') {
+  //       current += character;
+  //       quote = !quote;
+  //     }
+  //     else if (character === ',' && !quote) {
+  //       result.push(current.trim());
+  //       current = '';
+  //     }
+  //     else {
+  //       current += character;
+  //     }
+  //   }
+  //   if (value.length > 0) {
+  //     result.push($.trim(current));
+  //   }
 
-    return result;
-  }
+  //   return result;
+  // }
 
   /**
    * Returns the last value of an multi-value textfield.

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -207,8 +207,8 @@
    * @prop {Drupal~behaviorDetach} detach
    *   Detaches the autocomplete behaviors.
    */
-  Drupal.behaviors.autocomplete = {
-    attach: function (context) {
+  // Drupal.behaviors.autocomplete = {
+  //   attach: function (context) {
 
 
     // Add aria role to input.form-autocomplete
@@ -220,33 +220,33 @@
 
       // Act on textfields with the "form-autocomplete" class.
       // var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
-      var $autocomplete = $(context).find('input.form-autocomplete').attr({'role': 'combobox',
-                                                                            'aria-autocomplete': 'none',
-                                                                            'aria-expanded': 'false',
-                                                                            'aria-controls': 'optionListID'})
-      if ($autocomplete.length) {
+      // var $autocomplete = $(context).find('input.form-autocomplete').attr({'role': 'combobox',
+      //                                                                       'aria-autocomplete': 'none',
+      //                                                                       'aria-expanded': 'false',
+      //                                                                       'aria-controls': 'optionListID'})
+      // if ($autocomplete.length) {
     // Allow options to be overriden per instance.
-        var blacklist = $autocomplete.attr('data-autocomplete-first-character-blacklist');
-        $.extend(autocomplete.options, {
-          firstCharacterBlacklist: (blacklist) ? blacklist : ''
-        });
+        // var blacklist = $autocomplete.attr('data-autocomplete-first-character-blacklist');
+        // $.extend(autocomplete.options, {
+        //   firstCharacterBlacklist: (blacklist) ? blacklist : ''
+        // });
     // Use jQuery UI Autocomplete on the textfield.
-        $autocomplete.autocomplete(autocomplete.options)
-      .each(function () {
-        $(this).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
-        console.log("REANDER ITEMS");
-        console.log(autocomplete.options.renderItem);
-      });
-      }
-    },
-    detach: function (context, settings, trigger) {
-      if (trigger === 'unload') {
-        $(context).find('input.form-autocomplete')
-      .removeOnce('autocomplete')
-      .autocomplete('destroy');
-      }
-    }
-  };
+  //       $autocomplete.autocomplete(autocomplete.options)
+  //     .each(function () {
+  //       $(this).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
+  //       console.log("REANDER ITEMS");
+  //       console.log(autocomplete.options.renderItem);
+  //     });
+  //     }
+  //   },
+  //   detach: function (context, settings, trigger) {
+  //     if (trigger === 'unload') {
+  //       $(context).find('input.form-autocomplete')
+  //     .removeOnce('autocomplete')
+  //     .autocomplete('destroy');
+  //     }
+  //   }
+  // };
 
   /**
    * Autocomplete object implementation.

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -182,13 +182,14 @@
    * @return {jQuery}
    *   jQuery collection of the ul element.
    */
-  function renderMenu(ul, item) {
-    var that = this;
-    $.each( items, function( index, item ) {
-      that._renderItemData( ul, item );
-    });
-    $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
-  }
+  // IT DOESN'T SEEM THESE FUNCTIONS ARE DOING ANYTHING.
+  // function renderMenu(ul, item) {
+  //   var that = this;
+  //   $.each( items, function( index, item ) {
+  //     that._renderItemData( ul, item );
+  //   });
+  //   $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
+  // }
 
   // function renderItem(ul, item) {
   //   return $('<li>')
@@ -208,7 +209,12 @@
    */
   Drupal.behaviors.autocomplete = {
     attach: function (context) {
-      // Act on textfields with the "form-autocomplete" class.
+    // Add aria role to
+      $(context).find('input.form-autocomplete').attr({'role': 'combobox',
+                                                       'aria-autocomplete': 'none',
+                                                       'aria-expanded': 'false',
+                                                       'aria-controls': 'optionListID'});
+    // Act on textfields with the "form-autocomplete" class.
       var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
       if ($autocomplete.length) {
     // Allow options to be overriden per instance.

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -155,21 +155,21 @@
    * @return {bool}
    *   Returns false to indicate the event status.
    */
-  function selectHandler(event, ui) {
-    var terms = autocomplete.splitValues(event.target.value);
-    // Remove the current input.
-    terms.pop();
-    // Add the selected item.
-    if (ui.item.value.search(',') > 0) {
-      terms.push('"' + ui.item.value + '"');
-    }
-    else {
-      terms.push(ui.item.value);
-    }
-    event.target.value = terms.join(', ');
-    // Return false to tell jQuery UI that we've filled in the value already.
-    return false;
-  }
+  // function selectHandler(event, ui) {
+  //   var terms = autocomplete.splitValues(event.target.value);
+  //   // Remove the current input.
+  //   terms.pop();
+  //   // Add the selected item.
+  //   if (ui.item.value.search(',') > 0) {
+  //     terms.push('"' + ui.item.value + '"');
+  //   }
+  //   else {
+  //     terms.push(ui.item.value);
+  //   }
+  //   event.target.value = terms.join(', ');
+  //   // Return false to tell jQuery UI that we've filled in the value already.
+  //   return false;
+  // }
 
   /**
    * Override jQuery UI _renderItem function to output HTML by default.
@@ -183,19 +183,19 @@
    *   jQuery collection of the ul element.
    */
   // IT DOESN'T SEEM THESE FUNCTIONS ARE DOING ANYTHING.
-  function renderMenu(ul, item) {
-    var that = this;
-    $.each( items, function( index, item ) {
-      that._renderItemData( ul, item );
-    });
-    $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
-  }
+  // function renderMenu(ul, item) {
+  //   var that = this;
+  //   $.each( items, function( index, item ) {
+  //     that._renderItemData( ul, item );
+  //   });
+  //   $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
+  // }
 
-  function renderItem(ul, item) {
-    return $('<li>')
-      .append($('<a>').attr('role', 'option').html(item.label))
-      .appendTo(ul);
-  }
+  // function renderItem(ul, item) {
+  //   return $('<li>')
+  //     .append($('<a>').attr('role', 'option').html(item.label))
+  //     .appendTo(ul);
+  // }
 
   /**
    * Attaches the autocomplete behavior to all required fields.

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -219,7 +219,11 @@
 
 
       // Act on textfields with the "form-autocomplete" class.
-      var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
+      // var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
+      var $autocomplete = $(context).find('input.form-autocomplete').attr({'role': 'combobox',
+                                                                            'aria-autocomplete': 'none',
+                                                                            'aria-expanded': 'false',
+                                                                            'aria-controls': 'optionListID'})
       if ($autocomplete.length) {
     // Allow options to be overriden per instance.
         var blacklist = $autocomplete.attr('data-autocomplete-first-character-blacklist');
@@ -229,10 +233,9 @@
     // Use jQuery UI Autocomplete on the textfield.
         $autocomplete.autocomplete(autocomplete.options)
       .each(function () {
-        $(this).attr({'role': 'combobox',
-                      'aria-autocomplete': 'none',
-                      'aria-expanded': 'false',
-                      'aria-controls': 'optionListID'}).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
+        $(this).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
+        console.log("REANDER ITEMS");
+        console.log(autocomplete.options.renderItem);
       });
       }
     },

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -190,11 +190,11 @@
     $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
   }
 
-  function renderItem(ul, item) {
-    return $('<li>')
-      .append($('<a>').attr('role', 'option').html(item.label))
-      .appendTo(ul);
-  }
+  // function renderItem(ul, item) {
+  //   return $('<li>')
+  //     .append($('<a>').attr('role', 'option').html(item.label))
+  //     .appendTo(ul);
+  // }
 
   /**
    * Attaches the autocomplete behavior to all required fields.

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -182,10 +182,17 @@
    * @return {jQuery}
    *   jQuery collection of the ul element.
    */
+  function renderMenu(ul, item) {
+    var that = this;
+    $.each( items, function( index, item ) {
+      that._renderItemData( ul, item );
+    });
+    $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
+  }
+
   function renderItem(ul, item) {
     return $('<li>')
-      .attr('role', 'none')
-      .append($('<a>').html(item.label).attr('role', 'option'))
+      .append($('<a>').attr('role', 'option').html(item.label))
       .appendTo(ul);
   }
 

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -184,7 +184,8 @@
    */
   function renderItem(ul, item) {
     return $('<li>')
-      .append($('<a>').html(item.label))
+      .attr('role', 'none')
+      .append($('<a>').html(item.label).attr('role', 'option'))
       .appendTo(ul);
   }
 

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -155,21 +155,21 @@
    * @return {bool}
    *   Returns false to indicate the event status.
    */
-  function selectHandler(event, ui) {
-    var terms = autocomplete.splitValues(event.target.value);
-    // Remove the current input.
-    terms.pop();
-    // Add the selected item.
-    if (ui.item.value.search(',') > 0) {
-      terms.push('"' + ui.item.value + '"');
-    }
-    else {
-      terms.push(ui.item.value);
-    }
-    event.target.value = terms.join(', ');
-    // Return false to tell jQuery UI that we've filled in the value already.
-    return false;
-  }
+  // function selectHandler(event, ui) {
+  //   var terms = autocomplete.splitValues(event.target.value);
+  //   // Remove the current input.
+  //   terms.pop();
+  //   // Add the selected item.
+  //   if (ui.item.value.search(',') > 0) {
+  //     terms.push('"' + ui.item.value + '"');
+  //   }
+  //   else {
+  //     terms.push(ui.item.value);
+  //   }
+  //   event.target.value = terms.join(', ');
+  //   // Return false to tell jQuery UI that we've filled in the value already.
+  //   return false;
+  // }
 
   /**
    * Override jQuery UI _renderItem function to output HTML by default.
@@ -210,10 +210,10 @@
   Drupal.behaviors.autocomplete = {
     attach: function (context) {
     // Add aria role to
-      $(context).find('input.form-autocomplete').attr({'role': 'combobox',
-                                                       'aria-autocomplete': 'none',
-                                                       'aria-expanded': 'false',
-                                                       'aria-controls': 'optionListID'});
+      // $(context).find('input.form-autocomplete').attr({'role': 'combobox',
+      //                                                  'aria-autocomplete': 'none',
+      //                                                  'aria-expanded': 'false',
+      //                                                  'aria-controls': 'optionListID'});
     // Act on textfields with the "form-autocomplete" class.
       var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
       if ($autocomplete.length) {

--- a/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
+++ b/docroot/modules/custom/mass_entityreference/js/autocompletefilter.js
@@ -155,21 +155,21 @@
    * @return {bool}
    *   Returns false to indicate the event status.
    */
-  // function selectHandler(event, ui) {
-  //   var terms = autocomplete.splitValues(event.target.value);
-  //   // Remove the current input.
-  //   terms.pop();
-  //   // Add the selected item.
-  //   if (ui.item.value.search(',') > 0) {
-  //     terms.push('"' + ui.item.value + '"');
-  //   }
-  //   else {
-  //     terms.push(ui.item.value);
-  //   }
-  //   event.target.value = terms.join(', ');
-  //   // Return false to tell jQuery UI that we've filled in the value already.
-  //   return false;
-  // }
+  function selectHandler(event, ui) {
+    var terms = autocomplete.splitValues(event.target.value);
+    // Remove the current input.
+    terms.pop();
+    // Add the selected item.
+    if (ui.item.value.search(',') > 0) {
+      terms.push('"' + ui.item.value + '"');
+    }
+    else {
+      terms.push(ui.item.value);
+    }
+    event.target.value = terms.join(', ');
+    // Return false to tell jQuery UI that we've filled in the value already.
+    return false;
+  }
 
   /**
    * Override jQuery UI _renderItem function to output HTML by default.
@@ -183,19 +183,19 @@
    *   jQuery collection of the ul element.
    */
   // IT DOESN'T SEEM THESE FUNCTIONS ARE DOING ANYTHING.
-  // function renderMenu(ul, item) {
-  //   var that = this;
-  //   $.each( items, function( index, item ) {
-  //     that._renderItemData( ul, item );
-  //   });
-  //   $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
-  // }
+  function renderMenu(ul, item) {
+    var that = this;
+    $.each( items, function( index, item ) {
+      that._renderItemData( ul, item );
+    });
+    $( ul ).attr('role', 'listbox').find( "li" ).attr('role', 'none');
+  }
 
-  // function renderItem(ul, item) {
-  //   return $('<li>')
-  //     .append($('<a>').attr('role', 'option').html(item.label))
-  //     .appendTo(ul);
-  // }
+  function renderItem(ul, item) {
+    return $('<li>')
+      .append($('<a>').attr('role', 'option').html(item.label))
+      .appendTo(ul);
+  }
 
   /**
    * Attaches the autocomplete behavior to all required fields.
@@ -209,12 +209,16 @@
    */
   Drupal.behaviors.autocomplete = {
     attach: function (context) {
-    // Add aria role to
-      // $(context).find('input.form-autocomplete').attr({'role': 'combobox',
-      //                                                  'aria-autocomplete': 'none',
-      //                                                  'aria-expanded': 'false',
-      //                                                  'aria-controls': 'optionListID'});
-    // Act on textfields with the "form-autocomplete" class.
+
+
+    // Add aria role to input.form-autocomplete
+    // $(context).find('input.form-autocomplete').attr({'role': 'combobox',
+    //                                                   'aria-autocomplete': 'none',
+    //                                                   'aria-expanded': 'false',
+    //                                                   'aria-controls': 'optionListID'});
+
+
+      // Act on textfields with the "form-autocomplete" class.
       var $autocomplete = $(context).find('input.form-autocomplete').once('autocomplete');
       if ($autocomplete.length) {
     // Allow options to be overriden per instance.
@@ -225,7 +229,10 @@
     // Use jQuery UI Autocomplete on the textfield.
         $autocomplete.autocomplete(autocomplete.options)
       .each(function () {
-        $(this).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
+        $(this).attr({'role': 'combobox',
+                      'aria-autocomplete': 'none',
+                      'aria-expanded': 'false',
+                      'aria-controls': 'optionListID'}).data('ui-autocomplete')._renderItem = autocomplete.options.renderItem;
       });
       }
     },


### PR DESCRIPTION
Notes:

L.185 `function renderItem(ul, item)` is supposed to override the original function, but the edit for the function never shows up.  When the function is commented out, the option items still get rendered with `a` instead of `div` that is set up in core.
Not cure sure where the option list is actually configured.
---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
