### PR TITLE
DP-35609: Change sitewide alert notifications to only send emails when an alert is published or transitioned out of published state

### DIFF
--- a/changelogs/DP-35609.yml
+++ b/changelogs/DP-35609.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Change sitewide alert notifications to only send emails when an alert is published or transitioned out of published state.
+    issue: DP-35609

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -259,7 +259,10 @@ function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
     $current_state = $node->getModerationState()->getString();
 
     // Check if this is an update (node->original exists) to get the previous state.
-    $previous_state = $node->original->getModerationState()->getString() ?? NULL;
+    $previous_state = NULL;
+    if (!empty($node->original)) {
+      $previous_state = $node->original->getModerationState()->getString();
+    }
 
     if ($current_state == MassModeration::PUBLISHED || $previous_state == MassModeration::PUBLISHED) {
       $langcode = $node->language()->getId();

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -253,25 +253,34 @@ function mass_alerts_mail($key, &$message, $params) {
  */
 function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
   // Only send notifications after an alert has been published.
-  if ($node->bundle() === "sitewide_alert" && !MassModeration::isPrepublish($node)) {
+  if ($node->bundle() === "sitewide_alert") {
     // Only send notifications if the alert is site-wide.
-    $langcode = $node->language()->getId();
-    $email_addresses = \Drupal::state()->get('mass_alerts.alert_emails');
-    if (!empty($email_addresses)) {
-      $message_body = 'A sitewide alert was added or updated on Mass.gov (https://www.mass.gov):' . "\r\n\r\n" . $node->title->value . "\r\n\r\n";
-      if ($node->hasField('field_sitewide_alert')) {
-        $paragraph = $node->get('field_sitewide_alert')->referencedEntities();
-        foreach ($paragraph as $p) {
-          if ($p->hasField('field_sitewide_alert_message')) {
-            $value[] = $p->get('field_sitewide_alert_message')->value;
+
+    // Get the current moderation state.
+    $current_state = $node->moderation_state->value;
+
+    // Check if this is an update (node->original exists) to get the previous state.
+    $previous_state = $node->original->moderation_state->value ?? NULL;
+
+    if ($current_state == MassModeration::PUBLISHED || $previous_state == MassModeration::PUBLISHED) {
+      $langcode = $node->language()->getId();
+      $email_addresses = \Drupal::state()->get('mass_alerts.alert_emails');
+      if (!empty($email_addresses)) {
+        $message_body = 'A sitewide alert was added or updated on Mass.gov (https://www.mass.gov):' . "\r\n\r\n" . $node->title->value . "\r\n\r\n";
+        if ($node->hasField('field_sitewide_alert')) {
+          $paragraph = $node->get('field_sitewide_alert')->referencedEntities();
+          foreach ($paragraph as $p) {
+            if ($p->hasField('field_sitewide_alert_message')) {
+              $value[] = $p->get('field_sitewide_alert_message')->value;
+            }
           }
+          $message_body .= implode("\r\n", $value);
         }
-        $message_body .= implode("\r\n", $value);
-      }
-      foreach ($email_addresses as $to_email) {
-        \Drupal::service('plugin.manager.mail')->mail('mass_alerts',
-          'mass_alerts_sitewide', $to_email, $langcode,
-          ['message' => $message_body, 'subject' => $node->title->value]);
+        foreach ($email_addresses as $to_email) {
+          \Drupal::service('plugin.manager.mail')->mail('mass_alerts',
+            'mass_alerts_sitewide', $to_email, $langcode,
+            ['message' => $message_body, 'subject' => $node->title->value]);
+        }
       }
     }
   }

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -255,7 +255,6 @@ function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
   // Only send notifications after an alert has been published.
   if ($node->bundle() === "sitewide_alert") {
     // Only send notifications if the alert is site-wide.
-
     // Get the current moderation state.
     $current_state = $node->moderation_state->value;
 

--- a/docroot/modules/custom/mass_alerts/mass_alerts.module
+++ b/docroot/modules/custom/mass_alerts/mass_alerts.module
@@ -256,10 +256,10 @@ function mass_alerts_sitewide_alert_send_notifications(EntityInterface $node) {
   if ($node->bundle() === "sitewide_alert") {
     // Only send notifications if the alert is site-wide.
     // Get the current moderation state.
-    $current_state = $node->moderation_state->value;
+    $current_state = $node->getModerationState()->getString();
 
     // Check if this is an update (node->original exists) to get the previous state.
-    $previous_state = $node->original->moderation_state->value ?? NULL;
+    $previous_state = $node->original->getModerationState()->getString() ?? NULL;
 
     if ($current_state == MassModeration::PUBLISHED || $previous_state == MassModeration::PUBLISHED) {
       $langcode = $node->language()->getId();


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
