### PR TITLE
DP-37503: Enable microsites & microsite navigation

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -49,7 +49,7 @@ services:
       init:
         - sudo apt update
         # Install Node.js 16.x
-        - curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+        - curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
         - apt-get install -y nodejs
         # Install opcache
         - docker-php-ext-install opcache

--- a/changelogs/DP-37552.yml
+++ b/changelogs/DP-37552.yml
@@ -1,0 +1,43 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Enabled the "Entity Hierarchy Microsite" module.
+    issue: DP-577552
+  - description: Added microsite menu block to breadcrumbs region.
+    issue: DP-577552

--- a/changelogs/DP-37609.yml
+++ b/changelogs/DP-37609.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fix node JS version in Tugboat.
+    issue: DP-37609

--- a/conf/drupal/config/block.block.breadcrumbs.yml
+++ b/conf/drupal/config/block.block.breadcrumbs.yml
@@ -9,7 +9,7 @@ dependencies:
 id: breadcrumbs
 theme: mass_theme
 region: breadcrumb
-weight: -1
+weight: -6
 provider: null
 plugin: system_breadcrumb_block
 settings:

--- a/conf/drupal/config/block.block.mass_theme_micrositemenu.yml
+++ b/conf/drupal/config/block.block.mass_theme_micrositemenu.yml
@@ -1,0 +1,32 @@
+uuid: 16219b4c-98e1-4c1d-9733-f13a635ce79c
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_hierarchy_microsite
+  theme:
+    - mass_theme
+id: mass_theme_micrositemenu
+theme: mass_theme
+region: breadcrumb
+weight: -7
+provider: null
+plugin: entity_hierarchy_microsite_menu
+settings:
+  id: entity_hierarchy_microsite_menu
+  label: 'Microsite Menu'
+  label_display: '0'
+  provider: entity_hierarchy_microsite
+  context_mapping:
+    node: '@node.node_route_context:node'
+  field: field_primary_parent
+  level: 1
+  depth: 2
+  expand_all_items: true
+visibility:
+  entity_hierarchy_microsite_child:
+    id: entity_hierarchy_microsite_child
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    field: field_primary_parent

--- a/conf/drupal/config/core.entity_view_mode.media.entity_hierarchy_microsite.yml
+++ b/conf/drupal/config/core.entity_view_mode.media.entity_hierarchy_microsite.yml
@@ -1,0 +1,13 @@
+uuid: 240da31e-f957-41bb-a7b1-3b3defa292fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+_core:
+  default_config_hash: ruSY-BgvDPfwHykMlFG3AWZ0K1qo505M85iNpJKikmc
+id: media.entity_hierarchy_microsite
+label: 'Microsite branding'
+description: ''
+targetEntityType: media
+cache: true

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -48,6 +48,7 @@ module:
   entity_embed: 0
   entity_hierarchy: 0
   entity_hierarchy_breadcrumb: 0
+  entity_hierarchy_microsite: 0
   entity_reference_revisions: 0
   entity_reference_tree: 0
   entity_usage: 0

