### PR TITLE
DP-34663: Enable default display and SQL query in views settings

### DIFF
--- a/changelogs/DP-34663.yml
+++ b/changelogs/DP-34663.yml
@@ -1,0 +1,44 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: "Error on /admin/structure/views/settings when saving views configuration."
+    issue: DP-34663
+Added:
+  - description: "Made Default views display visible; Made SQL query related to view display visible."
+    issue: DP-34663

--- a/conf/drupal/config/views.settings.yml
+++ b/conf/drupal/config/views.settings.yml
@@ -8,14 +8,13 @@ ui:
   show:
     additional_queries: false
     advanced_column: true
-    default_display: false
+    default_display: true
     performance_statistics: false
     preview_information: true
     sql_query:
-      enabled: false
+      enabled: true
       where: above
     display_embed: false
-    master_display: false
   always_live_preview: true
   exposed_filter_any_label: old_any
 field_rewrite_elements:


### PR DESCRIPTION
The 'default_display' and 'sql_query.enabled' options have been set to 'true' to enhance the visibility and debugging capabilities of views in the Drupal configuration. This change ensures that the default display is always shown and SQL query previews are enabled for easier troubleshooting and performance tuning.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-34663


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
