### PR TITLE
DP-30881: Removed drush pm:security command from pending_security

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -661,8 +661,6 @@ jobs:
     steps:
       - attach_workspace: {at: /tmp}
       - run: "composer audit --no-interaction --no-dev"
-      - *vendor_bin_add_path
-      - run: "drush pm:security"
 
 workflows:
   build_test:

--- a/changelogs/DP-30881.yml
+++ b/changelogs/DP-30881.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Removed:
+  - description: Removed drush pm:security from pending_security job in CircleCI.
+    issue: DP-30881


### PR DESCRIPTION
**Description:**
Removes `drush pm:security` from pending_security job in CircleCI.


**Jira:** (Skip unless you are MA staff)
DP-30881


**To Test:**
- [ ] Re-run the pending_security CircleCI job or review successful job here: https://app.circleci.com/pipelines/github/massgov/openmass/28076/workflows/a095cabc-e691-4b5e-a501-46a1fe01d8fc


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
