### PR TITLE
DP-31225: info-details-header-length

### DIFF
--- a/changelogs/DP-31225.yml
+++ b/changelogs/DP-31225.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Max header length on info details section increased to 200.
+    issue: DP-31225

--- a/conf/drupal/config/core.entity_form_display.paragraph.section_long_form.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.section_long_form.default.yml
@@ -85,7 +85,7 @@ content:
       placeholder: ''
     third_party_settings:
       maxlength:
-        maxlength_js: 130
+        maxlength_js: 200
         maxlength_js_label: 'Content limited to @limit characters, remaining: <strong>@remaining</strong>'
         maxlength_js_enforce: true
   paragraphs_type_help__default:


### PR DESCRIPTION
**Description:**
Max header length on info details section increased to 200.


**Jira:** (Skip unless you are MA staff)
DP-31225


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
