### PR TITLE
Stop using memcache for entity and render caches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.352.2] - March 3, 2023
+
+### Fixed
+- DP-27400: Stop storing entity and render caches in Memcache.
+
 ## [0.352.1] - March 2, 2023
 
 ### Fixed

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -89,9 +89,12 @@ $configureMemcache = function($settings) use ($app_root, $site_path, $class_load
   $settings['cache']['bins']['default'] = 'cache.backend.memcache';
   $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
   $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.database';
-  $settings['cache']['bins']['entity'] = 'cache.backend.memcache';
+
+  // Acquia doesn't recommend these in memcache and we are seeing Revision confusion at https://edit.mass.gov/info-details/covid-19-response-reporting/revisions
+  // $settings['cache']['bins']['entity'] = 'cache.backend.memcache';
+  // $settings['cache']['bins']['render'] = 'cache.backend.memcache';
+
   $settings['cache']['bins']['menu'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['render'] = 'cache.backend.memcache';
   // All other cache bins are stored in the database.
 
   return $settings;


### PR DESCRIPTION
**Description:**
Stop storing render and entity caches in Memcache per https://docs.acquia.com/cloud-platform/performance/memcached/enable/ and https://github.com/acquia/memcache-settings/blob/main/memcache.settings.php. Also helps address revision confusion in the Jira issue noted below.

Eventually we should probably use the exact settings recommended by Acquia. But lets start a bit slower than that and make sure DB is healthy with new load.


**Jira:** (Skip unless you are MA staff)
DP-27400


**To Test:**
- [ ] See rows in cache_entity DB table


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
