### PR TITLE
DP-28606 analytics tab allow all appropriate content types

### DIFF
--- a/changelogs/DP-28606.yml
+++ b/changelogs/DP-28606.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Analytics NEW tab now showing for all appropriate content types.
+    issue: DP-28606

--- a/docroot/modules/custom/mass_analytics/src/Controller/MassAnalyticsController.php
+++ b/docroot/modules/custom/mass_analytics/src/Controller/MassAnalyticsController.php
@@ -20,6 +20,14 @@ class MassAnalyticsController extends ControllerBase {
     'location',
     'location_details',
     'service_details',
+    'form_page',
+    'advisory',
+    'news',
+    'event',
+    'campaign_landing',
+    'decision',
+    'executive_order',
+    'regulation'
   ];
 
   /**


### PR DESCRIPTION
**Description:**
The new analytics tab was not configured to show on all relevant content types. It now will show on all of them.


**Jira:** (Skip unless you are MA staff)
DP-28606


**To Test:**
- [ ] View a sample page of each content type and verify that you can see the new analytics tab.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
