### PR TITLE
DP-25587 a11y collection item heading levels

### DIFF
--- a/changelogs/DP-25587.yml
+++ b/changelogs/DP-25587.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Set up the correct heading level to pass on to the MF template for collection page listing items.
+    issue: DP-25587

--- a/composer.json
+++ b/composer.json
@@ -257,7 +257,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-25587_a11y-heading-level-for-collection-listing-items",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -257,7 +257,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-25587_a11y-heading-level-for-collection-listing-items",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a05a652bea2330968b467ea4248f0d16",
+    "content-hash": "59b708c75f02c73b2bfebcf10c0b939e",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12347,16 +12347,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-25587_a11y-heading-level-for-collection-listing-items",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "f7ad60655b978c01fe075c337b25a4ad61a9ee46"
+                "reference": "343fb329f2628eace747ee719171fe4d833d4848"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f7ad60655b978c01fe075c337b25a4ad61a9ee46",
-                "reference": "f7ad60655b978c01fe075c337b25a4ad61a9ee46",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/343fb329f2628eace747ee719171fe4d833d4848",
+                "reference": "343fb329f2628eace747ee719171fe4d833d4848",
                 "shasum": ""
             },
             "require": {
@@ -12376,9 +12376,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25587_a11y-heading-level-for-collection-listing-items"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2022-11-22T16:06:55+00:00"
+            "time": "2022-11-29T10:55:55+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22969,5 +22969,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59b708c75f02c73b2bfebcf10c0b939e",
+    "content-hash": "a05a652bea2330968b467ea4248f0d16",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12347,16 +12347,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-25587_a11y-heading-level-for-collection-listing-items",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "9ae35f6a330546a3d8e23a80e99cd27727b2ceb8"
+                "reference": "f7ad60655b978c01fe075c337b25a4ad61a9ee46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/9ae35f6a330546a3d8e23a80e99cd27727b2ceb8",
-                "reference": "9ae35f6a330546a3d8e23a80e99cd27727b2ceb8",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f7ad60655b978c01fe075c337b25a4ad61a9ee46",
+                "reference": "f7ad60655b978c01fe075c337b25a4ad61a9ee46",
                 "shasum": ""
             },
             "require": {
@@ -12376,9 +12376,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-25587_a11y-heading-level-for-collection-listing-items"
             },
-            "time": "2022-11-16T22:04:02+00:00"
+            "time": "2022-11-22T16:06:55+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -22969,5 +22969,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docroot/themes/custom/mass_theme/templates/content/node--info-details--listing.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--info-details--listing.html.twig
@@ -71,6 +71,7 @@
  */
 #}
 {# Determine how the node should display based on the existence of data listing data. #}
+{% set headingLevel = 3 %}
 {% if content.field_data_flag is defined
   and content.field_data_flag['#items'] is not empty
   and content.field_data_flag['#items'].0.value == 'data' %}
@@ -105,7 +106,7 @@
         "info": "",
         "property": ""
       },
-      "level": "",
+      "level": headingLevel,
       "emphasizedText": organizations,
       "tags": formats,
       "contents": [{
@@ -127,7 +128,7 @@
         "info": "",
         "property": ""
       },
-      "level": "",
+      "level": headingLevel,
       "emphasizedText": "",
       "tags": "",
       "contents": [{


### PR DESCRIPTION
**Description:**
Change `.ma__general-teaser__title`'s heading level from 2 to 3.

**Jira:** (Skip unless you are MA staff)
DP-25587

**To Test:**
- [ ] Go to /collections/qagtest/topic1.
- [ ] Find the heading level of collection item titles as 3 in inspect.

Before
<img width="1132" alt="before" src="https://user-images.githubusercontent.com/9633303/203371068-0fb6e0bd-65d4-4e38-8bce-39137d97b5c1.png">

After 
<img width="1006" alt="after" src="https://user-images.githubusercontent.com/9633303/203372238-09758071-d698-4857-abf2-2c3e33852dc4.png">

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
