### PR TITLE
DP-28762-fix-header-alerts-ios-styles

### DIFF
--- a/changelogs/DP-28762.yml
+++ b/changelogs/DP-28762.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Fixed:
-    description: Override header alerts and org nav search ios button colors, to keep design consistent between desktop and mobile.
+  - description: Override header alerts and org nav search ios button colors, to keep design consistent between desktop and mobile.
     issue: DP-28762

--- a/changelogs/DP-28762.yml
+++ b/changelogs/DP-28762.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+    description: Override header alerts and org nav search ios button colors, to keep design consistent between desktop and mobile.
+    issue: DP-28762

--- a/composer.json
+++ b/composer.json
@@ -272,7 +272,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-28762-fix-header-alerts-ios-styles",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.json
+++ b/composer.json
@@ -272,7 +272,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-28762-fix-header-alerts-ios-styles",
         "monolog/monolog": "^2.6",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^3.4 || ^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb57bb185d4360745479358d0c46d1df",
+    "content-hash": "4128fe530e83fa4fef7823afdeb56a56",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12869,16 +12869,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-28762-fix-header-alerts-ios-styles",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "7b10f9cf23897e75dbd502dc74fb773261df968d"
+                "reference": "225c367d51f785264ad41f7d44165193a8dcd477"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/7b10f9cf23897e75dbd502dc74fb773261df968d",
-                "reference": "7b10f9cf23897e75dbd502dc74fb773261df968d",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/225c367d51f785264ad41f7d44165193a8dcd477",
+                "reference": "225c367d51f785264ad41f7d44165193a8dcd477",
                 "shasum": ""
             },
             "require": {
@@ -12896,7 +12896,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-06-20T15:42:57+00:00"
+            "time": "2023-07-12T13:52:05+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -12873,12 +12873,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "225c367d51f785264ad41f7d44165193a8dcd477"
+                "reference": "a6c0ad20d1808eb027bdacb59de66d72b4a2bff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/225c367d51f785264ad41f7d44165193a8dcd477",
-                "reference": "225c367d51f785264ad41f7d44165193a8dcd477",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a6c0ad20d1808eb027bdacb59de66d72b4a2bff9",
+                "reference": "a6c0ad20d1808eb027bdacb59de66d72b4a2bff9",
                 "shasum": ""
             },
             "require": {
@@ -12896,7 +12896,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-07-12T13:52:05+00:00"
+            "time": "2023-07-13T17:50:48+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4128fe530e83fa4fef7823afdeb56a56",
+    "content-hash": "eb57bb185d4360745479358d0c46d1df",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12869,16 +12869,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-28762-fix-header-alerts-ios-styles",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "a6c0ad20d1808eb027bdacb59de66d72b4a2bff9"
+                "reference": "a6b3d95f5a77667729405b4cfbf92d4b37cae3b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a6c0ad20d1808eb027bdacb59de66d72b4a2bff9",
-                "reference": "a6c0ad20d1808eb027bdacb59de66d72b4a2bff9",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a6b3d95f5a77667729405b4cfbf92d4b37cae3b8",
+                "reference": "a6b3d95f5a77667729405b4cfbf92d4b37cae3b8",
                 "shasum": ""
             },
             "require": {
@@ -12896,7 +12896,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2023-07-13T17:50:48+00:00"
+            "time": "2023-07-14T20:30:31+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fixed:
    description: Override header alerts and org nav search ios button colors, to keep design consistent between desktop and mobile.
    issue: DP-28762

Link to MF PR https://github.com/massgov/mayflower/pull/1822