### PR TITLE
Fixup README and add ddev aliases command

### DIFF
--- a/.ddev/commands/host/aliases
+++ b/.ddev/commands/host/aliases
@@ -11,6 +11,6 @@ then
 fi
 
 gh api \
-  -H "Accept: application/vnd.github+json" \
+  -H "Accept: application/vnd.github.raw" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   repos/massgov/massgov-internal-docs/contents/self.site.yml > ./drush/sites/self.site.yml

--- a/.ddev/commands/host/aliases
+++ b/.ddev/commands/host/aliases
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+## Description: Fetch the mass.gov Drush aliases file
+## Usage: aliases
+## Example: "ddev aliases"
+
+if ! command -v gh &> /dev/null
+then
+    echo "Please install gh program, and be logged into it. See https://cli.github.com/"
+    exit 1
+fi
+
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  repos/massgov/massgov-internal-docs/contents/self.site.yml > ./drush/sites/self.site.yml

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,5 @@
 name: mass
-type: drupal9
+type: drupal10
 docroot: docroot
 php_version: "8.2"
 webserver_type: apache-fpm
@@ -35,4 +35,4 @@ web_environment:
   - LOWER_ENVIR_AUTH_PASS
 hooks:
   pre-start:
-    - exec-host: echo "No output is shown during the first container build. It may take a minute to install Tugboat, CircleCI, and GitHub CLI tools."
+    - exec-host: echo "No output is shown during the first container build. It may take a minute to install Tugboat, CircleCI, GitHub, and New Relic  CLI tools."

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ See the [Table of Contents](/docs/README.md) for additional documentation relate
 
 1. Move into the project directory: `cd openmass`
 
-1. Create a `.env` file in the ~/.ddev dir of the project by copying the example file shipped with the `mass` repo. This file contains more options; we suggest that you review it and adjust accordingly. Note that the `.env` file is ignored in `.gitignore`; and will not be tracked or pushed to Github.
+1. Create a `.env` file in the ~/.ddev dir of the project by copying the example file shipped with the `openmass` repo. This file contains more options; we suggest that you review it and adjust accordingly. Note that the `.env` file is ignored in `.gitignore`; and will not be tracked or pushed to Github.
     ```
-    $ cp .env.example .env
+    $ cp .ddev/.env.example .ddev/.env
     ```
 
-### Docker (optional)
+### DDEV and Docker
 
 1. [Install DDEV](https://ddev.readthedocs.io/en/stable/). On Windows, use the WSL2 method. Most of us use Colima as the Docker provider.
 1. Inject your ssh keys into the container via `ddev auth ssh`. [Read more about ddev CLI](https://ddev.readthedocs.io/en/stable/users/cli-usage/).
@@ -33,7 +33,7 @@ See the [Table of Contents](/docs/README.md) for additional documentation relate
     ```
 
 ###### Notes
-- The site is browseable at https://mass.local
+- The site is browseable at the URL reported by `ddev describe`. Thats usually https://mass.local
 - It takes a a minute for the `dbmass` container start up.
 - [You may override ddev config locally](https://ddev.readthedocs.io/en/stable/users/extend/config_yaml/). create a `.ddev/config.local.yml` file and add whatever you need.
 - Similarly, rename [.ddev/.env.example](https://github.com/massgov/openmass/blob/develop/.ddev/.env.example) to `.env` in order to use ARM containers suitable for the Apple M1 Macs. This is also how you specify the less sanitized variant of our database.


### PR DESCRIPTION
This new command fetches the drush aliaeses file from our internal repo. For it to work, you must have the `gh` command on the host and be logged in there.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
