### PR TITLE
Move data,menu cache bins to database backend. Also no more ChainedFast backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [0.397.4] - May 14, 2024
+## [0.397.5] - May 17, 2024
+
+### Changed
+- Added render cache debugging to edit.mass.gov requests
+- Move data,menu cache bins to database backend. Also no more ChainedFast backend
+
+## [0.397.4] - May 16, 2024
 
 ### Fixed
 - Fixed potential render cache issues where cache is applied to existing render arrays.

--- a/docroot/modules/custom/mass_admin_toolbar/src/Plugin/Block/MessageTabs.php
+++ b/docroot/modules/custom/mass_admin_toolbar/src/Plugin/Block/MessageTabs.php
@@ -9,6 +9,7 @@ use Drupal\Core\Block\MessagesBlockPluginInterface;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Menu\LocalTaskManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -75,13 +76,16 @@ class MessageTabs extends BlockBase implements ContainerFactoryPluginInterface, 
       '#primary' => count(Element::getVisibleChildren($primary['tabs'])) > 1 ? $primary['tabs'] : [],
       '#secondary' => count(Element::getVisibleChildren($secondary['tabs'])) > 1 ? $secondary['tabs'] : [],
     ];
-    $cacheability->applyTo($tabs);
 
-    return [
+    $build = [
       '#theme' => 'mass_admin_toolbar_message_tabs',
       '#messages' => ['#type' => 'status_messages'],
       '#tabs' => $tabs,
     ];
+
+    $cacheability->applyTo($build);
+
+    return $build;
   }
 
 }

--- a/docroot/modules/custom/mass_utility/src/MassUtilityServiceProvider.php
+++ b/docroot/modules/custom/mass_utility/src/MassUtilityServiceProvider.php
@@ -21,6 +21,12 @@ class MassUtilityServiceProvider extends ServiceProviderBase {
       $container->setParameter('monolog.processors', $processors);
     }
 
+    // @todo Consider comment this out after https://massgov.atlassian.net/browse/DP-33081 is resolved.
+    if ($container->hasDefinition('renderer')) {
+      $definition = $container->getDefinition('renderer');
+      $definition->setClass('Drupal\mass_utility\Renderer');
+    }
+
   }
 
 }

--- a/docroot/modules/custom/mass_utility/src/MassUtilityServiceProvider.php
+++ b/docroot/modules/custom/mass_utility/src/MassUtilityServiceProvider.php
@@ -21,7 +21,7 @@ class MassUtilityServiceProvider extends ServiceProviderBase {
       $container->setParameter('monolog.processors', $processors);
     }
 
