### PR TITLE
DP-26304 Remove empty aria-label from press teaser

### DIFF
--- a/changelogs/DP-26304.yml
+++ b/changelogs/DP-26304.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Remove empty aria-label from the span with a backgroud image for the press teaser component.
+    issue: DP-26304

--- a/composer.json
+++ b/composer.json
@@ -274,7 +274,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-26304_decorative-image",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -273,7 +273,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-26304_decorative-image",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58dd166fb8de766c4d7615ca783870cb",
+    "content-hash": "3acdd5fe2be704b5b88c2e9d0cafabb5",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12643,16 +12643,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-26304_decorative-image",
             "source": {
                 "type": "git",
-                "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "eaf1b283e7d9d9a456db949d6bf38187e441d24f"
+                "url": "git@github.com:massgov/mayflower-artifacts.git",
+                "reference": "f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/eaf1b283e7d9d9a456db949d6bf38187e441d24f",
-                "reference": "eaf1b283e7d9d9a456db949d6bf38187e441d24f",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2",
+                "reference": "f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2",
                 "shasum": ""
             },
             "require": {
@@ -12670,11 +12670,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "support": {
-                "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
-            },
-            "time": "2023-03-15T02:17:22+00:00"
+            "time": "2023-03-21T19:50:45+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -23608,5 +23604,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3acdd5fe2be704b5b88c2e9d0cafabb5",
+    "content-hash": "8aa5ab374c3ebd696102a77185eca116",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12704,16 +12704,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-26304_decorative-image",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "a601a89f4708a57a95aa166409fb813968974c12"
+                "reference": "416026c94c6e9bcea95f440e60fd2e88d378f26f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a601a89f4708a57a95aa166409fb813968974c12",
-                "reference": "a601a89f4708a57a95aa166409fb813968974c12",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/416026c94c6e9bcea95f440e60fd2e88d378f26f",
+                "reference": "416026c94c6e9bcea95f440e60fd2e88d378f26f",
                 "shasum": ""
             },
             "require": {
@@ -12731,7 +12731,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-03-28T15:45:18+00:00"
+            "time": "2023-03-28T16:02:16+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -23665,5 +23665,5 @@
     "platform-overrides": {
         "php": "8.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -12647,12 +12647,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2"
+                "reference": "a601a89f4708a57a95aa166409fb813968974c12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2",
-                "reference": "f426423a4f870efd5fe8e6e61ed87bb8f1a76ef2",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a601a89f4708a57a95aa166409fb813968974c12",
+                "reference": "a601a89f4708a57a95aa166409fb813968974c12",
                 "shasum": ""
             },
             "require": {
@@ -12670,7 +12670,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-03-21T19:50:45+00:00"
+            "time": "2023-03-28T15:45:18+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
**Description:**
When a press teaser image doesn't have alt value, its container doesn't have empty `aria-label`.

**Jira:** (Skip unless you are MA staff)
DP-26304


**To Test:**
- [ ] Go to the Recent news & announcements section in a page with press teaser component:  /orgs/massachusetts-department-of-children-families
- [ ] Check the markup for the image and find that `span` for a background image doesn't have `aria-label` and `role="img"`
 See https://github.com/massgov/mayflower/pull/1752 for the actual change in Mayflower.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
