### PR TITLE
DP-31780 [a11y] text space for screen readers

### DIFF
--- a/changelogs/DP-31780.yml
+++ b/changelogs/DP-31780.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Add space to screen reader only text containers where screen readers announce the text sequentially as a part of its parent contetiner's last word.
+    issue: DP-31780

--- a/changelogs/DP-31780.yml
+++ b/changelogs/DP-31780.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Add space to screen reader only text containers where screen readers announce the text sequentially as a part of its parent contetiner's last word.
+  - description: Add space to screen reader only text containers where screen readers announce the text sequentially as a part of its parent container's last word.
     issue: DP-31780

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-31780_a11y-sr-text-space",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.4",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-31780_a11y-sr-text-space",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df879c6b235276e393ec82b94a9c01a4",
+    "content-hash": "fa2f42102753820bf40e6875bd2c5310",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12436,16 +12436,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-31780_a11y-sr-text-space",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "5663808684e7b419f9a7f4eba07a877a54109b58"
+                "reference": "98586c434029ccd10a7b169099d53f3fddb7bf54"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/5663808684e7b419f9a7f4eba07a877a54109b58",
-                "reference": "5663808684e7b419f9a7f4eba07a877a54109b58",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/98586c434029ccd10a7b169099d53f3fddb7bf54",
+                "reference": "98586c434029ccd10a7b169099d53f3fddb7bf54",
                 "shasum": ""
             },
             "require": {
@@ -12463,7 +12463,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2024-02-05T20:26:30+00:00"
+            "time": "2024-02-14T20:53:22+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -23907,5 +23907,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -12440,12 +12440,12 @@
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "98586c434029ccd10a7b169099d53f3fddb7bf54"
+                "reference": "336c6f56fe31a481793ddf84165c3cb941f62533"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/98586c434029ccd10a7b169099d53f3fddb7bf54",
-                "reference": "98586c434029ccd10a7b169099d53f3fddb7bf54",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/336c6f56fe31a481793ddf84165c3cb941f62533",
+                "reference": "336c6f56fe31a481793ddf84165c3cb941f62533",
                 "shasum": ""
             },
             "require": {
@@ -12463,7 +12463,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2024-02-14T20:53:22+00:00"
+            "time": "2024-02-15T19:10:49+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa2f42102753820bf40e6875bd2c5310",
+    "content-hash": "df879c6b235276e393ec82b94a9c01a4",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12436,16 +12436,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-31780_a11y-sr-text-space",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "git@github.com:massgov/mayflower-artifacts.git",
-                "reference": "336c6f56fe31a481793ddf84165c3cb941f62533"
+                "reference": "6991267ee7889b3a1c6eb0cc56c6ae5594c25acc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/336c6f56fe31a481793ddf84165c3cb941f62533",
-                "reference": "336c6f56fe31a481793ddf84165c3cb941f62533",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/6991267ee7889b3a1c6eb0cc56c6ae5594c25acc",
+                "reference": "6991267ee7889b3a1c6eb0cc56c6ae5594c25acc",
                 "shasum": ""
             },
             "require": {
@@ -12463,7 +12463,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2024-02-15T19:10:49+00:00"
+            "time": "2024-02-20T15:52:29+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form.html.twig
+++ b/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form.html.twig
@@ -1,6 +1,6 @@
 {{ attach_library('mass_feedback_form/feedback-form') }}
 <div id="feedback" data-mass-feedback-form>
-  <h2 class="visually-hidden">{{ 'Feedback'|t }}</h2>
+  <h2 class="ma__visually-hidden">{{ 'Feedback'|t }}</h2>
   <form method="post" novalidate action="https://www.formstack.com/forms/index.php" class="fsForm {# fsSingleColumn fsMaxCol1 #}" id="fsForm2521317">
 
     <input type="hidden" name="form" value="2521317" />
@@ -62,7 +62,7 @@ NOTE:
 
     <fieldset{#  id="label47054416" #}>
       <legend{#  class="fsLabel requiredLabel fsLabelVertical" #}>
-        Did you find what you were looking for on this webpage?<span> * <span class="visually-hidden">required</span></span>
+        Did you find what you were looking for on this webpage?<span> * <span class="ma__visually-hidden">required</span></span>
       </legend>
 
       <div class="ma__input-group__items ma__input-group__items--inline">
@@ -86,7 +86,7 @@ NOTE:
 
     {# SHOW THIS WHEN "NO" IS SELECTED ABOVE #}
     <fieldset class="radio-no hide">
-      <label {# id="label47054414" class="fsLabel requiredLabel"  #}for="field47054414">If "No," please tell us what you were looking for:<span> * <span class="visually-hidden">required</span></span></label>
+      <label {# id="label47054414" class="fsLabel requiredLabel"  #}for="field47054414">If "No," please tell us what you were looking for:<span> * <span class="ma__visually-hidden">required</span></span></label>
       <textarea id="field47054414"
                 class="fsField required {# fsTextAreaMaxLength #}"
                 name="field47054414"

--- a/docroot/modules/custom/mass_fields/src/Plugin/Filter/FilterRichtextIndent.php
+++ b/docroot/modules/custom/mass_fields/src/Plugin/Filter/FilterRichtextIndent.php
@@ -27,7 +27,7 @@ class FilterRichtextIndent extends FilterBase {
     // Unique ID per table for accessibility to establish pairing between the buttons and the table container for responsible table.
     $tableId = uniqid();
     $tableWrapperTop = '<div class="ma__rich-text__indent ma__table--responsive js-ma-responsive-table" data-ma-heading-parent="H' . $parentHeadingNum . '">
-    <nav class="ma__table__horizontal-nav"><button class="ma__table__horizontal-nav__left" aria-controls="' . $tableId . '"><span class="visually-hidden">Scroll left</span></button><div class="clip-scrollbar"><div class="ma__scroll-indicator"><div class="ma__scroll-indicator--bar" aria-controls="' . $tableId . '" role="scrollbar" aria-orientation="horizontal"><div class="ma__scroll-indicator__button"></div></div></div></div><button class="ma__table__horizontal-nav__right" aria-controls="' . $tableId . '"><span class="visually-hidden">Scroll right</span></button>
+    <nav class="ma__table__horizontal-nav"><button class="ma__table__horizontal-nav__left" aria-controls="' . $tableId . '"><span class="ma__visually-hidden">Scroll left</span></button><div class="clip-scrollbar"><div class="ma__scroll-indicator"><div class="ma__scroll-indicator--bar" aria-controls="' . $tableId . '" role="scrollbar" aria-orientation="horizontal"><div class="ma__scroll-indicator__button"></div></div></div></div><button class="ma__table__horizontal-nav__right" aria-controls="' . $tableId . '"><span class="ma__visually-hidden">Scroll right</span></button>
     </nav>
     <div class="ma__table--responsive__wrapper" id="' . $tableId . '">
     <table>';

--- a/docroot/modules/custom/mass_fields/src/Plugin/Filter/FilterRichtextTable.php
+++ b/docroot/modules/custom/mass_fields/src/Plugin/Filter/FilterRichtextTable.php
@@ -24,7 +24,7 @@ class FilterRichtextTable extends FilterBase {
     $tableId = uniqid();
 
     $tableWrapperTop = '<div class="ma__table--responsive js-ma-responsive-table">
-    <nav class="ma__table__horizontal-nav"><button class="ma__table__horizontal-nav__left" aria-controls="' . $tableId . '"><span class="visually-hidden">Scroll left</span></button><div class="clip-scrollbar"><div class="ma__scroll-indicator"><div class="ma__scroll-indicator--bar" aria-controls="' . $tableId . '" role="scrollbar" aria-orientation="horizontal"><div class="ma__scroll-indicator__button"></div></div></div></div><button class="ma__table__horizontal-nav__right" aria-controls="' . $tableId . '"><span class="visually-hidden">Scroll right</span></button>
+    <nav class="ma__table__horizontal-nav"><button class="ma__table__horizontal-nav__left" aria-controls="' . $tableId . '"><span class="ma__visually-hidden">Scroll left</span></button><div class="clip-scrollbar"><div class="ma__scroll-indicator"><div class="ma__scroll-indicator--bar" aria-controls="' . $tableId . '" role="scrollbar" aria-orientation="horizontal"><div class="ma__scroll-indicator__button"></div></div></div></div><button class="ma__table__horizontal-nav__right" aria-controls="' . $tableId . '"><span class="ma__visually-hidden">Scroll right</span></button>
     </nav>
     <div class="ma__table--responsive__wrapper" id="' . $tableId . '">
     <table>';

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -243,9 +243,7 @@
 
         var alertBox =
           '<div ' +
-          ' id="' +
-          wrongBundleAlertId +
-          '" ' +
+          ' id="' + wrongBundleAlertId + '" ' +
           ' role="contentinfo" ' +
           ' aria-label="Alert" ' +
           ' class="messages messages--error"> ' +
@@ -261,10 +259,7 @@
           '</div>';
 
         var alertBoxWrapper =
-          '<div ' +
-          ' id="' +
-          wrongBundleAlertId +
-          '--wrapper" ' +
+          '<div ' + ' id="' + wrongBundleAlertId + '--wrapper" ' +
           ' role="contentinfo" ' +
           ' >' +
           ' <h2 class="ma__visually-hidden">Status message</h2> ' +

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -242,30 +242,34 @@
         var wrongBundleAlertId = 'hierarchy-node-wrong-bundle-alert';
 
         var alertBox =
-          '<div ' +
-          ' id="' + wrongBundleAlertId + '" ' +
+          "<div " +
+          ' id="' +
+          wrongBundleAlertId +
+          '" ' +
           ' role="contentinfo" ' +
           ' aria-label="Alert" ' +
           ' class="messages messages--error"> ' +
-          ' <h2 class="visually-hidden">Status message</h2> ' +
-          ' <div>' +
-          ' Moving this page to a parent of this content type is not allowed. ' +
-          ' Please move the row in red to a different content type. ' +
-          ' See knowledge base for more information about what types are allowed.' +
-          ' </div>' +
+          ' <h2 class="ma__visually-hidden">Status message</h2> ' +
+          " <div>" +
+          " Moving this page to a parent of this content type is not allowed. " +
+          " Please move the row in red to a different content type. " +
+          " See knowledge base for more information about what types are allowed." +
+          " </div>" +
           ' <div class="form-actions">' +
           '   <div class="button" id="hierarchyDismissAlert">Got it</div>' +
-          ' </div>' +
-          '</div>';
+          " </div>" +
+          "</div>";
 
         var alertBoxWrapper =
-          '<div ' +
-          ' id="' + wrongBundleAlertId + '--wrapper" ' +
+          "<div " +
+          ' id="' +
+          wrongBundleAlertId +
+          '--wrapper" ' +
           ' role="contentinfo" ' +
-          ' >' +
-          ' <h2 class="visually-hidden">Status message</h2> ' +
+          " >" +
+          ' <h2 class="ma__visually-hidden">Status message</h2> ' +
           alertBox +
-          '</div>';
+          "</div>";
 
         // Remove once data and class on already alerted rows
         // that currently are not wrong.
@@ -311,14 +315,18 @@
         }
 
         var messageBox =
-          '<div ' +
-          ' id="' + wrongMessageId + '" ' +
+          "<div " +
+          ' id="' +
+          wrongMessageId +
+          '" ' +
           ' role="contentinfo" ' +
           ' aria-label="Status message" ' +
-          ' class="messages messages--error ' + hierarchyMessagesClass + '"> ' +
-          ' <h2 class="visually-hidden">Status message</h2> ' +
+          ' class="messages messages--error ' +
+          hierarchyMessagesClass +
+          '"> ' +
+          ' <h2 class="ma__visually-hidden">Status message</h2> ' +
           message +
-          '</div>';
+          "</div>";
 
         // Only create one wrong bundle message.
         if ($('#' + wrongMessageId).length === 0) {

--- a/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
+++ b/docroot/modules/custom/mass_hierarchy/libraries/hierarchy/hierarchy.js
@@ -242,7 +242,7 @@
         var wrongBundleAlertId = 'hierarchy-node-wrong-bundle-alert';
 
         var alertBox =
-          "<div " +
+          '<div ' +
           ' id="' +
           wrongBundleAlertId +
           '" ' +
@@ -250,26 +250,26 @@
           ' aria-label="Alert" ' +
           ' class="messages messages--error"> ' +
           ' <h2 class="ma__visually-hidden">Status message</h2> ' +
-          " <div>" +
-          " Moving this page to a parent of this content type is not allowed. " +
-          " Please move the row in red to a different content type. " +
-          " See knowledge base for more information about what types are allowed." +
-          " </div>" +
+          ' <div>' +
+          ' Moving this page to a parent of this content type is not allowed. ' +
+          ' Please move the row in red to a different content type. ' +
+          ' See knowledge base for more information about what types are allowed.' +
+          ' </div>' +
           ' <div class="form-actions">' +
           '   <div class="button" id="hierarchyDismissAlert">Got it</div>' +
-          " </div>" +
-          "</div>";
+          ' </div>' +
+          '</div>';
 
         var alertBoxWrapper =
-          "<div " +
+          '<div ' +
           ' id="' +
           wrongBundleAlertId +
           '--wrapper" ' +
           ' role="contentinfo" ' +
-          " >" +
+          ' >' +
           ' <h2 class="ma__visually-hidden">Status message</h2> ' +
           alertBox +
-          "</div>";
+          '</div>';
 
         // Remove once data and class on already alerted rows
         // that currently are not wrong.
@@ -315,7 +315,7 @@
         }
 
         var messageBox =
-          "<div " +
+          '<div ' +
           ' id="' +
           wrongMessageId +
           '" ' +
@@ -326,7 +326,7 @@
           '"> ' +
           ' <h2 class="ma__visually-hidden">Status message</h2> ' +
           message +
-          "</div>";
+          '</div>';
 
         // Only create one wrong bundle message.
         if ($('#' + wrongMessageId).length === 0) {

--- a/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
+++ b/docroot/modules/custom/mass_search/js/mass_search.google_cse.js
@@ -35,7 +35,7 @@
  *  Required Markup:
  *
  * <div class="ma__suggestions-container js-suggestions-container">
- <div class="visually-hidden js-suggestions-help" role="status"  aria-live="polite"></div>
+ <div class="ma__visually-hidden js-suggestions-help" role="status"  aria-live="polite"></div>
  <input
  id="..."
  class="..."

--- a/docroot/themes/custom/mass_theme/templates/block/block--system-menu-block.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/block/block--system-menu-block.html.twig
@@ -37,7 +37,7 @@
 <ul{{ attributes.addClass('ma__footer-links__items') }}{{ attributes.setAttribute('aria-label', configuration.label) }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+    {% set title_attributes = title_attributes.addClass('ma__visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
   {{ title_suffix }}

--- a/docroot/themes/custom/mass_theme/templates/field/field--node--field-action-details.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/field/field--node--field-action-details.html.twig
@@ -43,7 +43,7 @@
 
       {# Jump menu #}
       <nav class="ma__action-details__anchor-links js-scroll-anchors" aria-labelledby="page_contents">
-          <h3 class="visually-hidden" id="page_contents">Page Contents</h3>
+          <h3 class="ma__visually-hidden" id="page_contents">Page Contents</h3>
           <button class="ma__action-details__toggle-link js-scroll-anchors-toggle">+</button>
           {% for key,value in subheads %}
               <a href="#{{key}}" class="js-scroll-anchors-link {{loop.first ? 'is-active' : ''}}">{{value}}</a>

--- a/docroot/themes/custom/mass_theme/templates/includes/organisms-suggested-pages.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/organisms-suggested-pages.html.twig
@@ -6,7 +6,7 @@
 #}
 <section class="ma__suggested-pages">
   <div class="ma__suggested-pages__container">
-    <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}<span class="visually-hidden"> {{ suggestedPages.titleContext }}</span></h2>
+    <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}<span class="ma__visually-hidden"> {{ suggestedPages.titleContext }}</span></h2>
     <div class="ma__suggested-pages__items">
       {% for page in suggestedPages.pages %}
         {% set illustratedLink = {

--- a/docroot/themes/custom/mass_theme/templates/includes/organisms-suggested-pages.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/includes/organisms-suggested-pages.html.twig
@@ -6,7 +6,7 @@
 #}
 <section class="ma__suggested-pages">
   <div class="ma__suggested-pages__container">
-    <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}<span class="ma__visually-hidden"> {{ suggestedPages.titleContext }}</span></h2>
+    <h2 class="ma__suggested-pages__title">{{ suggestedPages.title }}<span class="ma__visually-hidden">&nbsp; {{ suggestedPages.titleContext }}</span></h2>
     <div class="ma__suggested-pages__items">
       {% for page in suggestedPages.pages %}
         {% set illustratedLink = {

--- a/docroot/themes/custom/mass_theme/templates/layout/page--node--without-main.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/layout/page--node--without-main.html.twig
@@ -67,7 +67,7 @@
 {% if header_version_mixed %}
   <header class="ma__header__hamburger ma__header__mixed{{ header_class }}" id="header">
     <div class="menu-overlay"></div>
-    <a class="ma__header__hamburger__skip-nav visually-hidden focusable" href="#main-content">
+    <a class="ma__header__hamburger__skip-nav ma__visually-hidden focusable" href="#main-content">
       {{ 'Skip to main content'|t }}
     </a>
 

--- a/docroot/themes/custom/mass_theme/templates/layout/page.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/layout/page.html.twig
@@ -67,7 +67,7 @@
 {% if header_version_mixed %}
   <header class="ma__header__hamburger ma__header__mixed{{ header_class }}" id="header">
     <div class="menu-overlay"></div>
-    <a class="ma__header__hamburger__skip-nav visually-hidden focusable" href="#main-content">
+    <a class="ma__header__hamburger__skip-nav ma__visually-hidden focusable" href="#main-content">
       {{ 'Skip to main content'|t }}
     </a>
 

--- a/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/misc/status-messages.html.twig
@@ -35,7 +35,7 @@
       <div role="alert">
     {% endif %}
       {% if status_headings[type] %}
-        <h2 class="visually-hidden">{{ status_headings[type] }}</h2>
+        <h2 class="ma__visually-hidden">{{ status_headings[type] }}</h2>
       {% endif %}
       {% if messages|length > 1 %}
         <ul class="messages__list">

--- a/docroot/themes/custom/mass_theme/templates/navigation/pager.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/navigation/pager.html.twig
@@ -34,7 +34,7 @@
 {% if items %}
   <div class="ma__pagination">
     <div class="ma__pagination__container">
-      <h4 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h4>
+      <h4 id="pagination-heading" class="ma__visually-hidden">{{ 'Pagination'|t }}</h4>
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}
         <a href="{{ items.previous.href }}"
@@ -56,7 +56,7 @@
           {% set title = 'Go to page @key'|t({'@key': key}) %}
         {% endif %}
         <a href="{{ item.href }}" class="ma__pagination__page js-pagination-page {{ current == key ? ' is-active' : '' }}" data-page="{{- key -}}" aria-label="Go to Page {{- key -}}" {{ item.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">{{ current == key ? 'Current page'|t : 'Page '|t }} </span>
+            <span class="ma__visually-hidden">{{ current == key ? 'Current page'|t : 'Page '|t }} </span>
             {{- key -}}
         </a>
       {% endfor %}

--- a/docroot/themes/custom/mass_theme/templates/navigation/pager.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/navigation/pager.html.twig
@@ -56,7 +56,7 @@
           {% set title = 'Go to page @key'|t({'@key': key}) %}
         {% endif %}
         <a href="{{ item.href }}" class="ma__pagination__page js-pagination-page {{ current == key ? ' is-active' : '' }}" data-page="{{- key -}}" aria-label="Go to Page {{- key -}}" {{ item.attributes|without('href', 'title') }}>
-            <span class="ma__visually-hidden">{{ current == key ? 'Current page'|t : 'Page '|t }} </span>
+            <span class="ma__visually-hidden">{{ current == key ? 'Current page'|t : 'Page '|t }} &nbsp;</span>
             {{- key -}}
         </a>
       {% endfor %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--contact-info--extended-header.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--contact-info--extended-header.html.twig
@@ -49,7 +49,7 @@
     {% set address_values = content.field_address[0]['#context']['value']|split(', ') %}
     {% set location_name =  address_values[0] %}
     <p>{{ content.field_address|field_value }}</p>
-    <a class="ma__content-link " href="{{ address_url }}" title="{{ 'Directions to '|t ~ location_name }}">{{ 'Directions'|t }} <span class="ma__visually-hidden">to {{ location_name }}</span></a>
+    <a class="ma__content-link " href="{{ address_url }}" title="{{ 'Directions to '|t ~ location_name }}">{{ 'Directions'|t }} <span class="ma__visually-hidden">&nbsp; to {{ location_name }}</span></a>
   {% elseif content.field_phone|render|trim is not empty %}
     <div>
       {% if content.field_label|render|trim is not empty %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--contact-info--extended-header.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--contact-info--extended-header.html.twig
@@ -49,7 +49,7 @@
     {% set address_values = content.field_address[0]['#context']['value']|split(', ') %}
     {% set location_name =  address_values[0] %}
     <p>{{ content.field_address|field_value }}</p>
-    <a class="ma__content-link " href="{{ address_url }}" title="{{ 'Directions to '|t ~ location_name }}">{{ 'Directions'|t }} <span class="visually-hidden">to {{ location_name }}</span></a>
+    <a class="ma__content-link " href="{{ address_url }}" title="{{ 'Directions to '|t ~ location_name }}">{{ 'Directions'|t }} <span class="ma__visually-hidden">to {{ location_name }}</span></a>
   {% elseif content.field_phone|render|trim is not empty %}
     <div>
       {% if content.field_label|render|trim is not empty %}

--- a/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--icon--extended-header.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/paragraphs/paragraph--icon--extended-header.html.twig
@@ -36,7 +36,7 @@
  * @ingroup themeable
  */
 #}
-<h2 class="visually-hidden">Location Features</h2>
+<h2 class="ma__visually-hidden">Location Features</h2>
 <div class="ma__location-icons__item">
   {% if content.field_para_icon_term|render|trim is not empty %}
     <div class="ma__location-icons__icon">

--- a/docroot/themes/custom/mass_theme/templates/views/views-mini-pager.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/views/views-mini-pager.html.twig
@@ -15,19 +15,19 @@
 {% if items %}
   <div class="ma__pagination">
     <nav class="ma__pagination__container">
-      <h4 id="pagination-heading" class="visually-hidden">{{ 'Pagination'|t }}</h4>
+      <h4 id="pagination-heading" class="ma__visually-hidden">{{ 'Pagination'|t }}</h4>
       {# Print previous item if we are not on the first page. #}
       {% if items.previous %}
         <a href="{{ items.previous.href }}" class="ma__pagination__prev js-pagination-prev {% if pagination.prev.disabled %}disabled{% endif %}"
-        aria-label="Go to {{ items.previous.text|default('Previous'|t) }} page" 
+        aria-label="Go to {{ items.previous.text|default('Previous'|t) }} page"
         rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
           {{ items.previous.text|default('‹ Previous'|t) }}
         </a>
       {% endif %}
       {# Print next item if we are not on the last page. #}
       {% if items.next %}
-        <a href="{{ items.next.href }}" 
-        class="ma__pagination__next js-pagination-next {% if pagination.next.disabled %}disabled{% endif %}" 
+        <a href="{{ items.next.href }}"
+        class="ma__pagination__next js-pagination-next {% if pagination.next.disabled %}disabled{% endif %}"
         aria-label="Go to {{ items.next.text|default('Next'|t) }} page"
         rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
         {{ items.next.text|default('Next ›'|t) }}


### PR DESCRIPTION
**Description:**
- Change `visually-hidden` for front end files (templates + js + PHP for rendering elements) to `ma__visualy-hidden`.
- Add `&nbsp;` to `.ma__visually-hidden` in theming templates

sample test pages:

- /how-to/qag-request-help-with-a-computer-problem
- /orgs/qag-test-elected-org-page
- /locations/qag-locationgeneral1
- /guides/qag-guide

**Jira:** (Skip unless you are MA staff)
DP-31780


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
