### PR TITLE
DP-25829: Wait for leaflet map tiles and markers to load before taking a screenshot with Backstop

### DIFF
--- a/changelogs/DP-25829.yml
+++ b/changelogs/DP-25829.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Fixes Backstop ready code to wait for leaflet map tiles and markers to load before taking a screenshot
+    issue: DP-25829


### PR DESCRIPTION
**Description:**
Changes Backstop's ready function to wait until map tile images and map marker images have been loaded before taking a screenshot to prevent partially loaded maps being used for references/tests.


**Jira:** (Skip unless you are MA staff)
DP-25829


**To Test:**
- [ ] Change `backstop/all.json` to the following:
  ```
  [
    {"label": "OrgElectedOfficial", "url": "/orgs/qag-test-elected-org-page"},
    {"label": "OrgsNewsAnnouncements", "url": "/orgs/qag-executive-office-of-technology-services-and-security/news"}
  ]
  ```
- [ ] Run `ddev backstop reference --target=prod --list=all`
- [ ] Open the reference screenshots in `backstop/references` and verify you see the full map load
- [ ] Run `ddev backstop test --target=prod --list=all` and verify the test runs successfully

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
