### PR TITLE
Hotfix: Fix php error in drush ma:queue-revision-cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [0.352.1] - March 2, 2023
 
 ### Fixed
-- DP-27400: Fix php error in: drush ma:queue-revision-cleanup
+- DP-27400: Fix php error in: drush ma:queue-revision-cleanup.
 
 ## [0.352.0] - February 28, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
+## [0.352.1] - March 2, 2023
 
+### Fixed
+- DP-27400: Fix php error in: drush ma:queue-revision-cleanup
 
 ## [0.352.0] - February 28, 2023
 
@@ -16,29 +19,29 @@
   - DP-27213: Upgrade Drupal Rector and related dependencies
   - DP-27234: Upgrade Drush for more robust deployments
   - DP-27264: Added bare mass.gov domain to entity usage config to increase tracking of URLs specified by authors with www.
-  
+
 ### Added
   - DP-26079: Add suggestion list state to search input.
-  
+
 ### Fixed
   - DP-27248: Corrected URL of backstop test page.
-  
+
 
 
 ## [0.351.0] - February 14, 2023
 
 ### Added
   - DP-24435: Add option to toggle language bar labels.
-  
+
 ### Fixed
   - DP-26967: Style issue with header iframe on visual story info detail page.
-  
+
 ### Security
   - DP-27215: Drupal core major version (9.5.3) and DangerJS update.
-  
+
 ### Changed
   - DP-27227: Added default settings for entity usage queue tracking that can be overridden.
-  
+
 
 
 ## [0.350.0] - February 7, 2023
@@ -50,35 +53,35 @@
   - DP-27097.yml: Remove and block non-Azure logins for Drupal
   - DP-27143: Disallow bot traffic from Semrush.
   - DP-27176: More fields added to CSV export files for the All Content view.
-  
+
 ### Fixed
   - DP-27002: Fix form display for Collection selection on External link for Collections
   - DP-27163: Fix style issue with press release view.
   - DP-27164: Fix Google Translate styles caused by a classname change by Google.
-  
+
 ### Removed
   - DP-27049: Removed real pages from Backstop
   - DP-27157: Remove the background image from the form requirements section in form pages.
-  
+
 
 
 ## [0.349.0] - January 31, 2023
 
 ### Removed
   - DP-25783: Remove feedback survey UI from edit.mass.gov.
-  
+
 ### Changed
   - DP-26177: Update Purge, Acquia purge, Akamai modules
-  
+
 ### Added
   - DP-26735: New view showing recent press releases. Not linked at this time.
   - DP-26959: Add bulk edit to the "All documents" view for administrators.
   - DP-27072: New administrative view showing who has flagged what content to watch it. This will help testing of content migrations.
-  
+
 ### Fixed
   - DP-27000: Fix radio button and checkbox sizes in collection view.
   - DP-27077: Remove config warnings for Azure AD
-  
+
 
 
 ## [0.348.0] - January 24, 2023
@@ -88,17 +91,17 @@
   - DP-26328: Updated Collections view to use active cache invalidation.
   - DP-26840: Updated the Entity Usage Queue Tracking module with improvements to the cleaning command.
   - DP-26854: Fixed small bugs and removed unused code related to CircleCI jobs
-  
+
 ### Added
   - DP-26736: Updates to orphan view.
-  
+
 ### Fixed
   - DP-26999: Reset feedback form text area validation on radio button change.
   - DP-27003: Bug - not seeing all document language links shown.
-  
+
 ### Security
   - DP-27004: Drupal core and Entity Browser module security update.
-  
+
 
 
 ## [0.347.0] - January 17, 2023
@@ -106,16 +109,16 @@
 ### Added
   - DP-24550: Display link to document in multiple languages.
   - DP-26806: Add apple site icons.
-  
+
 ### Changed
   - DP-26327: Backend changes to org feedback options.
   - DP-26864: Change views to not show any results until there are filters added by user and user pushes button.
   - DP-26965: Related links not showing on News pages with 'news' subtype when there is no contact defined.
-  
+
 ### Fixed
   - DP-26649: Fix org nav being cut off at the bottom of the screen on mobile.
   - DP-26973: Fixed Behat XSS test failures for link fields.
-  
+
 
 
 ## [0.346.0] - January 10, 2023
