### PR TITLE
DP-30473: Help text for authors to ensure document accessibility

### DIFF
--- a/changelogs/DP-30473.yml
+++ b/changelogs/DP-30473.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Changed the Add/edit document page to have a link at the top to suggest not using a document and help text when uploading a file to remind authors to test documents for accessibility.
+    issue: DP-30473

--- a/conf/drupal/config/core.entity_form_display.media.document.default.yml
+++ b/conf/drupal/config/core.entity_form_display.media.document.default.yml
@@ -32,7 +32,6 @@ third_party_settings:
     group_timeframe:
       children:
         - field_start_date
-        - field_end_date
       label: Timeframe
       region: content
       parent_name: group_basic
@@ -57,24 +56,7 @@ third_party_settings:
         id: ''
         direction: horizontal
     group_advanced:
-      children:
-        - field_alternative_title
-        - field_geographic_area
-        - field_content_type
-        - field_subjects
-        - field_additional_info
-        - field_link_related_content
-        - field_part_of
-        - field_license
-        - field_rights
-        - field_conform
-        - field_data_quality
-        - field_system_of_records
-        - field_oclc_number
-        - field_file_migration_id
-        - field_link_classic_massgov
-        - field_checksum
-        - field_data_dictionary
+      children: {  }
       label: Advanced
       region: content
       parent_name: group_form
@@ -96,16 +78,10 @@ third_party_settings:
         - field_organizations
         - langcode
         - field_media_english_version
-        - field_creator
-        - field_publishing_frequency
-        - field_geographic_place
-        - field_contact_name
-        - field_contact_information
         - group_timeframe
         - field_document_type
         - field_document_label
         - field_collections
-        - field_tags
         - field_internal_notes
       label: Basic
       region: content
@@ -114,9 +90,10 @@ third_party_settings:
       format_type: tab
       format_settings:
         classes: ''
+        show_empty_fields: false
         id: ''
         formatter: open
-        description: ''
+        description: '<a href="https://www.mass.gov/kb/usehtml">Learn more about why it’s best to avoid documents and use HTML instead.</a>'
         required_fields: true
 id: media.document.default
 targetEntityType: media
@@ -285,6 +262,11 @@ content:
       display_label: true
     third_party_settings: {  }
     display_label: true
+  simple_sitemap:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 2

--- a/conf/drupal/config/field.field.media.document.field_upload_file.yml
+++ b/conf/drupal/config/field.field.media.document.field_upload_file.yml
@@ -12,7 +12,7 @@ field_name: field_upload_file
 entity_type: media
 bundle: document
 label: 'Select the file'
-description: 'References the file corresponding to the document.'
+description: '<p><b>IMPORTANT: All documents must be accessible</b> so that visitors who need assistive technology can use them. Test your documents prior to uploading <a href="https://www.mass.gov/kb/make-docs-accessible">using the guidance found in our Knowledge Base</a>.</p>'
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
**Description:**
Changed the Add/edit document page to have a link at the top to suggest not using a document and help text when uploading a file to remind authors to test documents for accessibility.


**Jira:** (Skip unless you are MA staff)
DP-30473


**To Test:**
- [ ] Add a document. Verify you see a link at the top suggesting to not use a document and a reminder at the file upload field to check docs for accessibility.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
