### PR TITLE
DP-37164-iframe-fix-layout-paragraphs

### DIFF
--- a/changelogs/DP-37164.yml
+++ b/changelogs/DP-37164.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Clear heading float to fix iframe issue in layout paragraphs.
+    issue: DP-37164

--- a/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/basic-html.css
@@ -120,3 +120,7 @@ form.fsForm.rtl {
   list-style-position: inside;
 }
 
+/* Clear layout paragraph iframe float */
+.ma__comp-heading, .ma__colored-heading {
+  clear: both;
+}


### PR DESCRIPTION
After layout paragraphs migration, there was a problem where you could not get to the contact form fields with a mouse click. On production, we have temporarily reverted the node to the state prior to the migration but it is not editable in this state. We need to get this working in Layout paragraphs.

[Email the Governor's Office](https://www.mass.gov/info-details/email-the-governors-office)