@@ -128,15 +131,15 @@
   - DP-26612: Add help text paragraph below H1 on page based feedback for authors.
   - DP-26766: Remove legacy "Pages Linking Here" tab and show new tab for all authors.
   - DP-26750: Modifications to the user view used by administrators, including downloadable CSV.
-  
+
 ### Fixed
   - DP-26222: A11y - Popular searches fix.
   - DP-26715: Bug - error in bulk job to add items to collection.
-  
+
 ### Security
   - DP-26767: Bump decode-uri-component from 0.2.0 to 0.2.2.
   - DP-26805: Dependabot - Multiple vulnerabilities.
-  
+
 
 
 ## [0.345.0] - December 13, 2022
@@ -144,17 +147,17 @@
 ### Changed
   - DP-25839: Removed the second set of <main> with its duplilcate ID from guide page.
   - DP-26300: Hide Offered By on Executive Order content.
-  
+
 ### Added
   - DP-26013: Added Azure AD integration.
-  
+
 ### Fixed
   - DP-26312: Fixed issue with referencing nodes with long titles via the Redirects tab.
   - DP-26642: Fixed missing validation for custom search components on service pages.
-  
+
 ### Removed
   - DP-26700: Eliminate author message to setup 2 factor auth that users see when logging in.
-  
+
 
 
 ## [0.344.0] - December 6, 2022
@@ -162,7 +165,7 @@
 ### Added
   - DP-25357: Added entity usage queue tracking module, and improved entity usage performance.
   - DP-26467: Report showing non-English documents and their English relatives.
-  
+
 ### Changed
   - DP-25587: Set up the correct heading level to pass on to the MF template for collection page listing items.
   - DP-25901: Changed Collection Search to a general search component for either collections or custom searches.
@@ -173,11 +176,11 @@
   - DP-26593: Advanced search report - Added org and parent fields to results, default order for pageviews changed to descending
   - DP-26593: All documents view - added filter for search status, any org filter will be remembered for future searches
   - DP-26593: All documents CSV export - added fields - extension, file size, created date, english version, search status, language.
-  
+
 ### Fixed
   - DP-26284: Un-install jsonapi_page_limit module to fix jsonapi page limit and offset query parameters.
   - DP-26492: Unpublished pages with maps still have published location listing pages, follow-up fix of breadcrumb rendering.
-  
+
 
 
 ## [0.343.0] - November 29, 2022

--- a/docroot/modules/custom/mass_utility/src/BatchService.php
+++ b/docroot/modules/custom/mass_utility/src/BatchService.php
@@ -24,7 +24,7 @@ class BatchService {
    * @param \DrushBatchContext $context
    *   Context for operations.
    */
-  public function populateRevisionsCleanupQueue(array $nids, $timestamp, $batch, DrushBatchContext &$context) {
+  public static function populateRevisionsCleanupQueue(array $nids, $timestamp, $batch, DrushBatchContext &$context) {
     if (empty($context['sandbox'])) {
       $context['sandbox']['progress'] = 0;
     }
@@ -83,7 +83,7 @@ class BatchService {
    * @param array $operations
    *   Array of operations.
    */
-  public function populateRevisionsCleanupQueueFinished($success, array $results, array $operations) {
+  public static function populateRevisionsCleanupQueueFinished($success, array $results, array $operations) {
     $messenger = \Drupal::service('messenger');
     if ($success) {
       $messenger->addMessage(

--- a/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
+++ b/docroot/modules/custom/mass_utility/src/Commands/MassUtilityCommands.php
@@ -293,7 +293,7 @@ class MassUtilityCommands extends DrushCommands {
    * @option offset
    *   Determines how many records to skip. Defaults to 0.
    * @option timestamp
-   *   The timestamp to use when processing revisions. Defaults to 14 months ago.
+   *   The unix timestamp to use when processing revisions. Defaults to a timestamp that is 14 months ago.
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Exception


### PR DESCRIPTION
**Description:**
Fix drush ma:queue-revision-cleanup --idlist=64361 --timestamp="1675359781". Its error is 

```
TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method Drupal\mass_utility\BatchService::populateRevisionsClea
  nupQueue() cannot be called statically in call_user_func_array() (line 256 of /mnt/www/html/massgovstg/vendor/drush/drush/includes/batch.inc).
```


**Jira:** (Skip unless you are MA staff)
DP-27400


**To Test:**
- [ ] Run above command


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
