### PR TITLE
DP-26086: Add local tasks to the Gin toolbar on the back and front-en…

### DIFF
--- a/conf/drupal/config/block.block.gin_primary_local_tasks.yml
+++ b/conf/drupal/config/block.block.gin_primary_local_tasks.yml
@@ -1,6 +1,6 @@
 uuid: 04f5fd0d-e890-4e0e-ada4-9a83d5ad8dff
 langcode: en
-status: true
+status: false
 dependencies:
   theme:
     - gin

--- a/docroot/modules/custom/mass_admin_pages/css/secondary_toolbar.css
+++ b/docroot/modules/custom/mass_admin_pages/css/secondary_toolbar.css
@@ -1,0 +1,32 @@
+.gin-secondary-toolbar.layout-container,
+.gin-secondary-toolbar.gin-secondary-toolbar--frontend,
+.gin-secondary-toolbar__layout-container {
+  height: calc(var(--gin-toolbar-secondary-height) * 2);
+  flex-wrap: wrap;
+  padding: 10px 0;
+  z-index: 9999;
+}
+
+#mass--toolbar-local-tasks {
+  width: 100%;
+}
+
+#mass--toolbar-local-tasks ul.tabs--primary {
+  margin: 0 0 10px 0;
+  padding: 0;
+}
+
+@media (min-width: 48em) {
+  #mass--toolbar-local-tasks .block-local-tasks-block {
+    margin-right: 0;
+  }
+
+  #mass--toolbar-local-tasks .tabs--primary {
+    justify-content: flex-end;
+  }
+
+  #mass--toolbar-local-tasks .tabs__tab:last-child a.tabs__link {
+    margin-right: 0;
+    padding-right: 0;
+  }
+}

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.libraries.yml
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.libraries.yml
@@ -17,6 +17,13 @@ toolbar:
     theme:
       css/toolbar.css: { }
 
+secondary_toolbar:
+  version: 1.x
+  css:
+    theme:
+      /core/themes/claro/css/components/tabs.css: { }
+      css/secondary_toolbar.css: { }
+
 right_sidebar:
   version: 1.x
   css:

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
@@ -39,6 +39,7 @@ function mass_admin_pages_preprocess_menu(&$variables) {
     }
   }
 }
