### PR TITLE
DP-36751: Fix for external links being evaluated as internal

### DIFF
--- a/changelogs/DP-36751.yml
+++ b/changelogs/DP-36751.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed issue with external link paths being changed to internal paths.
+    issue: DP-36751

--- a/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
+++ b/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
@@ -50,11 +50,11 @@ class MassUrlReplacementService {
     foreach ($anchors as $anchor) {
       // Extract the 'href' attribute value
       $href = $anchor->getAttribute('href');
-      $is_external = UrlHelper::isExternal($href);
-      $external_is_local = UrlHelper::externalIsLocal($href, \Drupal::request()->getHost());
-
-      if ($is_external || !$external_is_local) {
-        continue;
+      $base_host = \Drupal::request()->getSchemeAndHttpHost();
+      if (UrlHelper::isExternal($href)) {
+        if (!UrlHelper::externalIsLocal($href, $base_host)) {
+          continue;
+        }
       }
 
       // Check for 'media/[id]' or 'media/[id]/download' pattern and extract ID

--- a/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
+++ b/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
@@ -51,8 +51,9 @@ class MassUrlReplacementService {
       // Extract the 'href' attribute value
       $href = $anchor->getAttribute('href');
       $is_external = UrlHelper::isExternal($href);
+      $external_is_local = UrlHelper::externalIsLocal($href, \Drupal::request()->getHost());
 
-      if ($is_external) {
+      if ($is_external || !$external_is_local) {
         continue;
       }
 

--- a/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
+++ b/docroot/modules/custom/mass_fields/src/MassUrlReplacementService.php
@@ -3,6 +3,7 @@
 namespace Drupal\mass_fields;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 
 /**
@@ -49,6 +50,11 @@ class MassUrlReplacementService {
     foreach ($anchors as $anchor) {
       // Extract the 'href' attribute value
       $href = $anchor->getAttribute('href');
+      $is_external = UrlHelper::isExternal($href);
+
+      if ($is_external) {
+        continue;
+      }
 
       // Check for 'media/[id]' or 'media/[id]/download' pattern and extract ID
       if (preg_match('/media\/([0-9]+)(\/download)?(\?.*)?$/', $href, $matches)) {


### PR DESCRIPTION
**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-36751


**To Test:**
I have been trying the following test links in rich text fields:
- [ ] https://highways.dot.gov/media/10811 (should be unchanged)
- [ ] /media/10811 (should link to /doc alias path to media entity)
- [ ] https://pr2797-vfxe8jrrw3tvwzjbis0vvz5vhoc0yazy.tugboatqa.com/media/10811 (should link to /doc alias path to media entity)
- [ ] https://www.mass.gov/media/10811 (should be unchanged)


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
