### PR TITLE
Hotfix DP-25875 Bubble max-age to response headers. Fixes event listing staleness

### DIFF
--- a/.ddev/.disabled-services/docker-compose.selenium-chrome.yaml
+++ b/.ddev/.disabled-services/docker-compose.selenium-chrome.yaml
@@ -6,26 +6,19 @@ services:
   selenium-chrome:
     image: seleniarm/standalone-chromium:4.1.4-20220429
     container_name: ddev-${DDEV_SITENAME}-selenium-chrome
-    # todo: Enable this and remove the port below when ddev's router is fixed.
-    # Remember that ddev _copies_ this file so it will need to be updated or
-    # deleted to take effect.
-    # https://discord.com/channels/664580571770388500/976181828341866526
-    # https://github.com/drud/ddev/pull/3861
-    # expose:
-      # The internal noVNC port, which operates over HTTP so it can be exposed
-      # through the router.
-      # - 7900
-    #    environment:
-    #      - VIRTUAL_HOST=$DDEV_HOSTNAME
-    #      - HTTPS_EXPOSE=7900:7900
-    #      - HTTP_EXPOSE=7910:7900
-    #    external_links:
-    #      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
-    ports:
+    expose:
+      #      The internal noVNC port, which operates over HTTP so it can be exposed
+      #      through the router.
+      - 7900
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTPS_EXPOSE=7900:7900
+      - HTTP_EXPOSE=7910:7900
+    external_links:
+      - ddev-router:${DDEV_SITENAME}.${DDEV_TLD}
+      #ports:
       # VNC access for a traditional VNC client like macOS "Screen Sharing".
-      - "5900:5900"
-      # Remove this when the router is enabled.
-      - "7910:7900"
+      # - "5900:5900"
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-
+## [0.337.1] - October 8, 2022
+  - DP-25875 Hotfix. Bubble max-age to response headers. Fixes event listing staleness
 
 ## [0.337.0] - October 5, 2022
 
@@ -9,27 +10,27 @@
   - DP-25727: Permission cleanup of all roles in the system to correct errors and streamline permissions.
   - DP-25831: Restructure the CMS Welcome screen for authors.
   - DP-25897: Change unpublished preview links to always display a "www.mass.gov" domain.
-  
+
 ### Fixed
   - DP-25914: Fix duplicated feedback component on event agenda and minutes.
   - DP-25957: Menus on Org Page do not work correctly on mobile devices.
-  
+
 ### Security
   - DP-25945: Drupal Core security update to 9.4.7.
-  
+
 
 
 ## [0.336.0] - September 20, 2022
 
 ### Added
   - DP-25559: Added Total No, Total Yes, and Total Feedback to Content Performance.
-  
+
 ### Removed
   - DP-25808: Removed feedback survey from public site.
-  
+
 ### Fixed
   - DP-25861: Fixed permissions issue preventing authors and editors from viewing the entity browser.
-  
+
 
 
 ## [0.335.0] - September 13, 2022
@@ -37,16 +38,16 @@
 ### Added
   - DP-25204: Add confirmation warning when bulk transitioning documents.
   - DP-25248: Add testing for saving QAG pages.
-  
+
 ### Removed
   - DP-25692: Hide "Media" and remove "Moderated Content" from All Content view.
-  
+
 ### Fixed
   - DP-25803: Fix TOC jump link target margin top that blocks page content.
   - DP-25805: Fix accordions collapsing while scrolling on Android/iOS devices issue.
   - DP-25828: Resolve 500 error on decision tree page.
   - DP-25832: Fix accordion tests in patternlab.
-  
+
 
 
 ## [0.334.0] - September 6, 2022
@@ -55,29 +56,29 @@
   - DP-25215: Change description field in collection taxonomy to reflect use for search filtering.
   - DP-25248: Add testing for saving QAG pages.
   - DP-25551: Add rich text field to Service Section paragraph.
-  
+
 ### Changed
   - DP-25339: Extensive help text improvements.
