### PR TITLE
Add Romanian to the page language bar (DP-35689)

### DIFF
--- a/changelogs/DP-35689.yml
+++ b/changelogs/DP-35689.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Changed:
   - description: added Romanian to the page language bar.
     issue: DP-35689

--- a/changelogs/DP-35689.yml
+++ b/changelogs/DP-35689.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: added Romanian to the page language bar.
+    issue: DP-35689

--- a/conf/drupal/config/mass_theme.settings.yml
+++ b/conf/drupal/config/mass_theme.settings.yml
@@ -35,6 +35,7 @@ languages:
   pl: pl
   ps: ps
   pt: pt
+  ro: ro
   ru: ru
   rw: rw
   so: so
@@ -118,7 +119,6 @@ languages:
   qu: 0
   rm: 0
   rn: 0
-  ro: 0
   sa: 0
   sd: 0
   sg: 0


### PR DESCRIPTION
**Description:**
Configured the Mass Theme using the local web GUI and selected Romanian in the language dropdown.



**Jira:** (Skip unless you are MA staff)
DP-35689


**To Test:**
- [ ] Use the Google Translate language dropdown on the page.
- [ ] Select Romanian from the dropdown.
- [ ] Verify that the page translates correctly into Romanian.
---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
