### PR TITLE
Ensure that node_id is always an array when requested from feedback API

### DIFF
--- a/changelogs/DP-29938.yml
+++ b/changelogs/DP-29938.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Addressed issues where Feedback API calls were not properly formatted.
+    issue: DP-29938

--- a/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopAuthorInterfaceForm.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopAuthorInterfaceForm.php
@@ -80,7 +80,6 @@ class MassFeedbackLoopAuthorInterfaceForm extends FormBase {
     // Checks for query params in case pager link was used.
     /** @var \Symfony\Component\HttpFoundation\ParameterBag $query */
     $query = $this->getRequest()->query;
-    $feedback_api_params = [];
 
     $params = $query->all();
     $feedback_api_params = $this->contentFetcher->formatQueryParams($params);
@@ -300,19 +299,13 @@ class MassFeedbackLoopAuthorInterfaceForm extends FormBase {
 
     if (isset($response['total']) && is_numeric($response['total']) && $response['total'] > 0) {
       // Create and attach the link to download CSV export.
-      $feedback_api_csv_download_params = $feedback_api_params;
-      foreach ($feedback_api_csv_download_params as $key => $value) {
-        if (is_array($value)) {
-          $feedback_api_csv_download_params[$key] = implode(",", $value);
-        }
-      }
-      $csv_download_url = Url::fromRoute('mass_feedback_loop.mass_feedback_csv_download', [], ['query' => $feedback_api_csv_download_params]);
-      $csv_download_uri = $csv_download_url->toString();
+      $feedback_api_csv_download_params = $this->contentFetcher->formatQueryParams($feedback_api_params);
+      $csv_download_url = Url::fromRoute('mass_feedback_loop.mass_feedback_csv_download', [], ['query' => $feedback_api_csv_download_params])->toString();
       $form['csv_export'] = [
         '#type' => 'markup',
         // @codingStandardsIgnoreStart
         '#markup' => "<div class='csv-export-wrapper'>
-          <a href='$csv_download_uri'>
+          <a href='$csv_download_url'>
             <span class='feed-icon'></span> Download CSV Export
           </a>
         </div>",

--- a/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopPerNodeForm.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopPerNodeForm.php
@@ -138,20 +138,12 @@ class MassFeedbackLoopPerNodeForm extends FormBase {
     $form['table_wrapper']['pager'] = $this->contentFetcher->buildPager($response['total'], $response['per_page']);
 
     if (isset($response['total']) && is_numeric($response['total']) && $response['total'] > 0) {
-      // Create and attach the link to download CSV export.
-      $feedback_api_csv_download_params = $feedback_api_params;
-      foreach ($feedback_api_csv_download_params as $key => $value) {
-        if (is_array($value)) {
-          $feedback_api_csv_download_params[$key] = implode(",", $value);
-        }
-      }
-      $csv_download_url = Url::fromRoute('mass_feedback_loop.mass_feedback_csv_download', [], ['query' => $feedback_api_csv_download_params]);
-      $csv_download_uri = $csv_download_url->toString();
+      $csv_download_url = Url::fromRoute('mass_feedback_loop.mass_feedback_csv_download', [], ['query' => $feedback_api_params])->toString();
       $form['csv_export'] = [
         '#type' => 'markup',
         // @codingStandardsIgnoreStart
         '#markup' => "<div class='csv-export-wrapper'>
-          <a href='$csv_download_uri'>
+          <a href='$csv_download_url'>
             <span class='feed-icon'></span> Download CSV Export
           </a>
         </div>",

--- a/docroot/modules/custom/mass_feedback_loop/src/Service/MassFeedbackLoopContentFetcher.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Service/MassFeedbackLoopContentFetcher.php
@@ -226,7 +226,7 @@ class MassFeedbackLoopContentFetcher {
     // by default we fetch feedback for all the nodes that the current user is watching.
     if (!isset($feedback_api_params['node_id']) && !isset($feedback_api_params['org_id']) && !isset($feedback_api_params['author_id'])) {
       if (isset($feedback_api_params['watch_content']) && $feedback_api_params['watch_content'] == 1) {
-        $feedback_api_params['node_id'] = $this->fetchFlaggedContent();
+        $feedback_api_params['node_id'] = [$this->fetchFlaggedContent()];
       }
     }
     elseif (isset($feedback_api_params['node_id']) && (isset($feedback_api_params['watch_content']) && $feedback_api_params['watch_content'] == 1)) {
@@ -241,12 +241,7 @@ class MassFeedbackLoopContentFetcher {
       }
     }
     elseif ((isset($feedback_api_params['watch_content']) && $feedback_api_params['watch_content'] == 1)) {
-      $feedback_api_params['node_id'] = $this->fetchFlaggedContent();
-    }
-
-    // The ETL Feedback API always expects node_id to be an array.
-    if (!empty($feedback_api_params['node_id']) && !is_array($feedback_api_params['node_id'])) {
-      $feedback_api_params['node_id'] = [$feedback_api_params['node_id']];
+      $feedback_api_params['node_id'] = [$this->fetchFlaggedContent()];
     }
 
     // Fetches feedback from external API.

--- a/docroot/modules/custom/mass_feedback_loop/src/Service/MassFeedbackLoopContentFetcher.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Service/MassFeedbackLoopContentFetcher.php
@@ -244,6 +244,11 @@ class MassFeedbackLoopContentFetcher {
       $feedback_api_params['node_id'] = $this->fetchFlaggedContent();
     }
 
+    // The ETL Feedback API always expects node_id to be an array.
+    if (!empty($feedback_api_params['node_id']) && !is_array($feedback_api_params['node_id'])) {
+      $feedback_api_params['node_id'] = [$feedback_api_params['node_id']];
+    }
+
     // Fetches feedback from external API.
     try {
       // We always order by submit date without exposing this parameter to users.


### PR DESCRIPTION
**Description:**
The errors reported were related to parameters that were not send in the request as arrays, specifically node_id and org_id. This pull request ensures that at least those parameters are passed in to CSV file requests correctly.


**Jira:** (Skip unless you are MA staff)
DP-29938


**To Test:**
- [ ] Set up local environment with staging Feedback API credentials
- [ ] Go to https://mass.local/info-details/take-the-community-health-equity-survey/feedback
- [ ] Export CSV. Passes if the CSV exports
- [ ] Go to https://mass.local/admin/ma-dash/feedback?org_id[0]=64676&watch_content=0&flagged_inappropriate=0
- [ ] Export CSV. Passes if the CSV exports


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
