### PR TITLE
DP-37000: Node revisions potential fixes and monitoring

### DIFF
--- a/changelogs/DP-37000.yml
+++ b/changelogs/DP-37000.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Added a patch and logging as well as removed old code to potentially fix and track existing revision issues on update.
+    issue: DP-37000

--- a/changelogs/DP-37000.yml
+++ b/changelogs/DP-37000.yml
@@ -37,5 +37,5 @@
 #    issue: DP-19843
 #
 Changed:
-  - description: Added a patch and logging as well as removed old code to potentially fix and track existing revision issues on update.
+  - description: Added a patch and logging, removed old code to potentially fix and track existing revision issues.
     issue: DP-37000

--- a/composer.json
+++ b/composer.json
@@ -413,6 +413,9 @@
             "drupal/inline_entity_form": {
                 "Add a setting to enable/disable inline editing of existing entities (https://www.drupal.org/project/inline_entity_form/issues/2913571#comment-12811088)": "https://www.drupal.org/files/issues/2018-10-11/ief_edit_existing_2913571_7.patch"
             },
+            "drupal/memcache": {
+                "Transaction support for cache (tags) invalidation (https://www.drupal.org/project/memcache/issues/2996615)": "https://www.drupal.org/files/issues/2024-01-26/memcache-transaction-aware-2996615-45.patch"
+            },
             "drupal/paragraphs": {
                 "Nested paragraphs title gets cut off (https://www.drupal.org/project/paragraphs/issues/3246140)": "https://www.drupal.org/files/issues/2024-03-11/paragraphs-3246140-19-fix_paragraph_title_cutoff.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a92f2adf9f755fbc73e06dba0b658f22",
+    "content-hash": "608364cc732047cd2ce06a8f609bf770",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",

--- a/docroot/modules/custom/mass_content/mass_content.module
+++ b/docroot/modules/custom/mass_content/mass_content.module
@@ -49,6 +49,7 @@ use Drupal\mass_content\Entity\Bundle\paragraph\AddressBundle;
 use Drupal\mass_content\Entity\Bundle\paragraph\ListItemDocumentsBundle;
 use Drupal\mass_content\Entity\Bundle\taxonomy_term\CollectionsBundle;
 use Drupal\mass_content\Entity\Bundle\user\UserBundle;
+use Drupal\node\Entity\Node;
 use Drupal\views\Plugin\views\query\QueryPluginBase;
 use Drupal\views\ViewExecutable;
 
@@ -1460,5 +1461,34 @@ function mass_content_preprocess_layout_paragraphs_builder_component_menu(&$vari
       // Default sorting: Alphabetical by label.
       return strcmp($a['label'], $b['label']);
     });
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update().
+ */
+function mass_content_node_update(EntityInterface $node) {
+  // Compare the entity cache-stored vid to the vid stored in the database.
+  // @see https://massgov.atlassian.net/browse/DP-37000?focusedCommentId=425633
+  $nid = $node->id();
+
+  // Retrieve the vid value via Node::load to get the currently cached value.
+  $vid_cache = Node::load($nid)->getRevisionId();
+
+  // Query for vid.
+  $database = \Drupal::database();
+  $query = $database->select('node', 'n');
+  $vid_db = $query
+    ->fields('n', ['vid'])
+    ->condition('n.nid', $nid)
+    ->execute()
+    ->fetchField();
+
+  if ($vid_db !== $vid_cache) {
+    Drupal::logger('content')->info('Node @nid updated to revision @vid_db in the database, but revision @vid_cache was retrieved from cache.', [
+      '@nid' => $nid,
+      '@vid_db' => $vid_db,
+      '@vid_cache' => $vid_cache,
+    ]);
   }
 }

--- a/docroot/modules/custom/mass_utility/mass_utility.module
+++ b/docroot/modules/custom/mass_utility/mass_utility.module
@@ -254,29 +254,6 @@ function mass_utility_form_node_form_alter(&$form, FormStateInterface $form_stat
       $form['field_intended_audience']['widget']['#default_value'] = '_none';
     }
   }
-
-  foreach (array_keys($form['actions']) as $action) {
-    if ($action != 'preview' && isset($form['actions'][$action]['#type']) && $form['actions'][$action]['#type'] === 'submit') {
-      $form['actions'][$action]['#submit'][] = 'mass_utility_invalidate_node_tags_submit';
-    }
-  }
-}
-
-/**
- * Form submission handler to invalidate node cache tags.
- *
- * This callback is added as a submit handler to node form submits to address
- * an issue sometimes triggered when multiple nodes are saved within a short
- * period of time, resulting in the appearance that the node was not saved.
- *
- * @see https://jira.mass.gov/browse/DP-19001#Implementationdetails
- */
-function mass_utility_invalidate_node_tags_submit($form, FormStateInterface $form_state) {
-  if ($callback_object = $form_state->getBuildInfo()['callback_object']) {
-    $nid = $callback_object->getEntity()->id();
-    $tags = ['node:' . $nid];
-    \Drupal::service('cache_tags.invalidator')->invalidateTags($tags);
-  }
 }
 
 /**


### PR DESCRIPTION
**Description:**
- Adds back logging related to detecting cache / transaction issues
- Removes previous fix that was likely not helping
- Adds memcache patch to make transactional memcache backend available


**Jira:** (Skip unless you are MA staff)
DP-37000


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
