### PR TITLE
Remove build_with_latest_mayflower CI job which is used in deploy_cd workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,23 +168,23 @@ jobs:
           root: ..
           paths: [code]
 
-  build_with_latest_mayflower:
-    working_directory: ~/project/code
-    docker:
-      - image: cimg/php:8.2-node
-    steps:
-      - checkout
-      - *restore_composer_cache
-      - run: {name: 'Composer install', command: 'composer install --no-interaction --optimize-autoloader'}
-      - run:
-          name: Update Mayflower to latest develop
-          command: composer -n -vvv require massgov/mayflower-artifacts:dev-develop --update-with-dependencies
-      - *save_composer_cache
-      - *yarn_install
-      - enable_cacheability_headers
-      - persist_to_workspace:
-          root: ..
-          paths: [code]
+#  build_with_latest_mayflower:
+#    working_directory: ~/project/code
+#    docker:
+#      - image: cimg/php:8.2-node
+#    steps:
+#      - checkout
+#      - *restore_composer_cache
+#      - run: {name: 'Composer install', command: 'composer install --no-interaction --optimize-autoloader'}
+#      - run:
+#          name: Update Mayflower to latest develop
+#          command: composer -n -vvv require massgov/mayflower-artifacts:dev-develop --update-with-dependencies
+#      - *save_composer_cache
+#      - *yarn_install
+#      - enable_cacheability_headers
+#      - persist_to_workspace:
+#          root: ..
+#          paths: [code]
 
   push_acquia:
     working_directory: ~/project/code
@@ -1202,10 +1202,10 @@ workflows:
       and:
         - equal: [ deploy_cd, << pipeline.parameters.trigger_workflow >> ]
     jobs:
-      - build_with_latest_mayflower
+#      - build_with_latest_mayflower
       - deploy:
           name: deploy-cd-refresh-db
-          requires: [ build_with_latest_mayflower ]
+#          requires: [ build_with_latest_mayflower ]
           target: cd
           refresh-db: "--refresh-db"
       - backstop_test:

--- a/changelogs/DP-30639.yml
+++ b/changelogs/DP-30639.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Remove build_with_latest_mayflower CI job which is used in deploy_cd workflow.
+    issue: DP-30639


### PR DESCRIPTION
I could not find the root cause for the problem. I think we can workaround for now with this PR. It does:

Before: We deploy develop to CD but with the latest mayflower artifact regardless if develop is ready for it
After: We deploy develop to CD

**Jira:** (Skip unless you are MA staff)
DP-30639


**To Test:**
- [ ] None. We will trigger a pipeline run after merge


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
