### PR TITLE
Added an ensure item for links - DP-26973

### DIFF
--- a/changelogs/DP-26973.yml
+++ b/changelogs/DP-26973.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed Behat XSS test failures for link fields.
+    issue: DP-26973

--- a/docroot/modules/custom/mass_xss/mass_xss.module
+++ b/docroot/modules/custom/mass_xss/mass_xss.module
@@ -73,9 +73,6 @@ function mass_xss_ensure_item(ContentEntityInterface $entity, FieldDefinitionInt
       case 'image':
         $item = ['target_id' => 56];
         break;
-
-      case 'link':
-        $item = ['uri' => 'internal:/'];
     }
     $field->appendItem($item);
   }
@@ -110,6 +107,9 @@ function mass_xss_xssify_entity(ContentEntityInterface $entity) {
       case 'google_map_field':
       case 'daterange':
       case 'geofield':
+      case 'map':
+      case 'dynamic_entity_reference':
+      case 'entity_reference_hierarchy':
         break;
 
       // These field types are vulnerable:
@@ -119,7 +119,6 @@ function mass_xss_xssify_entity(ContentEntityInterface $entity) {
       case 'string_long':
       case 'list_string':
       case 'text_long':
-      case 'video_embed_field':
       case 'email':
       case 'telephone':
       case 'video_embed_field':
@@ -176,8 +175,7 @@ function mass_xss_xssify_entity(ContentEntityInterface $entity) {
         break;
 
       case 'link':
-        // We don't ensure link fields because it breaks too much stuff.
-        // @see https://jira.state.ma.us/browse/DP-6957
+        mass_xss_ensure_item($entity, $definition);
         foreach ($entity->get($definition->getName()) as $item) {
           $item->set('title', mass_xss_str($entity, $definition));
         }


### PR DESCRIPTION
**Description:**
Previously, we were not ensuring link items in Mass XSS. But, this has presented a problem recently when running Behat tests. So, I included this function for link fields, which we were previously not including it seems due to several other proposed tickets that ended not being completed (see the comments in DP-6957).

**Jira:** (Skip unless you are MA staff)
DP-26973


**To Test:**
- [ ] Check that Behat tests pass


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
