### PR TITLE
DP-30770: alert-validation-backport

### DIFF
--- a/changelogs/DP-30770.yml
+++ b/changelogs/DP-30770.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Changes to alert content type to fix validation issues related to conditional fields.
+    issue: DP-30770

--- a/conf/drupal/config/core.entity_form_display.node.alert.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.alert.default.yml
@@ -303,6 +303,24 @@ content:
             effect: show
             effect_options: {  }
             selector: ''
+        08140ff4-88d4-4605-a0c5-8fad93c71675:
+          entity_type: node
+          bundle: alert
+          dependee: field_alert_title_link
+          settings:
+            state: required
+            reset: false
+            condition: value
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              -
+                value: link
+            effect: show
+            effect_options: {  }
+            selector: ''
   field_english_version:
     type: entity_reference_autocomplete
     weight: 15

--- a/conf/drupal/config/core.entity_form_display.node.alert.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.alert.default.yml
@@ -197,13 +197,14 @@ content:
           dependee: field_alert_hide_message
           settings:
             state: '!visible'
-            condition: checked
+            reset: false
+            condition: value
             grouping: AND
             values_set: 1
             value: ''
             values: {  }
             value_form:
-              value: false
+              value: 1
             effect: show
             effect_options: {  }
             selector: ''
@@ -258,6 +259,23 @@ content:
             values: {  }
             value_form:
               value: 1
+            effect: show
+            effect_options: {  }
+            selector: ''
+        63600dba-b037-44da-923e-7a9248af34f4:
+          entity_type: node
+          bundle: alert
+          dependee: field_alert_hide_message
+          settings:
+            state: required
+            reset: false
+            condition: checked
+            grouping: AND
+            values_set: 1
+            value: ''
+            values: {  }
+            value_form:
+              value: false
             effect: show
             effect_options: {  }
             selector: ''

--- a/conf/drupal/config/field.field.node.alert.field_alert_title_link.yml
+++ b/conf/drupal/config/field.field.node.alert.field_alert_title_link.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: alert
 label: 'Alert title link option'
 description: ''
-required: true
+required: false
 translatable: false
 default_value:
   -

--- a/conf/drupal/config/field.field.node.alert.field_alert_title_link_target.yml
+++ b/conf/drupal/config/field.field.node.alert.field_alert_title_link_target.yml
@@ -13,7 +13,7 @@ entity_type: node
 bundle: alert
 label: 'Alert title link'
 description: 'Choose the page that you want to link the alert title to. You can start typing the title of an internal page or you can enter an external URL.'
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
**Description:**
Changes to alert content type to make alert link not required by default and use conditional logic to make it required when needed.


**Jira:** (Skip unless you are MA staff)
DP-30770


**To Test:**
- [ ] Modify an alert. You should be able to save without an alert link if you use the alert message but the link should be required when you choose to hide the alert message and link the alert title.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
