### PR TITLE
DP-27264-entity-usage-domain-add

### DIFF
--- a/changelogs/DP-27264.yml
+++ b/changelogs/DP-27264.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Added bare mass.gov domain to entity usage config to increase tracking of URLs specified by authors with www.
+    issue: DP-27264

--- a/conf/drupal/config/entity_usage.settings.yml
+++ b/conf/drupal/config/entity_usage.settings.yml
@@ -25,5 +25,5 @@ site_domains:
   - mass.gov
 edit_warning_message_entity_types: {  }
 delete_warning_message_entity_types: {  }
-usage_controller_items_per_page: 1
+usage_controller_items_per_page: 25
 usage_controller_subquery: true

--- a/conf/drupal/config/entity_usage.settings.yml
+++ b/conf/drupal/config/entity_usage.settings.yml
@@ -22,7 +22,8 @@ track_enabled_plugins:
 track_enabled_base_fields: true
 site_domains:
   - www.mass.gov
+  - mass.gov
 edit_warning_message_entity_types: {  }
 delete_warning_message_entity_types: {  }
-usage_controller_items_per_page: 25
+usage_controller_items_per_page: 1
 usage_controller_subquery: true


### PR DESCRIPTION
**Description:**
Add "mass.gov" bare domain to entity usage config


**Jira:** (Skip unless you are MA staff)
DP-27264


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
