### PR TITLE
Remove fixed feedback button from homepage - DP-26220

### DIFF
--- a/changelogs/DP-26220.yml
+++ b/changelogs/DP-26220.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Removed:
+  - description: Removed feedback button markup from home page.
+    issue: DP-26220

--- a/changelogs/DP-26220.yml
+++ b/changelogs/DP-26220.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Removed:
-  - description: Removed feedback button markup from home page.
+  - description: Removed feedback button markup from pages that do not have feedback forms.
     issue: DP-26220

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -4460,6 +4460,13 @@ function mass_theme_preprocess_page(&$variables) {
     $allowed_regions = ['post_content'];
     mass_theme_add_regions_to_node($allowed_regions, $variables);
   }
+
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $is_front_page = \Drupal::service('path.matcher')->isFrontPage();
+  $variables['footerFloatingAction'] = TRUE;
+  if ($is_front_page || $route_name != 'entity.node.canonical') {
+    $variables['footerFloatingAction'] = FALSE;
+  }
 }
 
 /**

--- a/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
@@ -1,7 +1,4 @@
 {% set floatingAction = footerFloatingAction %}
-{% if is_front %}
-  {% set floatingAction = false %}
-{% endif %}
 {% set feedbackButton = {
   "href": "#feedback",
   "text": "Feedback"

--- a/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
@@ -1,4 +1,4 @@
-{% set floatingAction = true %}
+{% set floatingAction = footerFloatingAction %}
 {% if is_front %}
   {% set floatingAction = false %}
 {% endif %}

--- a/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/organisms-footer.html.twig
@@ -1,4 +1,7 @@
 {% set floatingAction = true %}
+{% if is_front %}
+  {% set floatingAction = false %}
+{% endif %}
 {% set feedbackButton = {
   "href": "#feedback",
   "text": "Feedback"


### PR DESCRIPTION
**Description:**
This PR removes the `<div class="ma__fixed-feedback-button" />` markup from the home page.


**Jira:** (Skip unless you are MA staff)
DP-26220


**To Test:**
- [ ] Check the home page and other pages and inspect
- [ ] Check that the home page and non-node pages, such as those found at /locations or /news, do not have the markup. Confirm that other pages still have the markup


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
