### PR TITLE
DP-37489: Added patch to undo GTM script placement in header

### DIFF
--- a/changelogs/DP-37489.yml
+++ b/changelogs/DP-37489.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixed items missing from pushed data layer.
+    issue: DP-37489

--- a/composer.json
+++ b/composer.json
@@ -406,6 +406,9 @@
             "drupal/gin": {
                 "3281343 - Use Gin's edit form for Media Entries": "https://www.drupal.org/files/issues/2023-02-23/edit-form-media-3281343-9.patch"
             },
+            "drupal/google_tag": {
+                "On 2.0.6, Uncaught TypeError: Cannot read properties of undefined (reading 'apply') (https://www.drupal.org/project/google_tag/issues/3468036)": "https://www.drupal.org/files/issues/2025-02-05/3468036-google_tag-remove_header_property_from_libraries.patch"
+            },
             "drupal/iframe_resizer": {
                 "Missing license URL (https://www.drupal.org/project/iframe_resizer/issues/3385378)": "https://www.drupal.org/files/issues/2023-09-05/iframe_resizer-missing_license_url-3385378-3.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e988f27475a20c702b8faffab93a1c4",
+    "content-hash": "eed1627ac8d00ef043ad76a780daf46b",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",


### PR DESCRIPTION
**Description:**
Patch to undo changes breaking data layer.


**Jira:** (Skip unless you are MA staff)
DP-37489


**To Test:**
- [ ] Test that entityIdentifier and other data layer items are loading in GTM


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
