### PR TITLE
Update .htaccess for Drupal 10.3

### DIFF
--- a/changelogs/DP-35160.yml
+++ b/changelogs/DP-35160.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Review and update .htaccess to make sure it reflects the latest changes in the Drupal core 10.3.x
+    issue: DP-35160

--- a/docroot/.htaccess
+++ b/docroot/.htaccess
@@ -2,21 +2,13 @@
 # Apache/PHP/Drupal settings:
 #
 
-# Protect files and directories from prying eyes.  Drupal standard, less twig, plus package.json & yarn.lock.
-<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock))$|package.json|yarn.lock|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
+# Protect files and directories from prying eyes.
+<FilesMatch "\.(engine|inc|install|make|module|profile|po|sh|.*sql|theme|twig|tpl(\.php)?|xtmpl|yml)(~|\.sw[op]|\.bak|\.orig|\.save)?$|^(\.(?!well-known).*|Entries.*|Repository|Root|Tag|Template|composer\.(json|lock)|web\.config|yarn\.lock|package\.json)$|^#.*#$|\.php(~|\.sw[op]|\.bak|\.orig|\.save)$">
   <IfModule mod_authz_core.c>
     Require all denied
   </IfModule>
   <IfModule !mod_authz_core.c>
     Order allow,deny
-  </IfModule>
-</FilesMatch>
-
-# Force download of .twig files.
-<FilesMatch "\.(twig)$">
-  ForceType application/octet-stream
-  <IfModule headers_module>
-    Header set Content-Disposition attachment
   </IfModule>
 </FilesMatch>
 
@@ -60,7 +52,7 @@ AddType application/octet-stream .rte
 # Drupal\Core\DrupalKernel::bootEnvironment() for settings that can be
 # changed at runtime.
 <IfModule mod_php.c>
-  php_value zend.assertions 0
+  php_value assert.active                   0
 </IfModule>
 
 # Requires mod_expires to be enabled.
@@ -69,8 +61,6 @@ AddType application/octet-stream .rte
   ExpiresActive On
 
   # Cache all files for 2 weeks after access (A).
-  ExpiresDefault A1209600
-
   # Declare font content-types
   AddType application/vnd.ms-fontobject .eot
   AddType font/ttf .ttf
@@ -82,6 +72,8 @@ AddType application/octet-stream .rte
   ExpiresByType font/ttf A31536000
   ExpiresByType font/woff A31536000
   ExpiresByType font/woff2 A31536000
+  # Cache all files for 1 year after access.
+  ExpiresDefault "access plus 1 year"
 
   <FilesMatch \.php$>
     # Do not allow PHP scripts to be cached unless they explicitly send cache
@@ -118,6 +110,12 @@ AddType application/octet-stream .rte
   RewriteCond %{HTTPS} off
   RewriteCond %{HTTP:X-Forwarded-Proto} !https
   RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  # Set "protossl" to "s" if we were accessed via https://.  This is used later
+  # if you enable "www." stripping or enforcement, in order to ensure that
+  # you don't bounce between http and https.
+  RewriteRule ^ - [E=protossl]
+  RewriteCond %{HTTPS} on
+  RewriteRule ^ - [E=protossl:s]
 
   # Make sure Authorization HTTP header is available to PHP
   # even when running as CGI or FastCGI.
@@ -128,50 +126,11 @@ AddType application/octet-stream .rte
   # Git to store control files. Files whose names begin with a period, as well
   # as the control files used by CVS, are protected by the FilesMatch directive
   # above.
-  RewriteRule "(^|/)\.(?!well-known)" - [F]
-
-  #--- START: Edit access ----#
   #
-  # Also, for security, we require that certain actions (user login, any
-  # admin action) goes through a special "edit" domain.  This is enforced
-  # at the CDN level, but we also enforce it here for defense in depth.
-  # The `allowedit` environment variable is used as a flag to indicate
-  # whether we should allow this level of access or not.
+  # NOTE: This only works when mod_rewrite is loaded. Without mod_rewrite, it is
+  # not possible to block access to entire directories from .htaccess because
+  # <DirectoryMatch> is not allowed here.
   #
-  # Note: CDN token verification has moved to settings.acquia.php. See https://jira.mass.gov/browse/DP-20164.
-
-  # Start with default values:
-  RewriteRule ^ - [E=allowedit:0]
-
-  # Verify CDN in production always.
-  RewriteCond %{ENV:AH_SITE_ENVIRONMENT} ^prod$
-  RewriteRule ^ - [E=cdnverify:1]
-
-  # Allow edit access in production on edit domain
-  RewriteCond %{ENV:AH_SITE_ENVIRONMENT} ^prod$
-  RewriteCond %{HTTP_HOST} ^edit\.mass\.gov$
-  RewriteRule ^ - [E=allowedit:1]
-
-  # In non-prod Acquia environments, allow edit access on any domain
-  RewriteCond ${ENV:AH_SITE_ENVIRONMENT} !^prod$
-  RewriteRule ^ - [E=allowedit:1]
-
-  # (addendum to previous rule) - Block edit access in pre-production www mirror domains
-  RewriteCond ${ENV:AH_SITE_ENVIRONMENT} !^prod$
-  RewriteCond %{HTTP_HOST} ^stage.mass\.gov$ [OR]
-  RewriteCond %{HTTP_HOST} ^wwwcf\.digital\.mass.gov$
-  RewriteRule ^ - [E=allowedit:0]
-
-  # In non-Acquia contexts, allow edit anywhere.
-  RewriteCond %{ENV:AH_SITE_ENVIRONMENT} ^$
-  RewriteRule ^ - [E=allowedit:1]
-
-  # And block access on non-edit domains:
-  RewriteCond %{ENV:allowedit} !^1$
-  RewriteRule ^((scripts|profile|includes|\.php|install\.php|update\.php|xmlrpc\.php)/?(.*)?)$ - [F]
-  #---- END: edit access ----#
-
-
   #---- START: Hardening rules ----
   # Specific, well-known documentation files that can expose version data.
   RewriteCond %{REQUEST_URI} !^/files/
