### PR TITLE
DP-31191: dont-require-data-type-field-on-ext-link-collections

### DIFF
--- a/changelogs/DP-31191.yml
+++ b/changelogs/DP-31191.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: On the external link for collections content type, data type is no longer required.
+    issue: DP-31191

--- a/conf/drupal/config/field.field.node.external_data_resource.field_details_data_type.yml
+++ b/conf/drupal/config/field.field.node.external_data_resource.field_details_data_type.yml
@@ -12,7 +12,7 @@ entity_type: node
 bundle: external_data_resource
 label: 'Data type'
 description: "Choose the data type that applies to this page.<br/><br/> \r\n<b>Data resource:</b> A report.<br/> \r\n<b>Dataset:</b> A body of structured information describing some topic(s) of interest. A dataset usually comprises a description of the data and one or multiple data resources, which can be in various formats.<br/> \r\n<b>Data catalog:</b> A collection of datasets that covers one or more topics. For example, an open data portal or a curated dataset listing across multiple topics. \r\n"
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''


### PR DESCRIPTION
**Description:**
On external data content type, data type is no longer required


**Jira:** (Skip unless you are MA staff)
DP-31191


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
