### PR TITLE
DP-27545:  Disable Global Alerts in Backstop

### DIFF
--- a/backstop/all.json
+++ b/backstop/all.json
@@ -2,7 +2,6 @@
   {"label": "404", "url": "/this-page-does-not-exist"},
   {"label": "Document", "url": "/media/1268726", "screens": ["desktop", "mobile"]},
   {"label": "Homepage", "url": "/"},
-  {"label": "HomepageWithAlert", "url":  "/", "hideAlerts":  false},
   {"label": "Homepage Login link (Large sizes)", "delay": 2000, "url": "/", "clickSelector": ".ma__header__hamburger__utility-nav .ma__utility-nav__items li.ma__utility-nav__item:last-child button.ma__utility-nav__link", "screens": ["desktop", "tablet"] },
   {"label": "Homepage Login link (Mobile)", "delay": 2000, "url": "/", "screens": ["mobile"]},
   {"label": "Advisory", "url": "/memorandum/qag-advisory"},
@@ -70,8 +69,6 @@
   {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"},
   {"label": "InfoDetailsImageLeftAlign", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-text-wrap-full-width"},
   {"label": "InfoDetailsImageRightAlign", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-wrap-full-width"},
-  {"label": "ExpansionOfAccordions1", "url": "/report/qag-binderreport", "screens": ["desktop"]},
-  {"label": "ExpansionOfAccordions1_toggle", "url": "/report/qag-binderreport", "screens": ["desktop"]},
-  {"label": "ExpansionOfAccordions2", "url": "/how-to/qag-request-help-with-a-computer-problem", "screens": ["desktop"]},
-  {"label": "ExpansionOfAccordions2_toggle", "url": "/how-to/qag-request-help-with-a-computer-problem", "screens": ["desktop"]}
+  {"label": "ExpansionOfAccordions1", "url": "/report/qag-binderreport", "screens": ["desktop"], "showHeaderAlerts":  true},
+  {"label": "ExpansionOfAccordions1_toggle", "url": "/report/qag-binderreport", "screens": ["desktop"], "showHeaderAlerts":  true}
 ]

--- a/backstop/all.json
+++ b/backstop/all.json
@@ -69,6 +69,8 @@
   {"label": "InfoDetailsImageNoWrapRight", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-no-wrap"},
   {"label": "InfoDetailsImageLeftAlign", "url": "/info-details/qaginfo-details-image-in-section-left-align-with-text-wrap-full-width"},
   {"label": "InfoDetailsImageRightAlign", "url": "/info-details/qaginfo-details-image-in-section-right-align-with-wrap-full-width"},
-  {"label": "ExpansionOfAccordions1", "url": "/report/qag-binderreport", "screens": ["desktop"], "showHeaderAlerts":  true},
-  {"label": "ExpansionOfAccordions1_toggle", "url": "/report/qag-binderreport", "screens": ["desktop"], "showHeaderAlerts":  true}
+  {"label": "ExpansionOfAccordions1", "url": "/how-to/qag-request-help-with-a-computer-problem", "screens": ["desktop"], "showHeaderAlerts":  true},
+  {"label": "ExpansionOfAccordions1_toggle", "url": "/how-to/qag-request-help-with-a-computer-problem", "screens": ["desktop"], "showHeaderAlerts":  true},
+  {"label": "ExpansionOfAccordions2", "url": "/report/qag-binderreport", "screens": ["desktop"]},
+  {"label": "ExpansionOfAccordions2_toggle", "url": "/report/qag-binderreport", "screens": ["desktop"]}
 ]

--- a/backstop/backstop.js
+++ b/backstop/backstop.js
@@ -90,7 +90,7 @@ const scenarios = pages.map(function(page) {
     removeSelectors.push('.pre-content .mass-alerts-block');
   }
   if (!page.showGlobalAlerts) {
-    removeSelectors.push('.ma__emergency-alerts');
+    removeSelectors.push('.mass-alerts-block[data-alerts-path="/alerts/sitewide"]');
   }
   return {
     ...page,

--- a/backstop/backstop.js
+++ b/backstop/backstop.js
@@ -26,6 +26,7 @@ const target = opts.length ? opts[0].replace('--target=', '') : 'prod';
 const scenarios = pages.map(function(page) {
   let base = process.env.BASE_URL;
   let auth = false;
+  let removeSelectors = [];
 
   switch (target) {
     case 'prod':
@@ -85,11 +86,18 @@ const scenarios = pages.map(function(page) {
       });
     }
   }
+  if (!page.showHeaderAlerts) {
+    removeSelectors.push('.pre-content .mass-alerts-block');
+  }
+  if (!page.showGlobalAlerts) {
+    removeSelectors.push('.ma__emergency-alerts');
+  }
   return {
     ...page,
     url: withCache ? `${base}${page.url}${separator}cachebuster=${Math.random().toString(36).substring(7)}` : `${base}${page.url}`,
     misMatchThreshold: 0.1,
     auth,
+    removeSelectors,
   }
 });
 

--- a/backstop/post-release.json
+++ b/backstop/post-release.json
@@ -1,6 +1,5 @@
 [
   {"label": "Document", "url": "/media/1268726"},
-  {"label": "HomepageWithAlert", "url":  "/", "showAlerts":  true},
   {"label": "BinderAudit", "url": "/audit/qag-binderaudit"},
   {"label": "CampaginLandingHeaderBg", "url": "/qagcampaign-landing-with-image-key-message-header"},
   {"label": "CuratedListLinksDocs", "url": "/lists/qag-curatedlist"},

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -171,47 +171,6 @@ module.exports = async function (page, scenario, vp) {
     throw new Error(`${e.constructor.name}: Failed waiting for leaflet map to load on this page: ${page.url()}.`)
   }
 
-  if (!scenario.hideAlerts || scenario.hideAlerts === undefined) {
-    // Wait for a selector to become visible.
-    let expanded = await page.evaluate(async function () {
-      let result = undefined;
-      var el = document.querySelector( '.ma__emergency-header__toggle');
-      if (el !== null) {
-        if (el.getAttribute('aria-expanded') == true) {
-          result = true;
-        }
-        else {
-          result = false;
-        }
-      }
-      return result;
-    });
-    if (expanded == true) {
-      await page.waitForSelector('span.ma__emergency-alert__time-stamp', {
-        visible: true,
-        timeout: 10000,
-      })
-      await page.evaluate(async function () {
-        document.querySelector('.ma__emergency-alert__time-stamp').innerText = 'May. 24th, 2021, 5:00 pm';
-        document.querySelector('.ma__emergency-alert__link a.ma__content-link span:first-child').innerText = 'Everyone age 5+ should get a COVID-19 booster. Anyone age 50+ may get a second booster. See the latest updates as of ';
-      });
-    }
-    else if (expanded == false) {
-      await page.waitForSelector('.ma__emergency-header__toggle', {
-        visible: true,
-        timeout: 10000,
-      })
-    }
-
-    await page.waitForTimeout(1000);
-  }
-  else {
-    await page.evaluate(async function () {
-      var el = document.querySelector('.mass-alerts-block');
-      el.parentNode.removeChild(el);
-    })
-  }
-
   // Wait for iframes to be resized at least once.
   // Avoid iframes with fixed height.
   try {
@@ -255,15 +214,17 @@ module.exports = async function (page, scenario, vp) {
     // Emergency alert.
     case "ExpansionOfAccordions1_toggle":
       try {
-        await page.waitForSelector('.ma__emergency-alerts .ma__emergency-header__toggle', {
-          visible: true,
-          timeout: 10000,
-        });
-        await page.click('.ma__emergency-alerts .ma__emergency-header__toggle');
-        await page.waitForSelector('.ma__emergency-alerts__content', {
-          visible: true,
-          timeout: 60000,
-        });
+        if (scenario.showHeaderAlerts) {
+          await page.waitForSelector('.ma__emergency-alerts .ma__emergency-header__toggle', {
+            visible: true,
+            timeout: 10000,
+          });
+          await page.click('.ma__emergency-alerts .ma__emergency-header__toggle');
+          await page.waitForSelector('.ma__emergency-alerts__content', {
+            visible: true,
+            timeout: 60000,
+          });
+        }
       }
       catch (e) {
         console.error(e);
@@ -273,15 +234,17 @@ module.exports = async function (page, scenario, vp) {
     // Standard alert.
     case "ExpansionOfAccordions2_toggle":
       try {
-        await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__header__toggle', {
-          visible: true,
-          timeout: 10000,
-        });
-        await page.click('.pre-content .mass-alerts-block .ma__action-step__header__toggle');
-        await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__content', {
-          visible: true,
-          timeout: 60000,
-        });
+        if (scenario.showGlobalAlerts) {
+          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__header__toggle', {
+            visible: true,
+            timeout: 10000,
+          });
+          await page.click('.pre-content .mass-alerts-block .ma__action-step__header__toggle');
+          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__content', {
+            visible: true,
+            timeout: 60000,
+          });
+        }
       }
       catch (e) {
         console.error(e);

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -117,10 +117,15 @@ module.exports = async function (page, scenario, vp) {
   // All the alerts on the page must be processed.
   try {
     await page.waitForFunction("document.querySelectorAll('.mass-alerts-block').length == document.querySelectorAll('.mass-alerts-block[data-alert-processed]').length", {
-      timeout: 6000,
+      timeout: 15000,
     });
     // Alerts with content are all visible.
-    await page.waitForFunction("Array.from(document.querySelectorAll('.mass-alerts-block[data-alert-processed]')).filter(item => item.childElementCount).length == Array.from(document.querySelectorAll('.mass-alerts-block[data-alert-processed]')).filter(item => item.childElementCount).filter(item => item.offsetWidth > 0 || item.offsetHeight > 0).length")
+    if (scenario.showHeaderAlerts) {
+      await page.waitForFunction("Array.from(document.querySelectorAll('.pre-content .mass-alerts-block[data-alert-processed]')).filter(item => item.childElementCount).length == Array.from(document.querySelectorAll('.mass-alerts-block[data-alert-processed]')).filter(item => item.childElementCount).filter(item => item.offsetWidth > 0 || item.offsetHeight > 0).length")
+    }
+    if (scenario.showGlobalAlerts) {
+      await page.waitForFunction("Array.from(document.querySelectorAll('.mass-alerts-block[data-alerts-path=\"/alerts/sitewide\"]')).filter(item => item.childElementCount).length == Array.from(document.querySelectorAll('.mass-alerts-block[data-alert-processed]')).filter(item => item.childElementCount).filter(item => item.offsetWidth > 0 || item.offsetHeight > 0).length")
+    }
   }
   catch (e) {
     console.error(e);
@@ -211,7 +216,7 @@ module.exports = async function (page, scenario, vp) {
         document.querySelector(".ma__header__hamburger__nav-container").scrollTo(0, 500);
       })
       break;
-    // Emergency alert.
+    // Standard alert.
     case "ExpansionOfAccordions1_toggle":
       try {
         if (scenario.showHeaderAlerts) {
@@ -231,7 +236,9 @@ module.exports = async function (page, scenario, vp) {
         throw new Error(`${e.constructor.name}: Failed waiting to toggle accordions on this page: ${page.url()}.`)
       }
       break;
-    // Standard alert.
+    // Emergency alert.
+    // Disabled until we can explicitly turn on a global alert for a page.
+    /**
     case "ExpansionOfAccordions2_toggle":
       try {
         if (scenario.showGlobalAlerts) {
@@ -251,6 +258,7 @@ module.exports = async function (page, scenario, vp) {
         throw new Error(`${e.constructor.name}: Failed waiting to toggle accordions on this page: ${page.url()}.`)
       }
       break;
+     **/
   }
 
   // Wait for all visible fonts to complete loading.

--- a/backstop/scripts/ready.js
+++ b/backstop/scripts/ready.js
@@ -215,12 +215,12 @@ module.exports = async function (page, scenario, vp) {
     case "ExpansionOfAccordions1_toggle":
       try {
         if (scenario.showHeaderAlerts) {
-          await page.waitForSelector('.ma__emergency-alerts .ma__emergency-header__toggle', {
+          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__header__toggle', {
             visible: true,
             timeout: 10000,
           });
-          await page.click('.ma__emergency-alerts .ma__emergency-header__toggle');
-          await page.waitForSelector('.ma__emergency-alerts__content', {
+          await page.click('.pre-content .mass-alerts-block .ma__action-step__header__toggle');
+          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__content', {
             visible: true,
             timeout: 60000,
           });
@@ -235,12 +235,12 @@ module.exports = async function (page, scenario, vp) {
     case "ExpansionOfAccordions2_toggle":
       try {
         if (scenario.showGlobalAlerts) {
-          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__header__toggle', {
+          await page.waitForSelector('.ma__emergency-alerts .ma__emergency-header__toggle', {
             visible: true,
             timeout: 10000,
           });
-          await page.click('.pre-content .mass-alerts-block .ma__action-step__header__toggle');
-          await page.waitForSelector('.pre-content .mass-alerts-block .ma__action-step__content', {
+          await page.click('.ma__emergency-alerts .ma__emergency-header__toggle');
+          await page.waitForSelector('.ma__emergency-alerts__content', {
             visible: true,
             timeout: 60000,
           });

--- a/changelogs/DP-27545.yml
+++ b/changelogs/DP-27545.yml
@@ -1,0 +1,6 @@
+Fixed:
+  - description: |
+      Removes the accordion test in Backstop for global alerts as they aren't always present
+      Hides all alerts by default
+      Refactors the mechanism in Backstop to hide alerts
+    issue: DP-27545.yml


### PR DESCRIPTION
**Description:**
- Removes the accordion test in Backstop for global alerts as they aren't always present in production
- Hides all alerts by default
- Refactors the mechanism in Backstop to hide alerts

**Jira:** (Skip unless you are MA staff)
DP-27545


**To Test:**
- [ ] Verify backstop_reference-1 passes


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
