### PR TITLE
DP-28604: Add Siteimprove data to bigquery module

### DIFF
--- a/changelogs/DP-28604.yml
+++ b/changelogs/DP-28604.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add Siteimprove data to bigquery module
+    issue: DP-28604

--- a/docroot/modules/custom/mass_bigquery/mass_bigquery.install
+++ b/docroot/modules/custom/mass_bigquery/mass_bigquery.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the mass_bigquery module.
  */
 
+use Drupal\Core\Database\Database;
+
 /**
  * Implements hook_schema().
  */
@@ -46,6 +48,18 @@ function mass_bigquery_schema() {
         'type' => 'int',
         'description' => 'The total feedback.',
       ],
+      'broken_links' => [
+        'type' => 'int',
+        'description' => 'The number of broken links.',
+      ],
+      'grade_level' => [
+        'type' => 'int',
+        'description' => 'The grade level.',
+      ],
+      'nos_per_1000_cleaned' => [
+        'type' => 'float',
+        'description' => 'Populated if the node has 500 or more page views or 5 or more nos',
+      ],
     ],
     'indexes' => [
       'nid' => ['nid'],
@@ -57,4 +71,25 @@ function mass_bigquery_schema() {
   ];
 
   return $schema;
+}
+
+/**
+ * Implements hook_update_n().
+ *
+ * Add siteimprove fields and a cleaned nos_per_1000 field.
+ */
+function mass_bigquery_update_9001() {
+  $fields_to_add = [
+    'nos_per_1000_cleaned',
+    'broken_links',
+    'grade_level'
+  ];
+
+  $schema = Database::getConnection()->schema();
+  $table = 'mass_bigquery_data';
+  $spec = mass_bigquery_schema();
+
+  foreach ($fields_to_add as $field_to_add) {
+    $schema->addField($table, $field_to_add, $spec[$table]['fields'][$field_to_add]);
+  }
 }


### PR DESCRIPTION
**Description:**
Siteimprovement data was recently added to BigQuery in [DP-28552](https://massgov.atlassian.net/browse/DP-28552) . This PR fetches Siteimprovement data from BigQuery and saves it in the Drupal database.


**Jira:** (Skip unless you are MA staff)
DP-28604


**To Test:**
```
# Add the key file and set GOOGLE_APPLICATION_CREDENTIALS=/var/www/html/docroot/file/path.json in .ddev/.env
# Set the GOOGLE_CLOUD_PROJECT environment varaible
ddev restart
# Modify the time window and last ran so `hook_cron()` runs.
ddev drush cset mass_bigquery.config end '21:59'
ddev drush state:set mass_bigquery.last_run 0
# Queue the nodes.
ddev drush eval 'mass_bigquery_cron();'
ddev drush queue:list
# Process the queue.
time ddev drush queue:run mass_bigquery_node_queue                            
ddev drush cset mass_bigquery.config end '02:00'
# Verify data was saved to the table.
ddev drush sqlq "select * from mass_bigquery_data;"
```

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)


[DP-28552]: https://massgov.atlassian.net/browse/DP-28552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