--- a/conf/drupal/config/system.menu.entity-hierarchy-microsite.yml
+++ b/conf/drupal/config/system.menu.entity-hierarchy-microsite.yml
@@ -1,0 +1,10 @@
+uuid: 91a17334-3560-4997-b389-9937b02bacdc
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: HP1bZBi77_R1_RMKd4qh_XoH65gWIijfL1v_grxfmUU
+id: entity-hierarchy-microsite
+label: Microsites
+description: 'Microsite menus'
+locked: true

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3965,7 +3965,7 @@ function mass_theme_preprocess_menu(&$variables) {
     if ($params->has('node')) {
       $node = $params->get('node');
       $microsite_lookup = \Drupal::service('entity_hierarchy_microsite.microsite_lookup');
-      $microsites = $microsite_lookup->findMicrositesForNodeAndField($node, 'field_parent');
+      $microsites = $microsite_lookup->findMicrositesForNodeAndField($node, 'field_primary_parent');
       /**
        * @var MicrositeInterface
        */

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -3978,9 +3978,35 @@ function mass_theme_preprocess_menu(&$variables) {
         "title" => $microsite->getHome()->label(),
         "url" => $microsite->getHome()->toUrl(),
         "below" => [],
+        "altClass" => true,
       ];
 
+      // Adds home item to items array, but we're not going to use this for now.
       array_unshift($variables['items'], $home_item);
+
+      // Duplicate and translate menu structure for use with patternlab
+      $variables['mainNav'] = [];
+
+      foreach ($variables['items'] as $item) {
+        $navitem = [
+          "text" => $item['title'],
+          "href" => $item['url'],
+          "active" => $item['in_active_trail'],
+          "altClass" => $item['altClass'] ?? false,
+        ];
+
+        if ($item['below']) {
+          $navitem['subNav'] = [];
+          foreach ($item['below'] as $subitem) {
+            $navitem['subNav'][] = [
+              "text" => $subitem['title'],
+              "href" => $subitem['url'],
+            ];
+          }
+        }
+
+        $variables['mainNav'][] = $navitem;
+      }
     }
   }
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -17,6 +17,7 @@ use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\StringTranslation\ByteSizeMarkup;
 use Drupal\Core\Url;
+use Drupal\entity_hierarchy_microsite\Entity\MicrositeInterface;
 use Drupal\file\Entity\File;
 use Drupal\image\Entity\ImageStyle;
 use Drupal\mass_content\EventsRendererOrgPages;
@@ -3956,6 +3957,31 @@ function mass_theme_preprocess_menu(&$variables) {
       ];
     }
     $variables['mainNav'] = $mainNav;
+  }
+
+  if (array_key_exists('menu_name', $variables) && $variables['menu_name'] == 'entity-hierarchy-microsite') {
+    $params = \Drupal::routeMatch()->getParameters();
+
+    if ($params->has('node')) {
+      $node = $params->get('node');
+      $microsite_lookup = \Drupal::service('entity_hierarchy_microsite.microsite_lookup');
+      $microsites = $microsite_lookup->findMicrositesForNodeAndField($node, 'field_parent');
+      /**
+       * @var MicrositeInterface
+       */
+      $microsite = reset($microsites);
+
+      $home_item = [
+        "is_expanded" => false,
+        "is_collapsed" => false,
+        "in_active_trail" => false,
+        "title" => $microsite->getHome()->label(),
+        "url" => $microsite->getHome()->toUrl(),
+        "below" => [],
+      ];
+
+      array_unshift($variables['items'], $home_item);
+    }
   }
 }
 

--- a/docroot/themes/custom/mass_theme/templates/navigation/menu--entity-hierarchy-microsite.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/navigation/menu--entity-hierarchy-microsite.html.twig
@@ -1,0 +1,23 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link URL, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ *
+ * @ingroup themeable
+ */
+#}
+{% include '@molecules/main-nav.twig' %}


### PR DESCRIPTION
**Description:**

This PR enables the `entity_hierarchy` submodule "`entity_hierarchy_microsite`".

This allows use of the existing site hierarchy to define subtrees of the site as "microsites", and allows the hierarchy to create menus to more easily navigate horizontally across subtree sibling items. This feature is part of the effort to publish EOHLC's Statewide Housing Plan on mass.gov

The housing plan homepage's hierarchy:
<img width="1633" alt="Screenshot 2025-02-17 at 2 51 44 PM" src="https://github.com/user-attachments/assets/548243af-b41c-4b41-aaab-d316853dbce6" />

The raw menu block generated by that same hierarchy:
<img width="1815" alt="Screenshot 2025-02-17 at 2 52 22 PM" src="https://github.com/user-attachments/assets/534030ab-8b42-44fc-b9a4-2ff55ad9034f" />

The themed menu block using the `main-nav` patternlab template:
<img width="1307" alt="Screenshot 2025-02-19 at 11 53 38 AM" src="https://github.com/user-attachments/assets/c536188b-772d-48d8-bee1-b6c8d03505e6" />

**Jira:** (Skip unless you are MA staff)
DP-37503


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
