### PR TITLE
DP-28287: Resolve mapping-related JS errors and warnings

### DIFF
--- a/changelogs/DP-28287.yml
+++ b/changelogs/DP-28287.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Resolve mapping-related JS errors and warnings.
+    issue: DP-28287

--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,7 @@
         "drupal/geofield": "^1.57",
         "drupal/gin": "^3",
         "drupal/gin_toolbar": "^1",
-        "drupal/google_map_field": "^2",
+        "drupal/google_map_field": "^2.0",
         "drupal/google_tag": "^2.0",
         "drupal/http_response_headers": "^2",
         "drupal/hux": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.6",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-28287_resolve_map_errors_warnings",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.json
+++ b/composer.json
@@ -278,7 +278,7 @@
         "furf/jquery-ui-touch-punch": "dev-master",
         "geocoder-php/open-cage-provider": "^4.6",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-28287_resolve_map_errors_warnings",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17326f05aad85a70df4bb7c14cf62aeb",
+    "content-hash": "a32e84b78e13aedad9396acee616c7c0",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -6295,26 +6295,26 @@
         },
         {
             "name": "drupal/google_map_field",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/google_map_field.git",
-                "reference": "2.0.0"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/google_map_field-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "a37bc6ab1db07db356ff4d87c5db5b881b8ee7aa"
+                "url": "https://ftp.drupal.org/files/projects/google_map_field-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "d31e56a9759416a3bcbcc68e3399ab264c24add6"
             },
             "require": {
-                "drupal/core": "^9.4 || ^10.0"
+                "drupal/core": "^9.4 || ^10.0 || ^11"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1671969352",
+                    "version": "2.0.2",
+                    "datestamp": "1707657722",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a32e84b78e13aedad9396acee616c7c0",
+    "content-hash": "da77055e6f51eb6b39e045134a1bc174",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12349,16 +12349,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-28287_resolve_map_errors_warnings",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "5f9d9b651f6612175d330ba16b32d078ee47125d"
+                "reference": "221b4c326fc391048f2ab2db7b728dfd7cfd1620"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/5f9d9b651f6612175d330ba16b32d078ee47125d",
-                "reference": "5f9d9b651f6612175d330ba16b32d078ee47125d",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/221b4c326fc391048f2ab2db7b728dfd7cfd1620",
+                "reference": "221b4c326fc391048f2ab2db7b728dfd7cfd1620",
                 "shasum": ""
             },
             "require": {
@@ -12378,9 +12378,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-28287_resolve_map_errors_warnings"
             },
-            "time": "2024-07-29T13:37:38+00:00"
+            "time": "2024-07-31T10:20:16+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17326f05aad85a70df4bb7c14cf62aeb",
+    "content-hash": "a32e84b78e13aedad9396acee616c7c0",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12353,12 +12353,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "90c47512582553d44addcde739b9d78dc590a311"
+                "reference": "972686d8e653d58cfff97463ed60506b9656188a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/90c47512582553d44addcde739b9d78dc590a311",
-                "reference": "90c47512582553d44addcde739b9d78dc590a311",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/972686d8e653d58cfff97463ed60506b9656188a",
+                "reference": "972686d8e653d58cfff97463ed60506b9656188a",
                 "shasum": ""
             },
             "require": {
@@ -12380,7 +12380,7 @@
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
                 "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2024-08-01T16:04:17+00:00"
+            "time": "2024-08-02T17:38:50+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fix the console error: google.maps.event.addDomListener() is deprecated, use the standard
addEventListener() method instead:
https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener
The feature will continue to work and there is no plan to decommission
it.