### PR TITLE
DP-31982: org type field and taxonomy

### DIFF
--- a/changelogs/DP-31982.yml
+++ b/changelogs/DP-31982.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Org type field and Org type taxonomy - to be used and populated later.
+    issue: DP-31982

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -124,9 +125,9 @@ third_party_settings:
         - field_intended_audience
         - group_test_fieldset_group
         - field_parent
-        - field_org_no_search_filter
         - group_organization_parent_mass_g
         - field_billing_organization
+        - field_organization_type
       label: Overview
       region: content
       parent_name: group_node_edit_form
@@ -261,7 +262,7 @@ content:
       conditional_fields: {  }
   field_billing_organization:
     type: dynamic_entity_reference_options_select
-    weight: 137
+    weight: 136
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -279,7 +280,7 @@ content:
     third_party_settings: {  }
   field_career_opportunities:
     type: link_default
-    weight: 12
+    weight: 11
     region: content
     settings:
       placeholder_url: ''
@@ -374,7 +375,7 @@ content:
     third_party_settings: {  }
   field_more_about_leadership:
     type: entity_reference_autocomplete
-    weight: 10
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS
@@ -384,14 +385,14 @@ content:
     third_party_settings: {  }
   field_org_always_show_help_page:
     type: boolean_checkbox
-    weight: 135
+    weight: 136
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_org_directory_page:
     type: link_default
-    weight: 11
+    weight: 10
     region: content
     settings:
       placeholder_url: ''
@@ -423,6 +424,12 @@ content:
       add_mode: button
       form_display_mode: default
       default_paragraph_type: section_long_form
+    third_party_settings: {  }
+  field_organization_type:
+    type: options_buttons
+    weight: 137
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_organizations:
     type: entity_reference_autocomplete
@@ -485,7 +492,7 @@ content:
     third_party_settings: {  }
   field_public_records_link:
     type: link_default
-    weight: 13
+    weight: 12
     region: content
     settings:
       placeholder_url: ''

--- a/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.about_details.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -144,6 +145,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.default.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -298,6 +299,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 50
+    region: content
+  field_organization_type:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 141
     region: content
   field_organizations:
     type: entity_reference_label

--- a/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.feedback.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -129,6 +130,7 @@ hidden:
   field_org_no_search_filter: true
   field_org_page_thumbnail: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.link_and_description.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.link_and_description.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -115,6 +116,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.link_only.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.link_only.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -115,6 +116,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.logo_link.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -101,6 +102,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_services.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -106,6 +107,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.org_nav_featured_topics.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -106,6 +107,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.organization_grid.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -106,6 +107,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.preview_card.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -110,6 +111,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.teaser.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -106,6 +107,7 @@ hidden:
   field_org_sentence_phrasing: true
   field_org_short_name: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
+++ b/conf/drupal/config/core.entity_view_display.node.org_page.title_short_desc.yml
@@ -25,6 +25,7 @@ dependencies:
     - field.field.node.org_page.field_org_page_thumbnail
     - field.field.node.org_page.field_org_sentence_phrasing
     - field.field.node.org_page.field_organization_sections
+    - field.field.node.org_page.field_organization_type
     - field.field.node.org_page.field_organizations
     - field.field.node.org_page.field_parent
     - field.field.node.org_page.field_person_bio
@@ -95,6 +96,7 @@ hidden:
   field_org_page_thumbnail: true
   field_org_sentence_phrasing: true
   field_organization_sections: true
+  field_organization_type: true
   field_organizations: true
   field_parent: true
   field_person_bio: true

--- a/conf/drupal/config/field.field.node.org_page.field_organization_type.yml
+++ b/conf/drupal/config/field.field.node.org_page.field_organization_type.yml
@@ -1,0 +1,29 @@
+uuid: a9876a0b-fa1f-4ed8-b962-da32ace38678
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organization_type
+    - node.type.org_page
+    - taxonomy.vocabulary.organization_type
+id: node.org_page.field_organization_type
+field_name: field_organization_type
+entity_type: node
+bundle: org_page
+label: 'Organization Type'
+description: 'This field is used for reporting and analytics.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      organization_type: organization_type
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.storage.node.field_organization_type.yml
+++ b/conf/drupal/config/field.storage.node.field_organization_type.yml
@@ -1,0 +1,20 @@
+uuid: f5e6b61f-d5cf-4a9a-bf5e-b6e8e8ad76b4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_organization_type
+field_name: field_organization_type
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/language.content_settings.taxonomy_term.organization_type.yml
+++ b/conf/drupal/config/language.content_settings.taxonomy_term.organization_type.yml
@@ -1,0 +1,11 @@
+uuid: 9291795a-93d3-4794-821a-425a18ae1b43
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization_type
+id: taxonomy_term.organization_type
+target_entity_type_id: taxonomy_term
+target_bundle: organization_type
+default_langcode: site_default
+language_alterable: false

--- a/conf/drupal/config/rabbit_hole.behavior_settings.taxonomy_vocabulary_organization_type.yml
+++ b/conf/drupal/config/rabbit_hole.behavior_settings.taxonomy_vocabulary_organization_type.yml
@@ -1,0 +1,14 @@
+uuid: 200fd22d-edd8-4e21-9c19-d88d68e06748
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization_type
+id: taxonomy_vocabulary_organization_type
+entity_type_id: taxonomy_vocabulary
+entity_id: organization_type
+action: page_not_found
+allow_override: 1
+redirect: ''
+redirect_code: 301
+redirect_fallback_action: access_denied

--- a/conf/drupal/config/taxonomy.vocabulary.organization_type.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.organization_type.yml
@@ -1,0 +1,8 @@
+uuid: ee19c653-bd60-4a9a-949f-a654997ea4d8
+langcode: en
+status: true
+dependencies: {  }
+name: 'Organization Type'
+vid: organization_type
+description: 'Organization Type'
+weight: 0


### PR DESCRIPTION
**Description:**
Adding org type field and org type taxonomy that will be used with it. The taxonomy will be populated later. The field will be visible to authors but optional for now but will be configured later after the taxonomy is populated in production.


**Jira:** (Skip unless you are MA staff)
DP-31982


**To Test:**
- [ ] Verify that the org type field is visible for org content type. Should be no choices to pick since taxonomy will be empty.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