+
 /**
  * Implements hook_preprocess_HOOK() for menu-local-tasks templates.
  *

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\node\Entity\NodeType;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
+use Drupal\Core\Render\Element;
 
 /**
  * Add icon to Mass menu item thats shown in admin toolbar.
@@ -36,6 +37,54 @@ function mass_admin_pages_preprocess_menu(&$variables) {
       $options['attributes']['class'][] = $class;
       $variables['items'][$link]['url']->setOptions($options);
     }
+  }
+}
+/**
+ * Implements hook_preprocess_HOOK() for menu-local-tasks templates.
+ *
+ * Use preprocess hook to set #attached to child elements because they will be
+ * processed by Twig and \Drupal::service('renderer')->render() will be invoked.
+ */
+function mass_admin_pages_preprocess_menu_local_tasks(&$variables) {
+  if (!empty($variables['primary'])) {
+    $variables['primary']['#attached'] = [
+      'library' => [
+        'claro/drupal.nav-tabs',
+      ],
+    ];
+  }
+  elseif (!empty($variables['secondary'])) {
+    $variables['secondary']['#attached'] = [
+      'library' => [
+        'claro/drupal.nav-tabs',
+      ],
+    ];
+  }
+
+  foreach (Element::children($variables['primary']) as $key) {
+    $variables['primary'][$key]['#level'] = 'primary';
+  }
+  foreach (Element::children($variables['secondary']) as $key) {
+    $variables['secondary'][$key]['#level'] = 'secondary';
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK() for menu-local-task templates.
+ */
+function mass_admin_pages_preprocess_menu_local_task(&$variables) {
+  $variables['link']['#options']['attributes']['class'][] = 'tabs__link';
+  $variables['link']['#options']['attributes']['class'][] = 'js-tabs-link';
+
+  // Ensure is-active class is set when the tab is active. The generic active
+  // link handler applies stricter comparison rules than what is necessary for
+  // tabs.
+  if (isset($variables['is_active']) && $variables['is_active'] === TRUE) {
+    $variables['link']['#options']['attributes']['class'][] = 'is-active';
+  }
+
+  if (isset($variables['element']['#level'])) {
+    $variables['level'] = $variables['element']['#level'];
   }
 }
 
@@ -162,8 +211,12 @@ function mass_admin_pages_theme($existing, $type, $theme, $path) {
  * Use our template for breadcrumb in Gin secondary toolbar.
  */
 function mass_admin_pages_theme_registry_alter(&$theme_registry) {
-  $templates_path = \Drupal::service('extension.list.module')->getPath('mass_admin_pages') . '/templates';
-  $theme_registry['toolbar']['path'] = $templates_path;
+  $mass_admin_templates_path = \Drupal::service('extension.list.module')->getPath('mass_admin_pages') . '/templates';
+  $claro_templates_path = \Drupal::service('extension.list.theme')->getPath('claro') . '/templates';
+  $theme_registry['toolbar']['path'] = $mass_admin_templates_path;
+  $theme_registry['toolbar__gin__secondary']['path'] = $mass_admin_templates_path;
+  $theme_registry['menu_local_tasks']['path'] = $claro_templates_path;
+  $theme_registry['menu_local_task']['path'] = $claro_templates_path . '/navigation';
 }
 
 function mass_admin_pages_module_implements_alter(&$implementations, $hook) {

--- a/docroot/modules/custom/mass_admin_pages/templates/toolbar--gin--secondary.html.twig
+++ b/docroot/modules/custom/mass_admin_pages/templates/toolbar--gin--secondary.html.twig
@@ -1,0 +1,77 @@
+{#
+/**
+ * @file
+ * Theme override for the administrative toolbar.
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the wrapper.
+ * - toolbar_attributes: HTML attributes to apply to the toolbar.
+ * - toolbar_heading: The heading or label for the toolbar.
+ * - tabs: List of tabs for the toolbar.
+ *   - attributes: HTML attributes for the tab container.
+ *   - link: Link or button for the menu tab.
+ * - trays: Toolbar tray list, each associated with a tab. Each tray in trays
+ *   contains:
+ *   - attributes: HTML attributes to apply to the tray.
+ *   - label: The tray's label.
+ *   - links: The tray menu links.
+ * - remainder: Any non-tray, non-tab elements left to be rendered.
+ *
+ * @see template_preprocess_toolbar()
+ */
+#}
+<div{{ attributes.addClass('toolbar', 'toolbar-secondary').setAttribute('id', 'toolbar-administration-secondary') }}>
+  <nav{{ toolbar_attributes.addClass('toolbar-bar', 'clearfix').setAttribute('id', 'toolbar-bar') }}>
+    <h2 class="visually-hidden">{{ toolbar_heading }}</h2>
+    {% set local_tasks = '' %}
+
+    {% for key, tab in tabs %}
+      {% set tray = trays[key] %}
+      {% set user_menu = tray.links['user_links'] ? 'user-menu' : false %}
+      {% set item_id = [] %}
+
+      {% for key, item in tab.link['#attributes']['class'] %}
+        {% if 'icon-' in item %}
+          {% set item_id = item_id|merge(['toolbar-id--' ~ item]) %}
+        {% endif %}
+      {% endfor %}
+
+      {% set tab_id = tab.link['#id'] ? 'toolbar-tab--' ~ tab.link['#id'] %}
+      {% set tab_classes = item_id|merge(['toolbar-tab', user_menu, tab_id]) %}
+
+      {% set denylist_items = [
+        'toolbar-id--toolbar-icon-menu',
+        'toolbar-id--toolbar-icon-local-tasks',
+      ] %}
+
+      {# All items except main nav #}
+      {% if item_id[0] not in denylist_items %}
+        <div{{ tab.attributes.addClass(tab_classes) }}>
+          {% if item_id[0] == 'toolbar-id--toolbar-icon-user' %}
+            {{ user_picture }}
+          {% else %}
+            {{ tab.link }}
+          {% endif %}
+          <div{{ tray.attributes }}>
+            {% if tray.label %}
+              <nav class="toolbar-lining clearfix" role="navigation" aria-label="{{ tray.label }}">
+                <h3 class="toolbar-tray-name visually-hidden">{{ tray.label }}</h3>
+            {% else %}
+              <nav class="toolbar-lining clearfix" role="navigation">
+            {% endif %}
+            {{ tray.links }}
+            </nav>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </nav>
+  {{ remainder }}
+</div>
+
+{# Local Tasks #}
+<nav id="mass--toolbar-local-tasks" class="mass--toolbar-local-tasks">
+  {{ attach_library('mass_admin_pages/secondary_toolbar') }}
+  {{ attach_library('gin/tabs') }}
+  {{ drupal_block('local_tasks_block') }}
+</nav>

--- a/docroot/modules/custom/mass_admin_pages/templates/toolbar.html.twig
+++ b/docroot/modules/custom/mass_admin_pages/templates/toolbar.html.twig
@@ -24,7 +24,7 @@
         </nav>
       </div>
     </div>
-    {% include '@gin/navigation/toolbar--gin--secondary.html.twig' ignore missing %}
+    {% include '@mass_admin_pages/toolbar--gin--secondary.html.twig' ignore missing %}
   </div>
 </div>
 {% endif %}


### PR DESCRIPTION
![Screenshot from 2023-03-24 16-22-37](https://user-images.githubusercontent.com/345613/227584121-c1508611-f2b8-4e4e-a4ea-b10ff08fd0f2.png)
![Screenshot from 2023-03-24 16-23-03](https://user-images.githubusercontent.com/345613/227584147-6b7e2070-d092-4019-a387-96f5295bdf9d.png)
![Screenshot from 2023-03-24 16-24-16](https://user-images.githubusercontent.com/345613/227584174-99d32e24-1995-4dec-a9d5-67dd9f574531.png)
![Screenshot from 2023-03-24 16-24-02](https://user-images.githubusercontent.com/345613/227584153-e9c8dd09-f58c-41ef-b685-8f642665f5a2.png)

**Description:**
Renders local tasks as a block in the Gin admin theme


**Jira:** (Skip unless you are MA staff)
DP-26086

**To Do:**
- Remove the admonition banner about editing links being moved
- Some code to be removed from `mass_gin.module`
- Show whether or not the current item is published or not when Viewing the node
- Do we want this just for the node view or would it be more consistent to keep local tasks there for all pages?
![Screenshot from 2023-03-24 16-29-59](https://user-images.githubusercontent.com/345613/227585383-a3e446d1-7d81-452f-91fb-a33541af03f8.png)

**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
