### PR TITLE
DP-31620: News headlines on org pages are the same heading level as the "News" header

### DIFF
--- a/changelogs/DP-31620.yml
+++ b/changelogs/DP-31620.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: News headlines on org pages are the same heading level as the "News" header.
+    issue: DP-31620

--- a/composer.json
+++ b/composer.json
@@ -277,7 +277,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-31620_press_listing_heading_level",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^6",

--- a/composer.json
+++ b/composer.json
@@ -277,7 +277,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-31620_press_listing_heading_level",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "symfony/dom-crawler": "^6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6733134316a5e5b44a1a31ea51f7f03a",
+    "content-hash": "cb95ab2a99394f9f992624b6fb7b6b11",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12375,16 +12375,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-31620_press_listing_heading_level",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "0de96aa7b4151b79498c9f27236ac53704979b47"
+                "reference": "b6cf083eec565be249ffd5d2051cf511c65732ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/0de96aa7b4151b79498c9f27236ac53704979b47",
-                "reference": "0de96aa7b4151b79498c9f27236ac53704979b47",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/b6cf083eec565be249ffd5d2051cf511c65732ea",
+                "reference": "b6cf083eec565be249ffd5d2051cf511c65732ea",
                 "shasum": ""
             },
             "require": {
@@ -12402,7 +12402,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2024-01-25T06:36:17+00:00"
+            "time": "2024-01-29T06:27:55+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -12379,12 +12379,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "9bb07889bc254b86361d9ef626a43adfe89083b3"
+                "reference": "cc436f9a947808ea7c1508c78b2919b33852444b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/9bb07889bc254b86361d9ef626a43adfe89083b3",
-                "reference": "9bb07889bc254b86361d9ef626a43adfe89083b3",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/cc436f9a947808ea7c1508c78b2919b33852444b",
+                "reference": "cc436f9a947808ea7c1508c78b2919b33852444b",
                 "shasum": ""
             },
             "require": {
@@ -12402,7 +12402,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2024-01-29T15:20:08+00:00"
+            "time": "2024-01-29T18:18:30+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-31620


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
