### PR TITLE
DP-34966 modify feedback component to display even if a topic page has no organization

### DIFF
--- a/changelogs/DP-34966.yml
+++ b/changelogs/DP-34966.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Modify feedback component to display even if a Topic Page has no organization.
+    issue: DP-34966

--- a/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
+++ b/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
@@ -111,10 +111,10 @@ function mass_feedback_form_entity_extra_field_info() {
 /**
  * Implements hook_ENTITY_TYPE_view().
  */
-function mass_feedback_form_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+function mass_feedback_form_node_view(array &$build, EntityInterface $node, EntityViewDisplayInterface $display, $view_mode) {
   if ($display->getComponent('extra_org_feedback_form')) {
-    if ($entity->hasField('field_hide_feedback_component')) {
-      if ($entity->field_hide_feedback_component->value == 1) {
+    if ($node->hasField('field_hide_feedback_component')) {
+      if ($node->field_hide_feedback_component->value == 1) {
         return;
       }
     }
@@ -122,16 +122,17 @@ function mass_feedback_form_node_view(array &$build, EntityInterface $entity, En
     //TODO: document the logins, over with tests.
     $entity_type_manager = \Drupal::entityTypeManager();
     $view_builder = $entity_type_manager->getViewBuilder('node');
-    if ($entity->bundle() === 'org_page') {
-      $item = $view_builder->view($entity, 'feedback');
+    $org_node_view_feedback = [];
+    if ($node->bundle() === 'org_page') {
+      $org_node_view_feedback = $view_builder->view($node, 'feedback');
     }
     else {
-      if ($entity->field_organizations->count() > 0 && !empty($entity->field_organizations[0]->entity)) {
-        $item = $view_builder->view($entity->field_organizations[0]->entity, 'feedback');
+      if ($node->field_organizations->count() > 0 && !empty($node->field_organizations[0]->entity)) {
+        $org_node_view_feedback = $view_builder->view($node->field_organizations[0]->entity, 'feedback');
       }
     }
 
-    $item['#field_name'] = 'extra_org_feedback_form';
-    $build['extra_org_feedback_form'][] = $item;
+    $org_node_view_feedback['#field_name'] = 'extra_org_feedback_form';
+    $build['extra_org_feedback_form'][] = $org_node_view_feedback;
   }
 }

--- a/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
+++ b/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
@@ -33,6 +33,9 @@ function mass_feedback_form_help($route_name, RouteMatchInterface $route_match) 
  */
 function mass_feedback_form_theme() {
   return [
+    'mass_feedback_form_without_organization' => [
+      'render element' => NULL,
+    ],
     'mass_feedback_form' => [
       'variables' => ['node_id' => NULL],
     ],
@@ -119,12 +122,17 @@ function mass_feedback_form_node_view(array &$build, EntityInterface $node, Enti
       }
     }
 
-    //TODO: document the logins, over with tests.
+    //TODO: document the logic, cover with tests.
     $entity_type_manager = \Drupal::entityTypeManager();
     $view_builder = $entity_type_manager->getViewBuilder('node');
     $org_node_view_feedback = [];
     if ($node->bundle() === 'org_page') {
       $org_node_view_feedback = $view_builder->view($node, 'feedback');
+    }
+    elseif ($node->bundle() === 'topic_page' && $node->get('field_organizations')->isEmpty()) {
+      $org_node_view_feedback = [
+        '#theme' => 'mass_feedback_form_without_organization',
+      ];
     }
     else {
       if ($node->field_organizations->count() > 0 && !empty($node->field_organizations[0]->entity)) {

--- a/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
+++ b/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
@@ -122,7 +122,7 @@ function mass_feedback_form_node_view(array &$build, EntityInterface $node, Enti
       }
     }
 
-    //TODO: document the logic, cover with tests.
+    // TODO: document the logic, cover with tests.
     $entity_type_manager = \Drupal::entityTypeManager();
     $view_builder = $entity_type_manager->getViewBuilder('node');
     $org_node_view_feedback = [];

--- a/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
+++ b/docroot/modules/custom/mass_feedback_form/mass_feedback_form.module
@@ -118,16 +118,19 @@ function mass_feedback_form_node_view(array &$build, EntityInterface $entity, En
         return;
       }
     }
-    $entityTypeManager = \Drupal::entityTypeManager();
-    $viewBuilder = $entityTypeManager->getViewBuilder('node');
+
+    //TODO: document the logins, over with tests.
+    $entity_type_manager = \Drupal::entityTypeManager();
+    $view_builder = $entity_type_manager->getViewBuilder('node');
     if ($entity->bundle() === 'org_page') {
-      $item = $viewBuilder->view($entity, 'feedback');
+      $item = $view_builder->view($entity, 'feedback');
     }
     else {
       if ($entity->field_organizations->count() > 0 && !empty($entity->field_organizations[0]->entity)) {
-        $item = $viewBuilder->view($entity->field_organizations[0]->entity, 'feedback');
+        $item = $view_builder->view($entity->field_organizations[0]->entity, 'feedback');
       }
     }
+
     $item['#field_name'] = 'extra_org_feedback_form';
     $build['extra_org_feedback_form'][] = $item;
   }

--- a/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form-without-organization.html.twig
+++ b/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form-without-organization.html.twig
@@ -143,4 +143,3 @@
     "after": "If you would like to continue helping us improve Mass.gov, <a href=\"https://www.mass.gov/user-panel?utm_source=survey\">join our user panel<\/a> to test new features for the site."
   }
 } %}
-

--- a/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form-without-organization.html.twig
+++ b/docroot/modules/custom/mass_feedback_form/templates/mass-feedback-form-without-organization.html.twig
@@ -1,0 +1,146 @@
+{% set reportMessage = false %}
+{% set showHelp = false %}
+{% set showHelp = false %}
+{% set warnmsg = false %}
+{% set helpText = "The feedback will only be used for improving the website." %}
+
+{% set hiddenElements = [
+  {
+    "id": "field47056299",
+    "name": "field47056299",
+    "value": url('<current>'),
+    "class": "fsField"
+  },
+  {
+    "id": "field58154059",
+    "name": "field58154059",
+    "value": "entityIdentifier",
+    "class": "fsField data-layer-substitute"
+  },
+  {
+    "id": "field57432673",
+    "name": "field57432673",
+    "value": "entityIdentifier",
+    "class": "fsField data-layer-substitute"
+  },
+  {
+    "id": "field68798989",
+    "name": "field68798989",
+    "value": "",
+    "class": "fsField unique-id-substitute"
+  },
+  {
+    "id": "field97986104",
+    "name": "field97986104",
+    "value": "9999",
+    "class": "fsField"
+  },
+  {
+    "id": "form2521317",
+    "name": "form",
+    "value": "2521317"
+  },
+  {
+    "id": "viewkeyvx39GBYJhi",
+    "name": "viewkey",
+    "value": "vx39GBYJhi"
+  },
+  {
+    "id": "hidden_fields2521317",
+    "name": "hidden_fields",
+    "value": ""
+  },
+  {
+    "id": "submit2521317",
+    "name": "_submit",
+    "value": "1"
+  },
+  {
+    "id": "style_version2521317",
+    "name": "style_version",
+    "value": "3"
+  },
+  {
+    "id": "viewparam",
+    "name": "viewparam",
+    "value": "524744"
+  }
+] %}
+
+{{ attach_library('mass_feedback_form/feedback-form-behaviors') }}
+
+{% include "@organisms/feedback/mass-feedback.twig" with {
+
+  "formAction": 'https://www.formstack.com/forms/index.php',
+  "formId": "2521317",
+  "heading": "Help Us Improve Mass.gov",
+  "title": {
+    "value": "Did you find what you were looking for on this webpage?",
+    "required": true
+  },
+  "inputGroup": {
+    "type": "radio",
+    "required": true,
+    "inline": true,
+    "items": [
+      {
+        "name": "field47054416",
+        "value": "Yes",
+        "label": "Yes",
+        "id": "field47054416_1",
+        "checked": false,
+      },
+      {
+        "name": "field47054416",
+        "id": "field47054416_2",
+        "value": "No",
+        "label": "No",
+        "checked": false,
+      }
+    ],
+  },
+  "queryAffirmative": {
+    "value": "If you have any suggestions for the website, please let us know.",
+    "required": false
+  },
+  "affirmativeTextarea": {
+    "required": false,
+    "maxlength": 500,
+    "id": "field52940022",
+    "name": "field52940022",
+    "describedBy": "helptext-feedback-no-response",
+    "errorIds": "affirmative-textarea-error-alert"
+  },
+  "queryNegative": {
+    "value": "How can we improve the page?",
+    "required": true
+  },
+  "negativeTextarea": {
+    "required": true,
+    "maxlength": 500,
+    "id": "field47054414",
+    "name": "field47054414",
+    "errorMsg": "Please let us know how we can improve this page.",
+    "describedBy": "helptext-feedback-no-response",
+    "errorIds": "negative-textarea-error-alert"
+  },
+  "helpTip": {
+    "textBefore": "Please do not include personal or contact information.",
+    "textTrigger": "You will not get a response",
+    "helpText": helpText,
+    "id": "helptext-feedback-no-response",
+    "expanded": false,
+    "isDescription": true
+  },
+  "warnMsg": warnmsg,
+  "alertMsg": "Please remove any contact information or personal data from your feedback. <strong>You will NOT get a response</strong>.",
+  "alert": reportMessage,
+  "hiddenElements": hiddenElements,
+  "showWarnMsg": showHelp,
+  "submitted": false,
+  "success": {
+    "before": "Thank you for your website feedback! We will use this information to improve this page.",
+    "after": "If you would like to continue helping us improve Mass.gov, <a href=\"https://www.mass.gov/user-panel?utm_source=survey\">join our user panel<\/a> to test new features for the site."
+  }
+} %}
+

--- a/docroot/modules/custom/mass_fields/tests/src/ExistingSite/TopicPageRestrictionTest.php
+++ b/docroot/modules/custom/mass_fields/tests/src/ExistingSite/TopicPageRestrictionTest.php
@@ -124,7 +124,7 @@ class TopicPageRestrictionTest extends MassExistingSiteBase {
   /**
    * Creates a Topic Page with and without a feedback form component.
    */
-  private function createTopicPageShowHideFeedbackForm(bool $feedback_form_hidden) {
+  private function createTopicPageShowHideFeedbackForm(bool $feedback_form_hidden, bool $no_organization = FALSE) {
     // Test a new Topic page can be saved.
     $newOrgNode = $this->createNode([
       'type' => 'org_page',
@@ -141,7 +141,7 @@ class TopicPageRestrictionTest extends MassExistingSiteBase {
       'type' => 'topic_page',
       'title' => $this->randomMachineName(),
       'field_hide_feedback_component' => $feedback_form_hidden,
-      'field_organizations' => $newOrgNode->id(),
+      'field_organizations' => $no_organization ? NULL : $newOrgNode->id(),
       'field_topic_lede' => $this->randomString(20),
       'field_topic_content_cards' => [
         Paragraph::create([
@@ -283,7 +283,7 @@ class TopicPageRestrictionTest extends MassExistingSiteBase {
   }
 
   /**
-   * Tests organization feedback form show/hide functionality.
+   * Tests an organization feedback form show/hide functionality.
    */
   public function testTopicPageShowHideFeedbackForm() {
 
@@ -301,13 +301,26 @@ class TopicPageRestrictionTest extends MassExistingSiteBase {
     $this->user = $user;
     $this->drupalLogin($this->user);
 
-    // Create topic page without a feedback form.
+    // Create a Topic Page without a feedback form.
     $topic_page = $this->createTopicPageShowHideFeedbackForm(TRUE);
+    $this->drupalLogout();
     $this->drupalGet($topic_page->toUrl()->toString());
     $this->assertFalse($this->getCurrentPage()->hasContent('Help Us Improve Mass.gov'), 'The feedback form is visible, while it must be hidden.');
 
-    // Create topic page with a feedback form.
+    // Create a Topic Page with a feedback form.
+    $this->drupalLogin($this->user);
     $topic_page = $this->createTopicPageShowHideFeedbackForm(FALSE);
+    $this->drupalLogout();
+    $this->drupalGet($topic_page->toUrl()->toString());
+    $this->assertTrue($this->getCurrentPage()->hasContent('Help Us Improve Mass.gov'), 'The feedback form is hidden, while it must be visible.');
+
+    // Create a Topic Page with a feedback form, but without organization,
+    // a feedback component should be still visible.
+    $this->drupalLogin($this->user);
+    $topic_page = $this->createTopicPageShowHideFeedbackForm(FALSE, TRUE);
+    $this->drupalGet($topic_page->toUrl('edit-form')->toString());
+    $this->htmlOutput();
+    $this->drupalLogout();
     $this->drupalGet($topic_page->toUrl()->toString());
     $this->assertTrue($this->getCurrentPage()->hasContent('Help Us Improve Mass.gov'), 'The feedback form is hidden, while it must be visible.');
   }

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -96,84 +96,80 @@
   {% set helpText = "The feedback will only be used for improving the website. If you need assistance, please <a href='#{node.field_feedback_com_link.get(0).getUrl().toString()}'>#{node.field_feedback_com_link.title}</a>. <span class='ma__visually-hidden'>Please limit your input to 500 characters. </span>" %}
 {% endif %}
 
-{% set feedback_is_visible = node.field_hide_feedback_component.value ?? TRUE %}
+{{ attach_library('mass_feedback_form/feedback-form-behaviors') }}
 
-{% if feedback_is_visible %}
-  {{ attach_library('mass_feedback_form/feedback-form-behaviors') }}
+{% include "@organisms/feedback/mass-feedback.twig" with {
 
-  {% include "@organisms/feedback/mass-feedback.twig" with {
+  "formAction": 'https://www.formstack.com/forms/index.php',
+  "formId": "2521317",
+  "heading": "Help Us Improve Mass.gov",
+  "title": {
+    "value": "Did you find what you were looking for on this webpage?",
+    "required": true
+  },
+  "inputGroup": {
+    "type": "radio",
+    "required": true,
+    "inline": true,
+    "items": [
+      {
+        "name": "field47054416",
+        "value": "Yes",
+        "label": "Yes",
+        "id": "field47054416_1",
+        "checked": false,
+      },
+      {
+        "name": "field47054416",
+        "id": "field47054416_2",
+        "value": "No",
+        "label": "No",
+        "checked": false,
+      }
+    ],
+  },
+  "queryAffirmative": {
+    "value": "If you have any suggestions for the website, please let us know.",
+    "required": false
+  },
+  "affirmativeTextarea": {
+    "required": false,
+    "maxlength": 500,
+    "id": "field52940022",
+    "name": "field52940022",
+    "describedBy": "helptext-feedback-no-response",
+    "errorIds": "affirmative-textarea-error-alert"
+  },
+  "queryNegative": {
+    "value": "How can we improve the page?",
+    "required": true
+  },
+  "negativeTextarea": {
+    "required": true,
+    "maxlength": 500,
+    "id": "field47054414",
+    "name": "field47054414",
+    "errorMsg": "Please let us know how we can improve this page.",
+    "describedBy": "helptext-feedback-no-response",
+    "errorIds": "negative-textarea-error-alert"
+  },
+  "helpTip": {
+    "textBefore": "Please do not include personal or contact information.",
+    "textTrigger": "You will not get a response",
+    "helpText": helpText,
+    "id": "helptext-feedback-no-response",
+    "expanded": false,
+    "isDescription": true
+  },
+  "warnMsg": warnmsg,
+  "alertMsg": "Please remove any contact information or personal data from your feedback. <strong>You will NOT get a response</strong>.",
+  "alert": reportMessage,
+  "hiddenElements": hiddenElements,
+  "showWarnMsg": showHelp,
+  "submitted": false,
+  "success": {
+    "before": "Thank you for your website feedback! We will use this information to improve this page.",
+    "after": "If you would like to continue helping us improve Mass.gov, <a href=\"https://www.mass.gov/user-panel?utm_source=survey\">join our user panel<\/a> to test new features for the site."
+  }
+} %}
 
-    "formAction": 'https://www.formstack.com/forms/index.php',
-    "formId": "2521317",
-    "heading": "Help Us Improve Mass.gov",
-    "title": {
-      "value": "Did you find what you were looking for on this webpage?",
-      "required": true
-    },
-    "inputGroup": {
-      "type": "radio",
-      "required": true,
-      "inline": true,
-      "items": [
-        {
-          "name": "field47054416",
-          "value": "Yes",
-          "label": "Yes",
-          "id": "field47054416_1",
-          "checked": false,
-        },
-        {
-          "name": "field47054416",
-          "id": "field47054416_2",
-          "value": "No",
-          "label": "No",
-          "checked": false,
-        }
-      ],
-    },
-    "queryAffirmative": {
-      "value": "If you have any suggestions for the website, please let us know.",
-      "required": false
-    },
-    "affirmativeTextarea": {
-      "required": false,
-      "maxlength": 500,
-      "id": "field52940022",
-      "name": "field52940022",
-      "describedBy": "helptext-feedback-no-response",
-      "errorIds": "affirmative-textarea-error-alert"
-    },
-    "queryNegative": {
-      "value": "How can we improve the page?",
-      "required": true
-    },
-    "negativeTextarea": {
-      "required": true,
-      "maxlength": 500,
-      "id": "field47054414",
-      "name": "field47054414",
-      "errorMsg": "Please let us know how we can improve this page.",
-      "describedBy": "helptext-feedback-no-response",
-      "errorIds": "negative-textarea-error-alert"
-    },
-    "helpTip": {
-      "textBefore": "Please do not include personal or contact information.",
-      "textTrigger": "You will not get a response",
-      "helpText": helpText,
-      "id": "helptext-feedback-no-response",
-      "expanded": false,
-      "isDescription": true
-    },
-    "warnMsg": warnmsg,
-    "alertMsg": "Please remove any contact information or personal data from your feedback. <strong>You will NOT get a response</strong>.",
-    "alert": reportMessage,
-    "hiddenElements": hiddenElements,
-    "showWarnMsg": showHelp,
-    "submitted": false,
-    "success": {
-      "before": "Thank you for your website feedback! We will use this information to improve this page.",
-      "after": "If you would like to continue helping us improve Mass.gov, <a href=\"https://www.mass.gov/user-panel?utm_source=survey\">join our user panel<\/a> to test new features for the site."
-    }
-  } %}
-
-{% endif %}

--- a/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--org-page--feedback.html.twig
@@ -172,4 +172,3 @@
     "after": "If you would like to continue helping us improve Mass.gov, <a href=\"https://www.mass.gov/user-panel?utm_source=survey\">join our user panel<\/a> to test new features for the site."
   }
 } %}
-


### PR DESCRIPTION
**Description:**
Added standelone feedback theme without relations to organization.

**Jira:** (Skip unless you are MA staff)
DP-34966


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
