### PR TITLE
Revert Akamai version which got moved up recently. Fixes test failures.

### DIFF
--- a/changelogs/DP-25149.yml
+++ b/changelogs/DP-25149.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Revert Akamai version which got moved up recently. Fixes test failures.
+    issue: DP-25149

--- a/composer.json
+++ b/composer.json
@@ -162,7 +162,7 @@
         "drupal/acquia_purge": "^1",
         "drupal/address": "^1.9",
         "drupal/admin_toolbar": "^3.0",
-        "drupal/akamai": "dev-4.x",
+        "drupal/akamai": "^4",
         "drupal/allowed_formats": "^2",
         "drupal/asset_cache_bust": "^1.0",
         "drupal/auto_entitylabel": "^3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6db4528a7a1c7f0c844a6f5fd1f8226",
+    "content-hash": "df4d2f9c2d929837136d29e0c587f02c",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -2710,11 +2710,17 @@
         },
         {
             "name": "drupal/akamai",
-            "version": "dev-4.x",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/akamai.git",
-                "reference": "0dfc25d616dcd20e94468d24eef18ec5925a3bd3"
+                "reference": "4.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/akamai-4.1.0.zip",
+                "reference": "4.1.0",
+                "shasum": "512ade13a781876df2e03afbf9c04569f53ce6d0"
             },
             "require": {
                 "drupal/core": "~8.5 || ^9",
@@ -2727,15 +2733,12 @@
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-4.x": "4.x-dev"
-                },
                 "drupal": {
-                    "version": "4.1.0+1-dev",
-                    "datestamp": "1678898579",
+                    "version": "4.1.0",
+                    "datestamp": "1674831396",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 },
                 "drush": {
@@ -23750,7 +23753,6 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "drupal/akamai": 20,
         "drupal/ckeditor_liststyle": 20,
         "drupal/config_ignore": 20,
         "drupal/entity_diff_ui": 20,


### PR DESCRIPTION
Tests have been failing for days but nobody noticed or nobody said anything. For example - https://app.circleci.com/pipelines/github/massgov/openmass/26585/workflows/e2e9dd5c-ff37-4653-8744-a682be1cf436/jobs/114261

The intent here is to get us back to the same giot hash we have been on 0dfc25d. Thats also the tag 4.1.0 for drupal/akamai

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