@@ -192,11 +151,49 @@ AddType application/octet-stream .rte
   # All files in the core directory, period (covers .dist files and future changes).
   RewriteRule "^core/([^/\0]+)?$" - [L,R=404]
   #---- END: Hardening rules ----#
+  # If you do not have mod_rewrite installed, you should remove these
+  # directories from your webroot or otherwise protect them from being
+  # downloaded.
+  RewriteRule "/\.|^\.(?!well-known/)" - [F]
 
+  # If your site can be accessed both with and without the 'www.' prefix, you
+  # can use one of the following settings to redirect users to your preferred
+  # URL, either WITH or WITHOUT the 'www.' prefix. Choose ONLY one option:
+  #
+  # To redirect all users to access the site WITH the 'www.' prefix,
+  # (http://example.com/foo will be redirected to http://www.example.com/foo)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} .
+  # RewriteCond %{HTTP_HOST} !^www\. [NC]
+  # RewriteRule ^ http%{ENV:protossl}://www.%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
+  #
+  # To redirect all users to access the site WITHOUT the 'www.' prefix,
+  # (http://www.example.com/foo will be redirected to http://example.com/foo)
+  # uncomment the following:
+  # RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
+  # RewriteRule ^ http%{ENV:protossl}://%1%{REQUEST_URI} [L,R=301]
+
+  # Modify the RewriteBase if you are using Drupal in a subdirectory or in a
+  # VirtualDocumentRoot and the rewrite rules are not working properly.
+  # For example if your site is at http://example.com/drupal uncomment and
+  # modify the following line:
+  # RewriteBase /drupal
+  #
+  # If your site is running in a VirtualDocumentRoot at http://example.com/,
+  # uncomment the following line:
+  # RewriteBase /
+
+  # Redirect common PHP files to their new locations.
+  RewriteCond %{REQUEST_URI} ^(.*)?/(install\.php) [OR]
+  RewriteCond %{REQUEST_URI} ^(.*)?/(rebuild\.php)
+  RewriteCond %{REQUEST_URI} !core
+  RewriteRule ^ %1/core/%2 [L,QSA,R=301]
 
   # Disallow crawling on any domain that isn't www.mass.gov.
   RewriteCond %{HTTP_HOST} !^www.mass.gov$
   RewriteRule ^robots.txt /robots-none.txt [NC,L]
+  # Rewrite install.php during installation to see if mod_rewrite is working
+  RewriteRule ^core/install\.php core/install.php?rewrite=ok [QSA,L]
 
   # Pass all requests not referring directly to files in the filesystem to
   # index.php.
@@ -205,13 +202,20 @@ AddType application/octet-stream .rte
   RewriteCond %{REQUEST_URI} !=/favicon.ico
   RewriteRule ^ index.php [L]
 
-  # Additional Hardening.
-  # Block direct access to all PHP files other than index.php and hq2/*.php.
-  # This replaces the standard Drupal deny block.
-  # Note: this will deny access to any php file that bypasses Drupal bootstrap
-  # and may need to be modified for some authentication or other API methods.
-  RewriteCond %{REQUEST_URI} !^/hq2/[a-z]+.php$
-  RewriteCond %{REQUEST_URI} !^/index.php$
+  # For security reasons, deny access to other PHP files on public sites.
+  # Note: The following URI conditions are not anchored at the start (^),
+  # because Drupal may be located in a subdirectory. To further improve
+  # security, you can replace '!/' with '!^/'.
+  # Allow access to PHP files in /core (like authorize.php or install.php):
+  RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
+  # Allow access to test-specific PHP files:
+  RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?\.php
+  # Allow access to Statistics module's custom front controller.
+  # Copy and adapt this rule to directly execute PHP files in contributed or
+  # custom modules or to run another PHP application in the same directory.
+  RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics\.php$
+  # Deny access to any other PHP files that do not match the rules above.
+  # Specifically, disallow autoload.php from being served directly.
   RewriteRule "^(.+/.*|autoload)\.php($|/)" - [F]
 
   # Rules to correctly serve gzip compressed CSS and JS files.


### PR DESCRIPTION
**Description:**
Drops a few things we no longer use like .twig downloading and CDN token verification. Thats now enforced by our custom VCL.

As a follow-up we could consider maintaining a patch against .htaccess instead of a modified .htaccess. If we want that, see https://github.com/drupal-composer/drupal-scaffold/issues/45. Its slightly harder to make changes but slightly easier to keep up with Drupal's edits to .htaccess.


**Jira:** (Skip unless you are MA staff)
DP-35160



---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
