### PR TITLE
DP 36660 Fix gravity form embed iframe resizer timeout issue 

### DIFF
--- a/changelogs/DP-36660.yml
+++ b/changelogs/DP-36660.yml
@@ -1,0 +1,42 @@
+
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - description: Increase iframe resizer JS send dimensions to parent timeout from 1/3 second to 1/2 second.
+    issue: DP-36660

--- a/changelogs/DP-36660.yml
+++ b/changelogs/DP-36660.yml
@@ -37,6 +37,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
+Fixed:
   - description: Increase iframe resizer JS send dimensions to parent timeout from 1/3 second to 1/2 second.
     issue: DP-36660

--- a/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
+++ b/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
@@ -99,8 +99,8 @@ window.addEventListener('load', function () {
 
     observer.observe(document.body, config);
 
-    // Sent another update after 1/3 of a second just in case
-    window.setTimeout(sendDimensionsToParent, 300);
+    // Sent another update after 1/2 of a second just in case
+    window.setTimeout(sendDimensionsToParent, 500);
 
   }
   // if mutationobserver is NOT supported

--- a/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
+++ b/docroot/themes/custom/mass_theme/overrides/js/iframe_resizer_iframe.js
@@ -105,8 +105,8 @@ window.addEventListener('load', function () {
   }
   // if mutationobserver is NOT supported
   else {
-    // check for changes on a timed interval, every 1/3 of a second
-    window.setInterval(sendDimensionsToParent, 300);
+    // check for changes on a timed interval, every 1/2 of a second
+    window.setInterval(sendDimensionsToParent, 500);
   }
 
 


### PR DESCRIPTION
Fixed:
  - description: Increase iframe resizer JS send dimensions to parent timeout from 1/3 second to 1/2 second.
    issue: DP-36660


Before:
https://edit.mass.gov/forms/massgov-forms-gravity-forms-tester-feedback-questions-issues
After:
https://edit.stage.mass.gov/forms/massforms-iframe-resizer-console-error---unpublished