-    // @todo Consider comment this out after https://massgov.atlassian.net/browse/DP-33081 is resolved.
+    // @todo Consider commenting this out after https://massgov.atlassian.net/browse/DP-33081 is resolved.
     if ($container->hasDefinition('renderer')) {
       $definition = $container->getDefinition('renderer');
       $definition->setClass('Drupal\mass_utility\Renderer');

--- a/docroot/modules/custom/mass_utility/src/Renderer.php
+++ b/docroot/modules/custom/mass_utility/src/Renderer.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class Renderer extends \Drupal\Core\Render\Renderer {
 
   public function __construct(CallableResolver|ControllerResolverInterface $callable_resolver, ThemeManagerInterface $theme, ElementInfoManagerInterface $element_info, PlaceholderGeneratorInterface $placeholder_generator, RenderCacheInterface $render_cache, RequestStack $request_stack, array $renderer_config) {
+    // See https://massgov.atlassian.net/browse/DP-33081
     if (\Drupal::request()->getHost() !== 'www.mass.gov') {
       $rendererConfig['debug'] = TRUE;
     }

--- a/docroot/modules/custom/mass_utility/src/Renderer.php
+++ b/docroot/modules/custom/mass_utility/src/Renderer.php
@@ -15,7 +15,7 @@ class Renderer extends \Drupal\Core\Render\Renderer {
   public function __construct(CallableResolver|ControllerResolverInterface $callable_resolver, ThemeManagerInterface $theme, ElementInfoManagerInterface $element_info, PlaceholderGeneratorInterface $placeholder_generator, RenderCacheInterface $render_cache, RequestStack $request_stack, array $renderer_config) {
     // See https://massgov.atlassian.net/browse/DP-33081
     if (\Drupal::request()->getHost() !== 'www.mass.gov') {
-      $rendererConfig['debug'] = TRUE;
+      $renderer_config['debug'] = TRUE;
     }
     parent::__construct($callable_resolver, $theme, $element_info, $placeholder_generator, $render_cache, $request_stack, $renderer_config);
   }

--- a/docroot/modules/custom/mass_utility/src/Renderer.php
+++ b/docroot/modules/custom/mass_utility/src/Renderer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\mass_utility;
+
+use Drupal\Core\Controller\ControllerResolverInterface;
+use Drupal\Core\Render\ElementInfoManagerInterface;
+use Drupal\Core\Render\PlaceholderGeneratorInterface;
+use Drupal\Core\Render\RenderCacheInterface;
+use Drupal\Core\Theme\ThemeManagerInterface;
+use Drupal\Core\Utility\CallableResolver;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class Renderer extends \Drupal\Core\Render\Renderer {
+
+  public function __construct(CallableResolver|ControllerResolverInterface $callable_resolver, ThemeManagerInterface $theme, ElementInfoManagerInterface $element_info, PlaceholderGeneratorInterface $placeholder_generator, RenderCacheInterface $render_cache, RequestStack $request_stack, array $renderer_config) {
+    if (\Drupal::request()->getHost() !== 'www.mass.gov') {
+      $rendererConfig['debug'] = TRUE;
+    }
+    parent::__construct($callable_resolver, $theme, $element_info, $placeholder_generator, $render_cache, $request_stack, $renderer_config);
+  }
+
+}

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -80,21 +80,24 @@ $configureMemcache = function($settings) use ($app_root, $site_path, $class_load
   // Replace lock implementation with the memcache version:
   $settings['container_yamls'][] = $app_root . '/' . $site_path . '/services.memcache.yml';
 
+  // Decrease latency.
+  $settings['memcache']['options'][Memcached::OPT_TCP_NODELAY] = TRUE;
+
   // Override default configuration for static cache bins.
   // Specialized cache bin configuration.
   // See https://jira.state.ma.us/browse/DP-5906 for how this was selected.
   $settings['cache']['bins']['bootstrap'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['config'] = 'cache.backend.chainedfast';
-  $settings['cache']['bins']['data'] = 'cache.backend.memcache';
   $settings['cache']['bins']['default'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['discovery'] = 'cache.backend.chainedfast';
+  $settings['cache']['bins']['config'] = 'cache.backend.memcache';
+  $settings['cache']['bins']['discovery'] = 'cache.backend.memcache';
   $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.database';
 
   // Acquia doesn't recommend these in memcache and we are seeing Revision confusion at https://edit.mass.gov/info-details/covid-19-response-reporting/revisions
+  // See https://github.com/acquia/memcache-settings/blob/main/memcache.settings.php
   // $settings['cache']['bins']['entity'] = 'cache.backend.memcache';
   // $settings['cache']['bins']['render'] = 'cache.backend.memcache';
-
-  $settings['cache']['bins']['menu'] = 'cache.backend.memcache';
+  // $settings['cache']['bins']['data'] = 'cache.backend.memcache';
+  // $settings['cache']['bins']['menu'] = 'cache.backend.memcache';
   // All other cache bins are stored in the database.
 
   return $settings;


### PR DESCRIPTION
Aligns with Acquia recommendations at https://github.com/acquia/memcache-settings/blob/main/memcache.settings.php

The wild theory is that route cache is in cache_data and maybe we lose connection to memcache momentarily and fall victim to https://www.drupal.org/project/drupal/issues/3402447