### PR TITLE
Add Swahili, Pashto, and Dari to the list of available languages on Mass.gov

### DIFF
--- a/changelogs/DP-26127.yml
+++ b/changelogs/DP-26127.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add Swahili, Pashto, and Dari to the list of available languages on Mass.gov
+    issue: DP-26127

--- a/conf/drupal/config/language.entity.prs.yml
+++ b/conf/drupal/config/language.entity.prs.yml
@@ -1,0 +1,9 @@
+uuid: d6d75374-2275-42a7-9f9c-0f6067b64dfe
+langcode: en
+status: true
+dependencies: {  }
+id: prs
+label: Dari
+direction: rtl
+weight: 15
+locked: false

--- a/conf/drupal/config/language.entity.pst.yml
+++ b/conf/drupal/config/language.entity.pst.yml
@@ -1,0 +1,9 @@
+uuid: b0ccb795-7e65-444a-9b41-0ecc7aac3990
+langcode: en
+status: true
+dependencies: {  }
+id: pst
+label: Pashto
+direction: rtl
+weight: 14
+locked: false

--- a/conf/drupal/config/language.entity.sw.yml
+++ b/conf/drupal/config/language.entity.sw.yml
@@ -1,0 +1,9 @@
+uuid: 59b4fb77-e19b-400f-b2ac-9d2e3dafd8ce
+langcode: sw
+status: true
+dependencies: {  }
+id: sw
+label: Swahili
+direction: rtl
+weight: 13
+locked: false

--- a/conf/drupal/config/language.negotiation.yml
+++ b/conf/drupal/config/language.negotiation.yml
@@ -31,6 +31,9 @@ url:
     am: am
     '': null
     el: el
+    sw: sw
+    pst: pst
+    prs: prs
   domains:
     en: ''
     es: ''
@@ -57,4 +60,7 @@ url:
     so: ''
     am: ''
     el: ''
+    sw: ''
+    pst: ''
+    prs: ''
 selected_langcode: site_default

--- a/conf/drupal/config/mass_theme.settings.yml
+++ b/conf/drupal/config/mass_theme.settings.yml
@@ -31,10 +31,12 @@ languages:
   ml: ml
   ne: ne
   pl: pl
+  ps: ps
   pt: pt
   ru: ru
   so: so
   sq: sq
+  sw: sw
   ta: ta
   te: te
   th: th
@@ -111,7 +113,6 @@ languages:
   oc: 0
   om: 0
   pa: 0
-  ps: 0
   qu: 0
   rm: 0
   rn: 0
@@ -131,7 +132,6 @@ languages:
   st: 0
   su: 0
   sv: 0
-  sw: 0
   tg: 0
   ti: 0
   tk: 0


### PR DESCRIPTION
**Description:**
Note - Dari is not supported by Google Translate - See https://cloud.google.com/translate/docs/languages 


**Jira:** (Skip unless you are MA staff)
DP-26127


**To Test:**
- [ ] See 3 new languages available in edit UI and 2 new ones in Google Translate widget


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
