### PR TITLE
DP-33362: Changed database name in BigQuery

### DIFF
--- a/changelogs/DP-33362.yml
+++ b/changelogs/DP-33362.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Altered BigQuery module to query against changed name.
+    issue: DP-33362

--- a/docroot/modules/custom/mass_bigquery/src/BigqueryStorage.php
+++ b/docroot/modules/custom/mass_bigquery/src/BigqueryStorage.php
@@ -128,7 +128,7 @@ class BigqueryStorage implements BigqueryStorageInterface {
     $time = \Drupal::time()->getRequestTime();
     // Fetch data from Bigquery.
     $query =
-        'SELECT nodeId, totalPageViews, nosPerKUniquePageViews, ejectRate, negativeSurveys, positiveSurveys, brokenLinks, gradeLevel FROM `MassgovGA4_testing.aggregated_node_analytics` WHERE nodeId IN(' . implode(', ', $ids) . ')';
+        'SELECT nodeId, totalPageViews, nosPerKUniquePageViews, ejectRate, negativeSurveys, positiveSurveys, brokenLinks, gradeLevel FROM `MassgovGA4_prod.aggregated_node_analytics` WHERE nodeId IN(' . implode(', ', $ids) . ')';
     $queryResults = $this->bigqueryClient->runQuery($query);
     foreach ($queryResults as $row) {
       $nos_per_1000 = $row['nosPerKUniquePageViews'];
@@ -168,7 +168,7 @@ class BigqueryStorage implements BigqueryStorageInterface {
     $time = \Drupal::time()->getRequestTime();
     // Fetch data from Bigquery.
     $query =
-      'SELECT nodeId, totalPageViews, nosPerKUniquePageViews, ejectRate, negativeSurveys, positiveSurveys, brokenLinks, gradeLevel FROM `MassgovGA4_testing.aggregated_node_analytics` WHERE nodeId IN(' . implode(', ', $ids) . ')';
+      'SELECT nodeId, totalPageViews, nosPerKUniquePageViews, ejectRate, negativeSurveys, positiveSurveys, brokenLinks, gradeLevel FROM `MassgovGA4_prod.aggregated_node_analytics` WHERE nodeId IN(' . implode(', ', $ids) . ')';
     $queryResults = $this->bigqueryClient->runQuery($query);
     $result = [];
     foreach ($queryResults as $row) {


### PR DESCRIPTION
**Description:**
Changed database name in BigQuery module to match new name for prod.


**Jira:** (Skip unless you are MA staff)
DP-33362


**To Test:**
- [ ] On a test environment with BigQuery integration configured, go to admin/config/services/bigquery
- [ ] Change the time range to include current time and save
- [ ] Run `drush queue:list`. The items in mass_bigquery_node_queue will likely be zero. Note the number
- [ ] Run `drush cron`. Re-run `drush queue:list` and the items in mass_bigquery_node_queue should be higher
- [ ] Run `drush queue:run mass_bigquery_node_queue --time-limit=30 --no-interaction` and verify there are no errors.
- [ ] You can verify data by going to admin/content and checking columns for nos per 1000 and page views. Not all data will be verified until the run is complete.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
