### PR TITLE
Immediately deploy release branch (and related CircleCI updates)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - attach_workspace: {at: /tmp}
       - *vendor_bin_add_path
       - run: "drush pm:security"
-      - run: "composer audit"
+      - run: "drush pm:security-php"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,7 +651,7 @@ jobs:
       - attach_workspace: {at: /tmp}
       - *vendor_bin_add_path
       - run: "drush pm:security"
-      - run: "drush pm:security-php"
+      - run: "composer audit"
 
 workflows:
   version: 2
@@ -1212,16 +1212,12 @@ workflows:
               only:
                 - develop
 
-  # Nightly pm:security and pm:security-php.
+  # Nightly pm:security and composer audit. See https://app.circleci.com/settings/project/github/massgov/openmass/triggers.
   nightly_pending_security:
+    when:
+      and:
+        - equal: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
     jobs:
       - build
       - pending_security:
           requires: [build]
-    triggers:
-      - schedule:
-          cron: "05 07 * * *"
-          filters:
-              branches:
-                  only:
-                      - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1212,7 +1212,7 @@ workflows:
               only:
                 - develop
 
-  # Nightly pm:security and composer audit. See https://app.circleci.com/settings/project/github/massgov/openmass/triggers.
+  # Nightly pm:security and pm:security-php.
   nightly_pending_security:
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1214,8 +1214,8 @@ workflows:
 
   # Nightly pm:security and composer audit. See https://app.circleci.com/settings/project/github/massgov/openmass/triggers.
   nightly_pending_security:
-    # https://circleci.com/docs/configuration-reference/#using-when-in-workflows
-    when: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
+    when:
+      - equal: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
     jobs:
       - build
       - pending_security:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,6 @@ orbs:
 # - https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/
 # - https://github.com/circleci/frontend/blob/master/.circleci/config.yml
 references:
-  container_config: &container_config
-    working_directory: /var/www/code
-    docker:
-      # @see https://github.com/massgov/Drupal-Container
-      - image: massgov/drupal-container:1.0.20-ci
-        environment:
-          COMPOSER_ALLOW_SUPERUSER: 1
-          AWS_REGION: us-east-1
-
   # Dynamic hosts mean constantly checking interactively that we mean to connect to an unknown host. We ignore those here.
   no_host_check: &no_host_check
     run: {name: 'Disable StrictHostKeyChecking', command: 'mkdir -p $HOME/.ssh && echo "StrictHostKeyChecking no" > ~/.ssh/config'}
@@ -705,13 +696,6 @@ workflows:
             branches:
               <<: *branch_ignore
 
-      - backstop_test:
-          target: prod
-          force-reference: true
-          filters:
-            branches:
-              <<: *branch_ignore
-
   # This is to automate the creation of the release branch.
   # The cron time needs to be updated every Fall/Spring for daylight saving time.
   release_branch:
@@ -753,18 +737,8 @@ workflows:
           filters:
             branches:
               only: /^release\/.*$/
-      - hold - Release manager only:
-          type: approval
-          requires:
-            - build
-            - push_acquia
-          filters:
-            branches:
-              only: /^release\/.*$/
       - deploy:
           name: deploy-test-refresh-db
-          requires:
-            - hold - Release manager only
           target: test
           refresh-db: "--refresh-db"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1214,9 +1214,8 @@ workflows:
 
   # Nightly pm:security and composer audit. See https://app.circleci.com/settings/project/github/massgov/openmass/triggers.
   nightly_pending_security:
-    when:
-      and:
-        - equal: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
+    # https://circleci.com/docs/configuration-reference/#using-when-in-workflows
+    when: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
     jobs:
       - build
       - pending_security:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1215,7 +1215,8 @@ workflows:
   # Nightly pm:security and composer audit. See https://app.circleci.com/settings/project/github/massgov/openmass/triggers.
   nightly_pending_security:
     when:
-      - equal: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
+      and:
+        - equal: [ nightly_pending_security, << pipeline.parameters.trigger_workflow >> ]
     jobs:
       - build
       - pending_security:

--- a/changelogs/DP-27686.yml
+++ b/changelogs/DP-27686.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Immediately deploy release branch (and related CircleCI updates)
+    issue: DP-27686

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,3 +96,4 @@ The ideal case is that Product Owners and developers jointly describe new featur
 - Robust tests create and delete their own content. Relying on production content is brittle.
 - Do not break up your tests in to too many classes and methods. Each one has a startup cost and contributes to long test times for the whole suite.
 - Do not change a test that is failing for an unknown reason. Tests are supposed to fail when new work has a negative impact. Don't change a test until you have investigated and understood what purpose the test serves and are confident your new work and any test changes are an improvement.
+- Scheduled tests are managed on the [CircleCI triggers page](https://app.circleci.com/settings/project/github/massgov/openmass/triggers).


### PR DESCRIPTION
**Description:**
- Also removes the Backstop run on each PR
- Also removes unused Yaml anchor container_config
- Also updates `nightly_security_audit` workflow from a code based trigger to a UI based trigger as per https://circleci.com/blog/using-scheduled-pipelines/. Once this is working well, I will update the other triggers. One benefit is that we can kickoff pipelines like cutting releases release, grabbing backstop references, mysql_rebuild, etc without making a commit. Just use Triggers UI instead.


**Jira:** (Skip unless you are MA staff)
DP-27686


**To Test:**
- [ ] If the PR is green, the CI file is valid. That's sufficient.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
