### PR TITLE
D10 - update redirect module and config ignore. Uninstalls path_redirect_import

### DIFF
--- a/changelogs/DP-27983.yml
+++ b/changelogs/DP-27983.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: D10 - update redirect module
+    issue: DP-27983

--- a/composer.json
+++ b/composer.json
@@ -430,7 +430,7 @@
                 "Undefined array key in Drupal\\purge\\Plugin\\Purge\\Queue\\QueueService->commitAdding() (https://www.drupal.org/project/purge/issues/3343141#comment-14965816)": "https://www.drupal.org/files/issues/2023-03-14/purge-fix-undefined-key-for-invalidation-buffer-3343141-4.patch"
             },
             "drupal/redirect": {
-                "Add an intermediate redirect": "https://www.drupal.org/files/issues/2020-07-31/tmp.diff",
+                "Add an intermediate redirect (https://www.drupal.org/project/redirect/issues/3162696#comment-15084170)": "https://www.drupal.org/files/issues/2023-05-30/tmp.diff",
                 "Filter by redirect destination does not work with URL alias (https://www.drupal.org/project/redirect/issues/2981544)": "https://www.drupal.org/files/issues/2021-12-09/2981544-9.patch"
             },
             "drupal/views_bulk_operations": {

--- a/composer.json
+++ b/composer.json
@@ -430,7 +430,7 @@
                 "Undefined array key in Drupal\\purge\\Plugin\\Purge\\Queue\\QueueService->commitAdding() (https://www.drupal.org/project/purge/issues/3343141#comment-14965816)": "https://www.drupal.org/files/issues/2023-03-14/purge-fix-undefined-key-for-invalidation-buffer-3343141-4.patch"
             },
             "drupal/redirect": {
-                "Add an intermediate redirect (https://www.drupal.org/project/redirect/issues/3162696#comment-15084170)": "https://www.drupal.org/files/issues/2023-05-30/tmp.diff",
+                "Add an intermediate redirect (https://www.drupal.org/project/redirect/issues/3162696#comment-15085388)": "https://www.drupal.org/files/issues/2023-05-31/tmp.diff",
                 "Filter by redirect destination does not work with URL alias (https://www.drupal.org/project/redirect/issues/2981544)": "https://www.drupal.org/files/issues/2021-12-09/2981544-9.patch"
             },
             "drupal/views_bulk_operations": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "328d72d95a1b5f8ec8c2a472c2fd1089",
+    "content-hash": "1a0d546601fb6f3a02240ca91d6ad64a",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -8857,26 +8857,26 @@
         },
         {
             "name": "drupal/redirect",
-            "version": "1.6.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/redirect.git",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "f848e001deac8425ae57d4b9397087c491d37294"
+                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "a7a440423434472ff7115ae69df01553f763f839"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^9.2 || ^10"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1589312204",
+                    "version": "8.x-1.8",
+                    "datestamp": "1661806955",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -9963,28 +9963,28 @@
         },
         {
             "name": "drupal/view_mode_page",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/view_mode_page.git",
-                "reference": "4.0.1"
+                "reference": "4.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/view_mode_page-4.0.1.zip",
-                "reference": "4.0.1",
-                "shasum": "42e745be85e28c0f236a8b2d000324d6afb08500"
+                "url": "https://ftp.drupal.org/files/projects/view_mode_page-4.0.2.zip",
+                "reference": "4.0.2",
+                "shasum": "d68dc84ca772c3327c416dd9179a6c77c15eee4d"
             },
             "require": {
-                "drupal/core": "^8 || ^9",
+                "drupal/core": "^9.3 || ^10.0",
                 "drupal/ctools": "*",
                 "drupal/token": "*"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "4.0.1",
-                    "datestamp": "1609683108",
+                    "version": "4.0.2",
+                    "datestamp": "1671547412",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a0d546601fb6f3a02240ca91d6ad64a",
+    "content-hash": "3cfea4bff5a73d8ce801f166651f4718",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",

--- a/composer.lock
+++ b/composer.lock
@@ -3636,7 +3636,7 @@
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_ignore.git",
-                "reference": "f027d8f800b2ac60f78cfec877b0cf1b23148d29"
+                "reference": "5cf158b8ac62929512a9f45d63ca28ec5b251f40"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9 || ^10"

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -173,7 +173,6 @@ module:
   paragraphs: 0
   path: 0
   path_alias: 0
-  path_redirect_import: 0
   pathologic: 0
   pfdp: 0
   prepopulate: 0

--- a/conf/drupal/config/user.role.developer.yml
+++ b/conf/drupal/config/user.role.developer.yml
@@ -151,7 +151,6 @@ permissions:
   - 'administer environment indicator settings'
   - 'administer filters'
   - 'administer form for node feedback block'
-  - 'administer google tag manager'
   - 'administer image styles'
   - 'administer mailchimp transactional'
   - 'administer mailchimp transactional templates'


### PR DESCRIPTION
1. Updates to rerolled patch for redirect
2. Updated config ignore
3. Uninstalls path_redirect_import as we dont use that and upgrading it causes changes to migrate modules. Dont think we want that now.

**Jira:** (Skip unless you are MA staff)
DP-27983


**To Test:**
- [ ] See bot comment below for the changes in this PR


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
