### PR TITLE
DP-28890: Process BigQuery queue outside of cron

### DIFF
--- a/changelogs/DP-28890.yml
+++ b/changelogs/DP-28890.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Process BigQuery queue outside of cron
+    issue: DP-28890

--- a/docroot/modules/custom/mass_bigquery/src/Plugin/QueueWorker/BigQueryNodeQueueWorker.php
+++ b/docroot/modules/custom/mass_bigquery/src/Plugin/QueueWorker/BigQueryNodeQueueWorker.php
@@ -14,7 +14,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @QueueWorker(
  *   id = "mass_bigquery_node_queue",
  *   title = @Translation("BigQuery node queue"),
- *   cron = {"time" = 60}
  * )
  */
 class BigQueryNodeQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {


### PR DESCRIPTION
**Description:**
There was an error while processing the BigQuery queue that prevented the cron from finishing. It’s best practice to process queue items separately to prevent any errors from preventing the core cron from finishing.


**Jira:** (Skip unless you are MA staff)
DP-28890


**To Test:**
Queue items, run cron, and verify that the BigQuery queue isn't processed during cron.
```
# To make sure the queue worker metadata is updated
ddev drush cr
# Modify the time window and last ran so `mass_bigquery_cron()` runs.
ddev drush cset mass_bigquery.config end '21:59'
ddev drush state:set mass_bigquery.last_run 0
# Queue the nodes.
ddev drush eval 'mass_bigquery_cron();'
ddev drush queue:list
ddev drush cron
ddev drush queue:list
```


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
