### PR TITLE
Add drush ma:backup command for starting an on-demand DB backup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
       - image: cimg/php:8.0-node
     steps:
       - attach_workspace: { at: /tmp }
+      - fetch_drush_aliases
       - *vendor_bin_add_path
       - run:
           command: "drush ma:backup -v prod"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,16 @@ jobs:
       # @todo When needed, switch to https://circleci.com/developer/orbs/orb/circleci/github-cli
       - run: scripts/tag-release-deploy
 
+  acquia_db_backup:
+    working_directory: /tmp/code
+    docker:
+      - image: cimg/php:8.0-node
+    steps:
+      - attach_workspace: { at: /tmp }
+      - *vendor_bin_add_path
+      - run:
+          command: "drush ma:backup -v prod"
+
   validate:
     working_directory: /tmp/code
     docker:
@@ -1135,6 +1145,16 @@ workflows:
           gitRef: << pipeline.parameters.git-ref >>
           skip-maint: << pipeline.parameters.skip-maint >>
           refresh-db: << pipeline.parameters.refresh-db >>
+
+  # Nightly On Demand Prod DB Backup
+  nightly_prod_db_backup:
+    when:
+      and:
+        - equal: [ nightly_prod_db_backup, << pipeline.parameters.trigger_workflow >> ]
+    jobs:
+      - build
+      - acquia_db_backup:
+          requires: [ build ]
 
   # Nightly Backstop image references.
   nightly_backstop_snapshot:

--- a/changelogs/DP-29392.yml
+++ b/changelogs/DP-29392.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Add drush ma:backup command for starting an on-demand DB backup.
+    issue: DP-29392

--- a/drush/Commands/DeployCommands.php
+++ b/drush/Commands/DeployCommands.php
@@ -149,6 +149,28 @@ class DeployCommands extends DrushCommands implements SiteAliasManagerAwareInter
     $this->logger()->success($this->getSuccessMessage($body));
   }
 
+  /**
+   * Initiate an on-demand database backup via the Acquia API.
+   *
+   * @param string $target Target environment. Recognized values: dev, cd, test, feature1, feature2, feature3, feature4, feature5, prod.
+   *
+   * @usage drush ma:backup prod
+   *   Initiate a database backup in production.
+   *
+   * @command ma:backup
+   *
+   * @throws \Exception
+   */
+  public function createBackup($target) {
+    $env = $this->siteAliasManager()->getAlias($target);
+    $cloudapi = $this->getClient();
+    $backup = new DatabaseBackups($cloudapi);
+    $response = $backup->create($env->get('uuid'), 'massgov');
+    if ($response->message !== 'Creating the backup.') {
+      throw new \Exception('Failed to create a backup via Acquia Cloud API.');
+    }
+    $this->logger()->success('Backup initiated.');
+  }
 
   /**
    * Write the download link for the most recent database backup to stdout.


### PR DESCRIPTION
**Description:**
Will be scheduled to run daily at 6pm to support releases.


**Jira:** (Skip unless you are MA staff)
DP-29392


**To Test:**
- [ ] See successful run of _nightly_prod_db_backup workflow_ at https://app.circleci.com/pipelines/github/massgov/openmass?branch=feature%2FDP-29392_backups. That job was initiated. by the new CircleCI trigger.
- [ ] See a corresponding task get created in Acquia.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
