### PR TITLE
Redirect to destination page after login

### DIFF
--- a/changelogs/DP-27789.yml
+++ b/changelogs/DP-27789.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Redirect to destination page after login
+    issue: DP-27789

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -186,6 +186,7 @@ module:
   purge_ui: 0
   queue_unique: 0
   quick_node_clone: 0
+  r4032login: 0
   rabbit_hole: 0
   real_aes: 0
   redirect: 0

--- a/conf/drupal/config/openid_connect.settings.yml
+++ b/conf/drupal/config/openid_connect.settings.yml
@@ -5,7 +5,7 @@ connect_existing_users: true
 override_registration_settings: false
 end_session_enabled: false
 user_login_display: replace
-redirect_login: user
+redirect_login: ''
 redirect_logout: ''
 userinfo_mappings:
   timezone: zoneinfo

--- a/conf/drupal/config/r4032login.settings.yml
+++ b/conf/drupal/config/r4032login.settings.yml
@@ -1,0 +1,18 @@
+_core:
+  default_config_hash: FtwnuCXmazPAh2H2i_gbDhMK1-eBmNy1dG4RBU4qt4o
+langcode: en
+display_denied_message: false
+access_denied_message: 'Access denied. You must log in to view this page.'
+access_denied_message_type: error
+redirect_authenticated_users_to: ''
+throw_authenticated_404: false
+display_auth_denied_message: true
+access_denied_auth_message: 'Access denied. Check with your site administrator if you need assistance.'
+access_denied_auth_message_type: error
+user_login_path: /user/login
+default_redirect_code: 307
+add_noindex_header: false
+destination_parameter_override: ''
+match_noredirect_pages: ''
+match_noredirect_negate: 0
+redirect_to_destination: true

--- a/conf/drupal/config/r4032login.settings.yml
+++ b/conf/drupal/config/r4032login.settings.yml
@@ -13,6 +13,6 @@ user_login_path: /user/login
 default_redirect_code: 307
 add_noindex_header: false
 destination_parameter_override: ''
-match_noredirect_pages: '/user/reset/*'
+match_noredirect_pages: "/user/reset/*\r\n/user/password*"
 match_noredirect_negate: 0
 redirect_to_destination: true

--- a/conf/drupal/config/r4032login.settings.yml
+++ b/conf/drupal/config/r4032login.settings.yml
@@ -13,6 +13,6 @@ user_login_path: /user/login
 default_redirect_code: 307
 add_noindex_header: false
 destination_parameter_override: ''
-match_noredirect_pages: ''
+match_noredirect_pages: '/user/reset/*'
 match_noredirect_negate: 0
 redirect_to_destination: true

--- a/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
+++ b/docroot/modules/custom/mass_admin_pages/mass_admin_pages.module
@@ -7,26 +7,9 @@
 
 use Drupal\Component\Utility\UrlHelper;
 use Drupal\Component\Utility\Xss;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\Entity\NodeType;
-use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
-
-/**
- * Implements hook_user_login().
- *
- * Redirect users to the my-work page on successful login.
- */
-function mass_admin_pages_user_login(AccountInterface $account) {
-  $url = Url::fromRoute('mass_admin_pages.author_home')->toString();
-
-  // If there are no password reset parameters in the URL, then bypass the user edit
-  // page and go straight to my-work.
-  if (\Drupal::service('current_route_match')->getRouteName() !== 'user.reset.login') {
-    return \Drupal::requestStack()->getCurrentRequest()->query->set('destination', $url);
-  }
-}
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().

--- a/docroot/sites/default/services.acquia.yml
+++ b/docroot/sites/default/services.acquia.yml
@@ -11,3 +11,5 @@ parameters:
     default: ['acquia_syslog', 'acquia_newrelic']
     # Cut down noise in New Relic
     purge: ['acquia_syslog']
+    # 403 still visible at Akamai.
+    access denied: ['null']

--- a/features/error_pages.feature
+++ b/features/error_pages.feature
@@ -13,9 +13,9 @@ Feature:
   Scenario: Visit a page I should not be allowed to see
     Given I am on "/user/1/edit"
 #    Not a 403 because we have username_enumeration_prevention.
-    Then I should see the 404 error page
+    Then I am on "/user/login"
     Given I am on "/admin"
-    Then I should see the 403 error page
+    Then I am on "/user/login"
     When I am on "/admin/reports"
-    Then I should see the 403 error page
+    Then I am on "/user/login"
     And the page should be dynamically cached


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-27789


**To Test:**
- [ ] As Anon, go to a protected page like admin/reports. You will be redirected to login and then back to admin/reports instead of to admin/home

**Comms (if desired)**
It is no longer necessary to browse to /user to login to the CMS. Instead, browse to any page that requires login and you will be redirected to login (if needed) and then to your destination page. 

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
