### PR TITLE
Add support scripts for database clients.

### DIFF
--- a/.ddev/commands/host/massdbsa
+++ b/.ddev/commands/host/massdbsa
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+## Description: Open Sequel Ace with "circle" database opened.
+## Usage: massdbsa
+## Example: "ddev massdbsa"
+## OSTypes: darwin
+## HostBinaryExists: "/Applications/Sequel Ace.app"
+
+open mysql://circle:circle@mass.local:3206/circle -a '/Applications/Sequel Ace.app/Contents/MacOS/Sequel Ace'

--- a/.ddev/commands/host/massdbtb
+++ b/.ddev/commands/host/massdbtb
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Support for mass.gov TablePlus, https://tableplus.com/
+# This command is available on macOS only.
+## Description: Run TablePlus with mass.gov database.
+## Usage: massdbtb
+## Example: "ddev massdbtb"
+## OSTypes: darwin
+## HostBinaryExists: /Applications/TablePlus.app,/Applications/Setapp/TablePlus.app
+
+
+query="mysql://circle:circle@mass.local:3206/circle?Enviroment=local&Name=ddev-${DDEV_SITENAME}"
+set -eu -o pipefail
+
+if [ -d "/Applications/Setapp/TablePlus.app" ]; then
+    open "$query" -a "/Applications/Setapp/TablePlus.app/Contents/MacOS/TablePlus"
+else
+    open "$query" -a "/Applications/TablePlus.app/Contents/MacOS/TablePlus"
+fi


### PR DESCRIPTION
Add massdbtb and massdbsa scripts for TablePlus and Sequel Ace on macOS.

**Description:**
Added two new ddev commands to automatically launch the TablePlus and Sequel Ace with mass.gov db connections on macOS. 

**Jira:** (Skip unless you are MA staff)
DP-XXX

**To Test:**
TablePlus: 
- [ ] Make sure TablePlus is installed in your system
- [ ] start the project `ddev start`
- [ ] `ddev massdbtb` 
- [ ] Observe that TablePlus is opened automatically and connected to a database server/database.

Sequel Ace:
- [ ] Make sure Sequel Ace is installed in your system
- [ ] start the project `ddev start`
- [ ] `ddev massdbsa` 
- [ ] Observe that Sequel Ace is opened automatically and connected to a database server/database.

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
