### PR TITLE
DP-34151 - Added validation for featured mosaic items on org and service pages

### DIFF
--- a/changelogs/DP-34151.yml
+++ b/changelogs/DP-34151.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed validation for featured mosaic items.
+    issue: DP-34151

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -417,7 +417,7 @@ function _mass_validation_service_page_sections_validate(array &$form, FormState
       }
       $paragraph_error_string = 'field_service_sections][' . $section_key . '][subform][field_service_section_content][' . $key . '][subform]';
       _mass_validation_validate_caspio($form_state, $paragraph, $section_key, $key, 'field_service_sections', 'field_service_section_content');
-      _mass_validation_validate_mosaic_items($form_state, $paragraph);
+      _mass_validation_validate_mosaic_items($form_state, $paragraph, $section_key, $key, 'field_service_sections', 'field_service_section_content');
       _mass_validation_validate_custom_search($form_state, $paragraph, $paragraph_error_string);
       _mass_validation_validate_custom_flexible_links($form_state, $paragraph, $paragraph_error_string);
     }
@@ -1235,7 +1235,7 @@ function mass_validation_org_page_alter_helper(array &$form) {
 /**
  * Validates mosaic items to be 5 and Hightlight image for the first item.
  */
-function _mass_validation_validate_mosaic_items(FormStateInterface $form_state, &$paragraph) {
+function _mass_validation_validate_mosaic_items(FormStateInterface $form_state, &$paragraph, $section_key, $paragraph_key, $field_wrapper, $field) {
   if (!isset($paragraph['subform']['field_featured_item_mosaic_items'])) {
     return;
   }
@@ -1243,7 +1243,7 @@ function _mass_validation_validate_mosaic_items(FormStateInterface $form_state, 
     $form_state->setErrorByName('mosaic_items_add_more', t('You must provide 5 featured items.'));
   }
   // Find the item with the lowest weight.
-  foreach ($paragraph['subform']['field_featured_item_mosaic_items'] as $mosaic_array) {
+  foreach ($paragraph['subform']['field_featured_item_mosaic_items'] as $mosaic_key => $mosaic_array) {
     if (!isset($mosaic_array['_weight'])) {
       continue;
     }
@@ -1251,6 +1251,11 @@ function _mass_validation_validate_mosaic_items(FormStateInterface $form_state, 
     if (!isset($lowest) || $weight < $lowest) {
       $lowest = $weight;
       $first = $mosaic_array;
+    }
+
+    if (str_starts_with($mosaic_array['subform']['field_featured_item_link'][0]['uri'], 'internal:')) {
+      $form_state->setErrorByName($field_wrapper . '][' . $section_key . '][subform][' . $field . '][' . $paragraph_key . '][subform][field_featured_item_mosaic_items][' . $mosaic_key . '][subform][field_featured_item_link][0][uri',
+        t('The entered value must be either a selected existing page or a complete URL.'));
     }
   }
   if (isset($first) && empty($first['subform']['field_featured_item_highlight'][0]['fids'])) {
@@ -1404,7 +1409,7 @@ function _mass_validation_form_node_org_page_form_validate(array &$form, FormSta
         foreach ($paragraphs as $paragraph_key => $paragraph) {
           $paragraph_error_string = 'field_organization_sections][' . $section_key . '][subform][field_section_long_form_content][' . $paragraph_key . '][subform]';
           _mass_validation_validate_caspio($form_state, $paragraph, $section_key, $paragraph_key, 'field_organization_sections', 'field_section_long_form_content');
-          _mass_validation_validate_mosaic_items($form_state, $paragraph);
+          _mass_validation_validate_mosaic_items($form_state, $paragraph, $section_key, $paragraph_key, 'field_organization_sections', 'field_section_long_form_content');
           _mass_validation_validate_custom_iframe($form_state, $paragraph, $paragraph_error_string);
           _mass_validation_validate_custom_search($form_state, $paragraph, $paragraph_error_string);
           _mass_validation_validate_custom_flexible_links($form_state, $paragraph, $paragraph_error_string);


### PR DESCRIPTION
**Description:**
Added validation for featured mosaic items on org and service pages.


**Jira:** (Skip unless you are MA staff)
DP-34151


**To Test:**
- [ ] Re-save orgs/office-of-cultural-resources---unpublished, which will show the error. 
- [ ] If issue not present on database or already resolved, create a Featured Item Mosaic on an org and service page and attempt to add an invalid value on a Featured Item, such a path (e.g. /orgs/department-of-conservation-recreation/news)


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
