### PR TITLE
DP-35403: Removed percy job from tag workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1118,16 +1118,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /.*/
-      - browserstack_percy_test:
-          name: browserstack-percy-test
-          requires: [deploy-tag-prod-acquia-maint]
-          target: prod
-          list: all
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /.*/
       - new_relic_change_tracking:
           name: new-relic-change-tracking-prod-maint
           requires: [deploy-tag-prod-acquia-maint]

--- a/changelogs/DP-35403.yml
+++ b/changelogs/DP-35403.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Removed:
   - description: Removed Percy job from post-release workflow.
     issue: DP-35403

--- a/changelogs/DP-35403.yml
+++ b/changelogs/DP-35403.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Removed Percy job from post-release workflow.
+    issue: DP-35403


### PR DESCRIPTION
**Description:**
This PR removes the Percy job from the build_tag workflow after release. Instead, this job will be run by a scheduled CircleCI workflow.


**Jira:** (Skip unless you are MA staff)
DP-35403


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
