### PR TITLE
DP-27421: Remove cache busting string from URLs fetched by Backstop for references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,6 +449,7 @@ jobs:
       tugboat:
         type: string
         default: ""
+      # Set this to true by default to not change any existing behaviour.
       cachebuster:
         type: boolean
         default: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ parameters:
   viewport:
     type: string
     default: "all"
+  cachebuster:
+    type: boolean
+    default: false
 
   # These params for currently used in drush ma:release
   ma-release:
@@ -446,29 +449,38 @@ jobs:
       tugboat:
         type: string
         default: ""
+      cachebuster:
+        type: boolean
+        default: true
     resource_class: xlarge
     docker:
       - image: backstopjs/backstopjs
     steps:
       - checkout
       - run:
+          name: "Setup environment variables"
+          command: |
+            if [ "<< parameters.cachebuster >>" = "true" ]; then
+              echo 'export CACHEBUSTER="--cachebuster"' >> "$BASH_ENV"
+            fi
+      - run:
           name: Backstop reference
           working_directory: backstop
-          command: backstop --config=backstop.js reference --target=<< parameters.reference >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --cachebuster
+          command: backstop --config=backstop.js reference --target=<< parameters.reference >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> ${CACHEBUSTER}
       - when:
           condition: << parameters.tugboat >>
           steps:
             - run:
                 name: Backstop test (Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >> --cachebuster
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >> ${CACHEBUSTER}
       - unless:
           condition: << parameters.tugboat >>
           steps:
             - run:
                 name: Backstop test (non Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --cachebuster
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> ${CACHEBUSTER}
                 no_output_timeout: 300m
       - store_test_results:
           path: backstop/report
@@ -486,16 +498,25 @@ jobs:
       viewport:
         type: string
         default: all
+      cachebuster:
+        type: boolean
+        default: false
     resource_class: xlarge
     docker:
       - image: backstopjs/backstopjs
     steps:
       - checkout
       - run:
+          name: "Setup environment variables"
+          command: |
+            if [ "<< parameters.cachebuster >>" = "true" ]; then
+              echo 'export CACHEBUSTER="--cachebuster"' >> "$BASH_ENV"
+            fi
+      - run:
           name: Capture Backstop Reference Screenshots
           working_directory: backstop
           command: |
-            backstop --config=backstop.js reference --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >>
+            backstop --config=backstop.js reference --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> ${CACHEBUSTER}
       - run:
           name: Archive Reference Screenshots
           command: |
@@ -536,11 +557,20 @@ jobs:
       tugboat:
         type: string
         default: ""
+      cachebuster:
+        type: boolean
+        default: false
     resource_class: xlarge
     docker:
       - image: backstopjs/backstopjs
     steps:
       - checkout
+      - run:
+          name: "Setup environment variables"
+          command: |
+            if [ "<< parameters.cachebuster >>" = "true" ]; then
+              echo 'export CACHEBUSTER="--cachebuster"' >> "$BASH_ENV"
+            fi
       - run:
           name: Verify Artifacts
           command: |
@@ -578,14 +608,14 @@ jobs:
             - run:
                 name: Backstop test (Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >>
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >> ${CACHEBUSTER}
       - unless:
           condition: << parameters.tugboat >>
           steps:
             - run:
                 name: Backstop test (non Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >>
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> ${CACHEBUSTER}
                 no_output_timeout: 300m
       - store_test_results:
           path: backstop/report
@@ -1141,6 +1171,7 @@ workflows:
           list: << pipeline.parameters.list >>
           viewport: << pipeline.parameters.viewport >>
           tugboat: << pipeline.parameters.tugboat >>
+          cachebuster: << pipeline.parameters.cachebuster >>
 
   # Usually triggered by drush ma:release.
   deploy_ad_hoc:
@@ -1181,6 +1212,7 @@ workflows:
           target: << pipeline.parameters.target >>
           list: << pipeline.parameters.list >>
           viewport: << pipeline.parameters.viewport >>
+          cachebuster: << pipeline.parameters.cachebuster >>
 
   backstop_compare:
     when:
@@ -1193,6 +1225,7 @@ workflows:
           list: << pipeline.parameters.list >>
           viewport: << pipeline.parameters.viewport >>
           tugboat: << pipeline.parameters.tugboat >>
+          cachebuster: << pipeline.parameters.cachebuster >>
 
 # Nightly deploy develop branch (with the latest Mayflower develop branch) to the CD environment, runs at 11:00PM EST.
 # Add the backstop one in here

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,21 +454,21 @@ jobs:
       - run:
           name: Backstop reference
           working_directory: backstop
-          command: backstop --config=backstop.js reference --target=<< parameters.reference >> --list=<< parameters.list >> --viewport=<< parameters.viewport >>
+          command: backstop --config=backstop.js reference --target=<< parameters.reference >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --cachebuster
       - when:
           condition: << parameters.tugboat >>
           steps:
             - run:
                 name: Backstop test (Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >>
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --tugboat=<< parameters.tugboat >> --cachebuster
       - unless:
           condition: << parameters.tugboat >>
           steps:
             - run:
                 name: Backstop test (non Tugboat target)
                 working_directory: backstop
-                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >>
+                command: backstop --config=backstop.js test --target=<< parameters.target >> --list=<< parameters.list >> --viewport=<< parameters.viewport >> --cachebuster
                 no_output_timeout: 300m
       - store_test_results:
           path: backstop/report

--- a/backstop/README.md
+++ b/backstop/README.md
@@ -23,12 +23,14 @@ they look the same.
 ## Options
 
 ```
---target=local   # Choose an enviornment to target(feature#, test, or prod)
-                 # `local` is default
+--target=local  # Choose an enviornment to target(feature#, test, or prod)
+                # `local` is default
 --list=all	    # Choose a json page to run with backstop (all or post-release)
                 # `all` is default
                 # `post-release` runs fewer scenarios, and is run automatically after a release
---viewport=all   # Options are desktop, tablet, phone, or all (default)
+--viewport=all  # Options are desktop, tablet, phone, or all (default)
+
+--cachebuster   # Appends a cache busting query string to URLs of pages to be tested.
 ```
 
 - `pages.json` is the list pages that are tested when Backstop is run. This is
@@ -82,6 +84,12 @@ used later by `drush ma:backstop-compare` e.g.
 ```
 drush ma:ci:backstop-snapshot --target=prod
 drush ma:ci:backstop-compare --reference=prod --target=test
+```
+
+If you want to run a specific branch you're working on to test changes, you can
+use the `--ci-branch` parameter.
+```
+drush ma:ci:backstop-snapshot --target=prod --ci-branch=dp-26913-run-backstop-js-locally
 ```
 
 You can also run the tests using CircleCi's [local CLI](https://circleci.com/docs/local-cli/).

--- a/backstop/backstop.js
+++ b/backstop/backstop.js
@@ -86,7 +86,8 @@ const scenarios = pages.map(function(page) {
   }
   return {
     ...page,
-    url: `${base}${page.url}${separator}cachebuster=${Math.random().toString(36).substring(7)}`,
+    //url: `${base}${page.url}${separator}cachebuster=${Math.random().toString(36).substring(7)}`,
+    url: `${base}${page.url}`,
     misMatchThreshold: 0.1,
     auth,
   }

--- a/backstop/backstop.js
+++ b/backstop/backstop.js
@@ -1,6 +1,7 @@
 // Determine the list of urls to use with backstop
 const opt = process.argv.filter(arg=>arg.match(/^--list=/));
 const file = opt.length ? opt[0].replace('--list=', '') : 'all';
+const withCache = process.argv.filter(arg=>arg.match(/^--cachebuster/)).length > 0;
 
 let pages;
 
@@ -86,8 +87,7 @@ const scenarios = pages.map(function(page) {
   }
   return {
     ...page,
-    //url: `${base}${page.url}${separator}cachebuster=${Math.random().toString(36).substring(7)}`,
-    url: `${base}${page.url}`,
+    url: withCache ? `${base}${page.url}${separator}cachebuster=${Math.random().toString(36).substring(7)}` : `${base}${page.url}`,
     misMatchThreshold: 0.1,
     auth,
   }

--- a/changelogs/DP-25389.yml
+++ b/changelogs/DP-25389.yml
@@ -1,0 +1,6 @@
+Type:
+  - description: |
+      Remove cache busting string from URLs fetched by Backstop for references in
+      the new job which only collects reference images. Also adds a
+      `--cachebuster` parameter to the relevant drush jobs.
+    issue: DP-25389

--- a/changelogs/DP-25389.yml
+++ b/changelogs/DP-25389.yml
@@ -1,6 +1,0 @@
-Type:
-  - description: |
-      Remove cache busting string from URLs fetched by Backstop for references in
-      the new job which only collects reference images. Also adds a
-      `--cachebuster` parameter to the relevant drush jobs.
-    issue: DP-25389

--- a/changelogs/DP-27421.yml
+++ b/changelogs/DP-27421.yml
@@ -1,0 +1,3 @@
+Changed:
+  - description: Remove cache busting string from URLs fetched by Backstop for references
+    issue: DP-27421

--- a/changelogs/DP-27421.yml
+++ b/changelogs/DP-27421.yml
@@ -1,3 +1,6 @@
 Changed:
-  - description: Remove cache busting string from URLs fetched by Backstop for references
+  - description: |
+      Remove cache busting string from URLs fetched by Backstop for references
+      in the new job which only collects reference images. Also adds a
+      `--cachebuster` parameter to the relevant drush jobs.
     issue: DP-27421

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -193,7 +193,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     $this->logger()->success($this->getSuccessMessage($body));
   }
 
-  
+
   /**
    * Write the download link for the most recent database backup to stdout.
    *

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -109,6 +109,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @option list The list you want to run. Recognized values: page, all, post-release. See backstop/backstop.js
    * @option viewport The viewport you want to run.  Recognized values: desktop, tablet, phone. See backstop/backstop.js.
    * @option ci-branch The branch that CircleCI should check out at start, default value is "develop"
+   * @option cachebuster Appends a cache busting query string to URLs of pages to be tested
    * @usage drush ma:ci:backstop-snapshot --target=prod
    *   Create a backstop snapshot from production.
    * @aliases ma-ci-backstop-snapshot
@@ -117,7 +118,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @throws \Exception
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function ci_backstop_snapshot(array $options = ['target' => 'prod', 'ci-branch' => 'develop', 'list' => 'all', 'viewport' => 'all']): void {
+  public function ci_backstop_snapshot(array $options = ['target' => 'prod', 'ci-branch' => 'develop', 'list' => 'all', 'viewport' => 'all', 'cachebuster' => false]): void {
     $stack = $this->getStack();
     $client = new \GuzzleHttp\Client(['handler' => $stack]);
     $options = [
@@ -130,6 +131,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
           'target' => $options['target'],
           'list' => $options['list'],
           'viewport' => $options['viewport'],
+          'cachebuster' => $options['cachebuster'],
         ],
       ],
     ];
@@ -153,6 +155,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @option list The list you want to run. Recognized values: page, all, post-release. See backstop/backstop.js
    * @option viewport The viewport you want to run.  Recognized values: desktop, tablet, phone. See backstop/backstop.js.
    * @option ci-branch The branch that CircleCI should check out at start, default value is "develop"
+   * @option cachebuster Appends a cache busting query string to URLs of pages to be tested
    * @usage drush ma:ci:backstop-compare --reference=prod --target=test
    *   Run backstop in the test environment against the latest production screenshots
    *   Create a backstop snapshot from production.
@@ -162,7 +165,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @throws \Exception
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
-  public function ci_backstop_compare(array $options = ['reference' => 'prod', 'target' => 'test', 'ci-branch' => 'develop', 'list' => 'all', 'viewport' => 'all']): void {
+  public function ci_backstop_compare(array $options = ['reference' => 'prod', 'target' => 'test', 'ci-branch' => 'develop', 'list' => 'all', 'viewport' => 'all', 'cachebuster' => false]): void {
     $stack = $this->getStack();
     $client = new \GuzzleHttp\Client(['handler' => $stack]);
     $options = [
@@ -176,6 +179,7 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
           'target' => $options['target'],
           'list' => $options['list'],
           'viewport' => $options['viewport'],
+          'cachebuster' => $options['cachebuster']
         ],
       ],
     ];


### PR DESCRIPTION
**Description:**
Hopefully stop timeouts when fetching reference pages

**Jira:** (Skip unless you are MA staff)
DP-27421


**To Test:**
- [ ] Run the backstop-snapshot and backstop-compare drush commands with/without the new `--cachebuster` option e.g.
    Result of `ddev drush ma:ci:backstop-snapshot --target=prod --ci-branch=justafish/DP-27421-remove-backstop-cachebust`:
    https://app.circleci.com/pipelines/github/massgov/openmass/23907/workflows/f4b82c15-0fd1-46df-aae4-15c81248dc06

    Result of `ddev drush ma:ci:backstop-snapshot --target=prod --ci-branch=justafish/DP-27421-remove-backstop-cachebust --cachebuster` (it timed out):
    https://app.circleci.com/pipelines/github/massgov/openmass/23908/workflows/a2259fd9-66de-4562-b367-dffd5d533068
- [ ] Open the "Cache Backstop Reference Screenshots" step and verify URLs being tested do/do not have a cache busting query string as appropriate

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
