### PR TITLE
Fixed empty headings for 3up content

### DIFF
--- a/changelogs/DP-26219.yml
+++ b/changelogs/DP-26219.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed empty headings on the home page.
+    issue: DP-26219

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5375,27 +5375,30 @@ function mass_theme_preprocess_paragraph__3_up_content(&$variables) {
         }
       }
 
-      $list[] = [
-        'items' => [
-          [
-            'path' => '@atoms/04-headings/column-heading.twig',
-            'data' => [
-              'columnHeading' => [
-                'text' => $item->get('field_heading')->value,
-                'href' => '',
-                'info' => '',
-              ],
+      $list_items = [];
+      if ($item->get('field_heading')->value) {
+        $list_items[] = [
+          'path' => '@atoms/04-headings/column-heading.twig',
+          'data' => [
+            'columnHeading' => [
+              'text' => $item->get('field_heading')->value,
+              'href' => '',
+              'info' => '',
             ],
           ],
-          [
-            'path' => '@organisms/by-author/rich-text.twig',
-            'data' => [
-              'richText' => [
-                'rteElements' => $paragraphs,
-              ],
-            ],
+        ];
+      }
+      $list_items[] = [
+        'path' => '@organisms/by-author/rich-text.twig',
+        'data' => [
+          'richText' => [
+            'rteElements' => $paragraphs,
           ],
         ],
+      ];
+
+      $list[] = [
+        'items' => $list_items,
       ];
     }
   }


### PR DESCRIPTION
**Description:**
Fixes empty headings on 3up content, including the homepage.


**Jira:** (Skip unless you are MA staff)
DP-26219


**To Test:**
- [ ] Inspect three-column section on home page. Verify there is no longer an empty h3 column heading


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
