### PR TITLE
DP-26965: Related links not showing on News pages with 'news' subtype when there is no contact defined

### DIFF
--- a/changelogs/DP-26965.yml
+++ b/changelogs/DP-26965.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Related links not showing on News pages with 'news' subtype when there is no contact defined.
+    issue: DP-26965

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3269,16 +3269,20 @@ function mass_theme_preprocess_node_news_full(&$variables) {
     $cache_tags = array_merge($cache_tags, $author->getCacheTags());
   }
 
+  $is_blog_post = FALSE;
+  $is_news = FALSE;
   switch ($node->field_news_type->value) {
     case 'blog_post':
     case 'guest_post':
       $is_blog_post = TRUE;
       break;
 
-    default:
-      $is_blog_post = FALSE;
+    case 'news':
+      $is_news = TRUE;
+      break;
   }
   $variables['is_blog_post'] = $is_blog_post;
+  $variables['is_news'] = $is_news;
 
   $variables['blogpostCollectionHeader'] = [];
 

--- a/docroot/themes/custom/mass_theme/templates/content/node--news.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--news.html.twig
@@ -127,7 +127,7 @@
 
     {% set aside_has_content =
       (not is_blog_post and sidebar.contactList) or
-      show_blogpost_author
+      show_blogpost_author or is_news
     %}
 
     {% set author_section %}


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-26965


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
