### PR TITLE
DP-34207: Alter the ImageStyle class to substitute original URI if image is animated GIF.

### DIFF
--- a/changelogs/DP-34207.yml
+++ b/changelogs/DP-34207.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added posibility to skip GIF image derivative generation if image is animated gif
+    issue: DP-34207

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -24,6 +24,7 @@ use Drupal\Core\Url;
 use Drupal\editor\Entity\Editor;
 use Drupal\file\Entity\File;
 use Drupal\link\LinkItemInterface;
+use Drupal\mass_utility\EntityAlter\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\PathAliasInterface;
 use Drupal\redirect\Entity\Redirect;
@@ -1377,7 +1378,8 @@ function mass_utility_query_linkit_entity_autocomplete_alter(AlterableInterface 
 /**
  * Implements hook_views_data_alter().
  *
- * Add a relationship between the node_field_data and node_field_revision tables.
+ * Add a relationship between the node_field_data and node_field_revision
+ * tables.
  *
  * As it stands, by default there's no way to get comprehensive infromation
  * about a node's most recent revision when using node_field_data as the base
@@ -1456,4 +1458,13 @@ function mass_utility_form_alter(&$form, FormStateInterface $form_state, $form_i
  */
 function mass_utility_ckeditor_css_alter(array &$css, Editor $editor) {
   $css[] = \Drupal::service('extension.list.module')->getPath('mass_utility') . '/css/ckeditor.css';
+}
+
+/**
+ * Implements hook__entity_type_build().
+ */
+function mass_utility_entity_type_build(&$entity_types) {
+  if (isset($entity_types['image_style'])) {
+    $entity_types['image_style']->setClass(ImageStyle::class);
+  }
 }

--- a/docroot/modules/custom/mass_utility/src/EntityAlter/ImageStyle.php
+++ b/docroot/modules/custom/mass_utility/src/EntityAlter/ImageStyle.php
@@ -57,9 +57,14 @@ class ImageStyle extends ImageStyleOriginal {
       return parent::buildUri($uri);
     }
 
+    // Do nothing of file does not exist.
+    $path = \Drupal::service('file_system')->realpath($uri);
+    if (!file_exists($path)) {
+      return parent::buildUri($uri);
+    }
+
     // Check if the GIF is animated.
     // If it is not animated a GIF - do nothing, default behaviour.
-    $path = \Drupal::service('file_system')->realpath($uri);
     if (!$this->isAnimatedGif($path)) {
       return parent::buildUri($uri);
     }

--- a/docroot/modules/custom/mass_utility/src/EntityAlter/ImageStyle.php
+++ b/docroot/modules/custom/mass_utility/src/EntityAlter/ImageStyle.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\mass_utility\EntityAlter;
+
+use Drupal\image\Entity\ImageStyle as ImageStyleOriginal;
+
+/**
+ * Class ImageStyle.
+ *
+ * Overrides an ImageStyle class from the "image" module.
+ */
+class ImageStyle extends ImageStyleOriginal {
+
+  /**
+   * Check if an image file is an animated GIF.
+   *
+   * Taken from
+   * https://www.php.net/manual/en/function.imagecreatefromgif.php#104473.
+   *
+   * @param string $filename
+   *   The path to the image.
+   *
+   * @return bool
+   *   Returns true if the image file is an animated gif, false otherwise.
+   */
+  private function isAnimatedGif(string $filename): bool {
+    if (!($fh = @fopen($filename, 'rb'))) {
+      return FALSE;
+    }
+    $count = 0;
+    // An animated GIF contains multiple "frames", with each frame having a
+    // Header made up of:
+    // * a static 4-byte sequence (\x00\x21\xF9\x04)
+    // * 4 variable bytes
+    // * a static 2-byte sequence (\x00\x2C) (some variants may use \x00\x21 ?)
+    // We read through the file til we reach the end of the file, or we've found
+    // at least 2 frame headers
+    while (!feof($fh) && $count < 2) {
+      // Read 100kb at a time
+      $chunk = fread($fh, 1024 * 100);
+      $count += preg_match_all('#\x00\x21\xF9\x04.{4}\x00(\x2C|\x21)#s', $chunk, $matches);
+    }
+
+    fclose($fh);
+    return $count > 1;
+  }
+
+  /**
+   * Override standard method.
+   *
+   * Do not create derivative URI for animated GIF images.
+   */
+  public function buildUri($uri) {
+    $mime = \Drupal::service('file.mime_type.guesser')->guessMimeType($uri);
+    // If it is not a GIF - do nothing, default behaviour.
+    if ($mime != 'image/gif') {
+      return parent::buildUri($uri);
+    }
+
+    // Check if the GIF is animated.
+    // If it is not animated a GIF - do nothing, default behaviour.
+    $path = \Drupal::service('file_system')->realpath($uri);
+    if (!$this->isAnimatedGif($path)) {
+      return parent::buildUri($uri);
+    }
+
+    // Do not apply image style if it is animated GIF.
+    return $uri;
+  }
+
+}


### PR DESCRIPTION
**Description:**
Altered the ImageStyle class so we can substitute the GIF image URI in certain conditions.

**Jira:** (Skip unless you are MA staff)
DP-34207


**To Test:**
- Open any page with giant GIF animated, for example /masstalent and observe that page is loading, image is visible (probably need to wait some time for the image to load).
Despite path is still point to image style - the original file loaded should be instead (so the size image must be equal to the original).

---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
