### PR TITLE
DP-28586 Orphan report change English only

### DIFF
--- a/conf/drupal/config/views.view.report_orphaned_documents.yml
+++ b/conf/drupal/config/views.view.report_orphaned_documents.yml
@@ -1113,36 +1113,10 @@ display:
           plugin_id: language
           operator: in
           value:
+            '***LANGUAGE_site_default***': '***LANGUAGE_site_default***'
             en: en
-            es: es
-            zh-hans: zh-hans
-            zh-hant: zh-hant
-            pt-br: pt-br
-            pt-pt: pt-pt
-            fr: fr
-            ru: ru
-            ko: ko
-            vi: vi
-            ar: ar
-            it: it
-            cv: cv
-            ht: ht
-            pl: pl
-            lo: lo
-            km: km
-            af: af
-            sq: sq
-            am: am
-            hi: hi
-            ne: ne
-            so: so
-            uk: uk
-            el: el
-            sw: sw
-            pst: pst
-            prs: prs
           group: 1
-          exposed: true
+          exposed: false
           expose:
             operator_id: langcode_op
             label: Language
@@ -1500,7 +1474,7 @@ display:
           plugin_id: text
           empty: true
           content:
-            value: "<p>This report shows published documents that aren't linked from other published pages. </p>\r\n\r\n<p>If you see documents in this report, you could either unpublish the document if it is not needed or add a link to the document from another published page. To verify that a document is not linked, you can search for the link in SiteImprove's link inventory, or look for a link in Google.</p>\r\n\r\n<p>Documents that are not linked but published can still be found by the public through search because published documents are in a sitemap that is made available to search engines. </p>"
+            value: "<p>This report shows published documents that aren't linked from other published pages. Non-English documents won't appear on this report.</p>\r\n\r\n<p>If you see documents in this report, you could either unpublish the document if it is not needed or add a link to the document from another published page. To verify that a document is not linked, you can search for the link in SiteImprove's link inventory, or look for a link in Google.</p>\r\n\r\n<p>Documents that are not linked but published can still be found by the public through search because published documents are in a sitemap that is made available to search engines. </p>"
             format: basic_html
           tokenize: false
       footer: {  }


### PR DESCRIPTION
**Description:**
Orphan report will show only English pages and documents to avoid showing non-English items in error.


**Jira:** (Skip unless you are MA staff)
DP-28586


**To Test:**
- [ ] Verify that orphan page and document reports show only English results.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