-  
+
 ### Fixed
   - DP-25642: Duplicates of locations exist on service location listing pages.
   - DP-25755: Fixed Behat test failure due to the entity_embed module array to string conversion warning.
   - DP-25762: Fix bug with updated date on events that are public meetings
-  
+
 
 
 ## [0.333.0] - August 30, 2022
 
 ### Changed
   - DP-24286: Adjust the keyboard navigation on the main nav to more make sense to users.
-  
+
 ### Fixed
   - DP-25175: Improve sticky TOC accessibility - make section headings the jump link targets.
   - DP-25638: Missing breadcrumb on some events pages.
-  
+
 ### Removed
   - DP-25409: Cleanup and remove old service page fields no longer needed after flexibility changes.
-  
+
 
 
 ## [0.332.0] - August 9, 2022
@@ -88,18 +89,18 @@
   - DP-25519: Search in some collections doesn't show expected results.
   - DP-25583: Fix issue with thumbnail image when saving content types locally.
   - DP-25597: Fix Bulk watch / unwatch error.
-  
+
 ### Changed
   - DP-25173: Reduce Collection Header vertical spacing, make title H1, and reduce H1 line height, fix logo alignment.
-  
+
 ### Added
   - DP-25211: Enable latest Upgrade Status module.
   - DP-25285: Add a warning message for authors if editing a page that has an existing draft.
   - DP-25408: Add description to curated list content type for each list.
-  
+
 ### Removed
   - DP-25410: Cleanup and remove old ORG page fields no longer needed after flexibility changes.
-  
+
 
 
 ## [0.331.0] - July 26, 2022
@@ -109,22 +110,22 @@
   - DP-25157: Fixes the relationship indicators script on Mayflower to avoid failures on Backstop tests.
   - DP-25473: Fixed mg_organizations metatag value generation on organization pages.
   - DP-25506: Fixed flaky media bulk action tests.
-  
+
 ### Added
   - DP-24958: Add a skip link target indicator at click to verify users' whereabout. Set focus on the target (= anchor) at click to ensure users can navigate page below the TOC.
-  
+
 ### Removed
   - DP-25205: Remove author options to bulk edit or save pages.
-  
+
 ### Security
   - DP-25324: Resolve dependabot security issues on openmass, update Drupal core to 9.4.2.
   - DP-25522: Drupal core update to version 9.4.3.
-  
+
 ### Changed
   - DP-25406: Allow Topic Pages to be a parent page of Form Pages.
   - DP-25468: Allow Rules of Court Pages to be a parent page of Rules of Court Pages.
   - DP-25527: In local development, pin portainer and fix DB persistence
-  
+
 
 
 ## [0.330.0] - July 19, 2022

--- a/composer.json
+++ b/composer.json
@@ -339,7 +339,8 @@
                 "Avoid warnings when getting permissions for roles that do not have permissions and are not administrators": "patches/DP-23561-avoid-warnings-on-roles-without-permissions.patch",
                 "2845144 - User can't reference unpublished content even when they have access to it" : "https://www.drupal.org/files/issues/2022-06-17/2845144-67.patch",
                 "Link error The internal path component is invalid (https://www.drupal.org/project/drupal/issues/2943135)":  "https://www.drupal.org/files/issues/2021-12-01/2943135-31.patch",
-                "Ensure to have build info on View Page Controller before getting the view title" : "patches/DP-24420--View-pages-arguments-title-overrides-not-working--2.patch"
+                "Ensure to have build info on View Page Controller before getting the view title" : "patches/DP-24420--View-pages-arguments-title-overrides-not-working--2.patch",
+                "Bubbling of elements' max-age to the page's headers and the page cache (https://www.drupal.org/project/drupal/issues/2352009#comment-14724015)": "https://www.drupal.org/files/issues/2022-10-07/bubble.patch"
             },
 
             "drupal/conditional_fields": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c424d55a6cb50068d02b18e135653e45",
+    "content-hash": "31df7d404a84c7f714941c9a50e88882",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",


### PR DESCRIPTION
Same as #1731, but as a hotfix.

**Jira:** (Skip unless you are MA staff)
DP-25875

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
