### PR TITLE
DP-29553 backstop removal of service details pages

### DIFF
--- a/backstop/all.json
+++ b/backstop/all.json
@@ -55,8 +55,6 @@
   {"label": "RegulationDraft", "url": "/regulations/900-CMR-3-qag-regulation-title-ultricies-tristique-nulla-aliquet-enim-tortor-at-auctor", "screens": ["desktop"]},
   {"label": "RegulationEffectiveDate", "url": "/regulations/900-CMR-2-qag-regulation-title"},
   {"label": "RulesOfCourt", "url": "/trial-court-rules/qag-rulesofcourt"},
-  {"label": "ServiceDetails", "url": "/service-details/qag-servicedetails"},
-  {"label": "ServiceDetailsResources", "url": "/service-details/qag-servicedetails/resources", "screens": ["desktop", "mobile"]},
   {"label": "Service1", "url": "/qag-service1"},
   {"label": "Service3", "url": "/qag-service3", "screens": ["desktop"]},
   {"label": "Service4", "url": "/qag-service4", "screens": ["desktop"]},

--- a/backstop/post-release.json
+++ b/backstop/post-release.json
@@ -14,7 +14,6 @@
   {"label": "OrgQAGEOTSSGeneralOrg", "url": "/orgs/qag-executive-office-of-technology-services-and-security"},
   {"label": "OrgElectedOfficial", "url": "/orgs/qag-test-elected-org-page"},
   {"label": "RegulationEffectiveDate", "url": "/regulations/900-CMR-2-qag-regulation-title"},
-  {"label": "ServiceDetails", "url": "/service-details/qag-servicedetails"},
   {"label": "Service1", "url": "/qag-service1"},
   {"label": "TopicPage1", "url": "/topics/qag-topicpage1"}
 

--- a/changelogs/DP-29553.yml
+++ b/changelogs/DP-29553.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Remove service details pages from visual regression testing in backstop.
+    issue: DP-29553


### PR DESCRIPTION
**Description:**
Removing pages related to service details from backstop


**Jira:** (Skip unless you are MA staff)
DP-29553


**To Test:**
- [ ] Run backstop and verify it doesn't test service details pages.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
