### PR TITLE
Hotfix/fix service bluesky icon

### DIFF
--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -5053,6 +5053,9 @@ function mass_theme_preprocess_field(&$variables, $hook) {
         if (strpos($url, $service)) {
           $item['icon'] = Helper::getIconPath($service);
         }
+        elseif (strpos($url, 'bsky')) {
+          $item['icon'] = Helper::getIconPath('bluesky');
+        }
       }
     }
   }


### PR DESCRIPTION
the social media butterfly icon for BlueSky is not showing up on service pages but it is showing up on org pages. 
https://stage.mass.gov/qag-service1?g
https://stage.mass.gov/orgs/governor-maura-healey-and-lt-governor-kim-driscoll


Fixed: https://pr2825-gesv47mgwagjs5rqff9lbwic7tfpremg.tugboatqa.com/qag-service1