### PR TITLE
DP-32345: regulation date field label

### DIFF
--- a/changelogs/DP-32345.yml
+++ b/changelogs/DP-32345.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Label change for date on regulation type.
+    issue: DP-32345

--- a/conf/drupal/config/field.field.node.regulation.field_date_published.yml
+++ b/conf/drupal/config/field.field.node.regulation.field_date_published.yml
@@ -11,7 +11,7 @@ id: node.regulation.field_date_published
 field_name: field_date_published
 entity_type: node
 bundle: regulation
-label: 'Last updated'
+label: 'Last updated by Mass. Register'
 description: ''
 required: true
 translatable: true


### PR DESCRIPTION
**Description:**
Changed internal label for date field on regulation type


**Jira:** (Skip unless you are MA staff)
DP-32345


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
