### PR TITLE
Map zindex

### DIFF
--- a/changelogs/mapfix.yml
+++ b/changelogs/mapfix.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Target z-index -1 setting for maps to ones in location banners.
+    issue: DP-26364

--- a/composer.json
+++ b/composer.json
@@ -271,7 +271,7 @@
         "enyo/dropzone": "5.7.2",
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-map-zindex",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55df1e505dd1bd9b1b9756e2b2a1a89b",
+    "content-hash": "e8b94526ed3dd2f68f951e346e48d8e7",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12450,16 +12450,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-map-zindex",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "dc4cf283b037605ace3fe92ebf7ea9fd0dc229c6"
+                "reference": "e04d299fc87bb6e9066a29d1049139d978276291"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/dc4cf283b037605ace3fe92ebf7ea9fd0dc229c6",
-                "reference": "dc4cf283b037605ace3fe92ebf7ea9fd0dc229c6",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e04d299fc87bb6e9066a29d1049139d978276291",
+                "reference": "e04d299fc87bb6e9066a29d1049139d978276291",
                 "shasum": ""
             },
             "require": {
@@ -12477,7 +12477,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-05-22T14:39:48+00:00"
+            "time": "2023-05-23T19:14:48+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
**Description:**
The temp fix is applied to release 0.362.0 by adding overriding CSS in theming.
As the fix is added to Mayflower, remove the following from openmass:

- Remove the file:  docroot/themes/custom/mass_theme/overrides/css/map-zindex.css 
- Remove the line in docroot/themes/custom/mass_theme/mass_theme.libraries.yml:  L.28. overrides/css/map-zindex.css: {} 

Also, make sure no conflicts with the Mayflower PHP 8 update in openmass as we found the integer filter was not recognized at the time.

**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
