### PR TITLE
Truncate entity usage during test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
             and:
               - equal: [ phpunit, << parameters.command >> ]
           steps:
-            run: 'su -s /bin/bash root -c "phpunit docroot/modules/custom --verbose --log-junit /tmp/test-results/dtt/junit.xml"'
+            run: 'su -s /bin/bash root -c "phpunit docroot/modules/custom --testdox --log-junit /tmp/test-results/dtt/junit.xml"'
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:

--- a/changelogs/DP-28067.yml
+++ b/changelogs/DP-28067.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: Truncate entity usage during test
     issue: DP-28067

--- a/changelogs/DP-28067.yml
+++ b/changelogs/DP-28067.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Truncate entity usage during test
+    issue: DP-28067

--- a/changelogs/template.yml
+++ b/changelogs/template.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
     issue: DP-****

--- a/changelogs/template.yml
+++ b/changelogs/template.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Changed:
+Type:
   - description: Describe the change. If you need multiple lines, start the first line with the following "|-" characters.
     issue: DP-****

--- a/docroot/modules/custom/mass_entity_usage/tests/src/ExistingSite/EntityUsageTest.php
+++ b/docroot/modules/custom/mass_entity_usage/tests/src/ExistingSite/EntityUsageTest.php
@@ -41,7 +41,7 @@ class EntityUsageTest extends ExistingSiteBase {
     // to avoid long cleaning times that break this test.
     // Note this avoids triggering events on bulk deletes, such as at
     // \Drupal\entity_usage\EntityUsage::bulkDeleteTargets().
-    \Drupal::service('database')->delete('entity_usage')->execute();
+    \Drupal::service('database')->truncate('entity_usage')->execute();
 
     $this->emptyEntityUsageQueues();
     $user = User::create(['name' => $this->randomMachineName()]);


### PR DESCRIPTION
**Description:**
- Truncate is faster as no row by row deletion is performed.
- The --testdox is a phpunit feature which adds test start/finish log messages in the console.


**Jira:** (Skip unless you are MA staff)
N/A


**To Test:**
- [ ] If its green its good


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
