### PR TITLE
DP-30787: Change allowable size of info details header from 100 to 130 characters

### DIFF
--- a/changelogs/DP-30787.yml
+++ b/changelogs/DP-30787.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Change allowable size of info details header from 100 to 130 characters.
+    issue: DP-30787

--- a/conf/drupal/config/core.entity_form_display.paragraph.section_long_form.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.section_long_form.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - paragraphs.paragraphs_type.section_long_form
   module:
     - field_group
+    - maxlength
     - paragraphs
 third_party_settings:
   field_group:
@@ -82,7 +83,11 @@ content:
     settings:
       size: 60
       placeholder: ''
-    third_party_settings: {  }
+    third_party_settings:
+      maxlength:
+        maxlength_js: 130
+        maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
+        maxlength_js_enforce: true
   paragraphs_type_help__default:
     weight: -100
     region: content

--- a/conf/drupal/config/field.storage.paragraph.field_section_long_form_heading.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_section_long_form_heading.yml
@@ -9,7 +9,7 @@ field_name: field_section_long_form_heading
 entity_type: paragraph
 type: string
 settings:
-  max_length: 100
+  max_length: 255
   case_sensitive: false
   is_ascii: false
 module: core

--- a/docroot/modules/custom/mass_content/mass_content.install
+++ b/docroot/modules/custom/mass_content/mass_content.install
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Change field_section_long_form_heading char count to 130.
+ * Change field_section_long_form_heading char count to 255.
  */
 function mass_content_update_9002() {
   $entity_type_id = 'paragraph';

--- a/docroot/modules/custom/mass_content/mass_content.install
+++ b/docroot/modules/custom/mass_content/mass_content.install
@@ -1,0 +1,37 @@
+<?php
+
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Implements hook_update_N().
+ */
+function mass_content_update_9002() {
+  $entity_type_id = 'paragraph';
+  $field_name = 'field_section_long_form_heading';
+  $new_length = 255;
+  $name = 'field.storage.' . $entity_type_id . "." . $field_name;
+
+  // Get the current settings
+  $result = \Drupal::database()->query(
+    'SELECT data FROM {config} WHERE name = :name',
+    [':name' => $name]
+  )->fetchField();
+  $data = unserialize($result);
+  $data['settings']['max_length'] = $new_length;
+
+  // Write settings back to the database.
+  \Drupal::database()->update('config')
+    ->fields(['data' => serialize($data)])
+    ->condition('name', $name)
+    ->execute();
+
+  // Update the value column in both the _data and _revision tables for the field
+  $table = $entity_type_id . "__" . $field_name;
+  // This is the revision table for the field in paragraph
+  $table_revision = 'paragraph_r__8e196b0e1c';
+  $new_field = ['type' => 'varchar', 'length' => $new_length];
+  $col_name = $field_name . '_value';
+  \Drupal::database()->schema()->changeField($table, $col_name, $col_name, $new_field);
+  \Drupal::database()->schema()->changeField($table_revision, $col_name, $col_name, $new_field);
+}

--- a/docroot/modules/custom/mass_content/mass_content.install
+++ b/docroot/modules/custom/mass_content/mass_content.install
@@ -1,10 +1,7 @@
 <?php
 
-use Drupal\Core\Config\Entity\ConfigEntityInterface;
-use Drupal\field\Entity\FieldStorageConfig;
-
 /**
- * Implements hook_update_N().
+ * Change field_section_long_form_heading char count to 130.
  */
 function mass_content_update_9002() {
   $entity_type_id = 'paragraph';


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
