### PR TITLE
DP-37544: Adding Components to Content Types: Services

### DIFF
--- a/changelogs/DP-37544.yml
+++ b/changelogs/DP-37544.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Adds 'Featured Message', 'Card Group', 'Key Message' and 'Stat' Paragraph types to the Services Content Type.
+    issue: DP-37544

--- a/conf/drupal/config/field.field.node.service_page.field_service_sections.yml
+++ b/conf/drupal/config/field.field.node.service_page.field_service_sections.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - field.storage.node.field_service_sections
     - node.type.service_page
+    - paragraphs.paragraphs_type.featured_message
+    - paragraphs.paragraphs_type.info_details_card_group
     - paragraphs.paragraphs_type.key_message_section
     - paragraphs.paragraphs_type.service_section
+    - paragraphs.paragraphs_type.stat
   module:
     - entity_reference_revisions
 id: node.service_page.field_service_sections
@@ -14,7 +17,7 @@ field_name: field_service_sections
 entity_type: node
 bundle: service_page
 label: 'Service Sections'
-description: 'Choose to add either a <a href="https://www.mass.gov/kb/key-message" target="_blank">Key Message</a> to display a call to action, or a <a href="https://www.mass.gov/kb/service-page-section" target="_blank">Service Section</a>, which can include numerous elements, including Flexible Link Groups, Rich Text, Events, Contact Information, Video, and more. Multiple sections can be added.'
+description: "<p>You can add a Featured Message, Card Group, Stat or Service Section here (see notes below).</p>\r\n<p>&nbsp;</p>\r\n<p><strong>Service Sections</strong></p>\r\nChoose to add either a <a href=\"https://www.mass.gov/kb/key-message\" target=\"_blank\">Key Message</a> to display a call to action, or a <a href=\"https://www.mass.gov/kb/service-page-section\" target=\"_blank\">Service Section</a>, which can include numerous elements, including Flexible Link Groups, Rich Text, Events, Contact Information, Video, and more. Multiple sections can be added. "
 required: false
 translatable: false
 default_value: {  }
@@ -23,8 +26,11 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
+      featured_message: featured_message
+      info_details_card_group: info_details_card_group
       key_message_section: key_message_section
       service_section: service_section
+      stat: stat
     negate: 0
     target_bundles_drag_drop:
       1up_stacked_band:
@@ -80,6 +86,9 @@ settings:
         enabled: false
       advisory_section:
         weight: 144
+        enabled: false
+      alert:
+        weight: 154
         enabled: false
       board_member:
         weight: 145
@@ -164,7 +173,7 @@ settings:
         enabled: false
       featured_message:
         weight: 170
-        enabled: false
+        enabled: true
       featured_topics:
         weight: 171
         enabled: false
@@ -179,6 +188,9 @@ settings:
         enabled: false
       footnotes:
         weight: 174
+        enabled: false
+      from_library:
+        weight: 188
         enabled: false
       full_bleed:
         weight: 175
@@ -215,7 +227,7 @@ settings:
         enabled: false
       info_details_card_group:
         weight: 186
-        enabled: false
+        enabled: true
       issuer:
         weight: 187
         enabled: false
@@ -239,6 +251,9 @@ settings:
         enabled: false
       links_downloads:
         weight: 191
+        enabled: false
+      links_downloads_flexible:
+        weight: 206
         enabled: false
       list_board_members:
         weight: 196
@@ -363,6 +378,9 @@ settings:
       section_board_members:
         weight: 236
         enabled: false
+      section_header:
+        weight: 251
+        enabled: false
       section_heading_text:
         weight: 237
         enabled: false
@@ -395,7 +413,7 @@ settings:
         enabled: false
       stat:
         weight: 245
-        enabled: false
+        enabled: true
       state_organization:
         weight: 246
         enabled: false
@@ -404,6 +422,9 @@ settings:
         enabled: false
       tableau_embed:
         weight: 248
+        enabled: false
+      time_callout:
+        weight: 266
         enabled: false
       video:
         weight: 249


### PR DESCRIPTION
**Description:**
This PR adjusts the `Services` Content Type to include the following Paragraph Types for use within the `Service Section` field
- Featured Message
- Card Group
- Key Message
- Stat


**Jira:** (Skip unless you are MA staff)
DP-37544


**To Test:**
- [ ] Go to `/node/add/service_page`
- [ ] Fill in the required fields in the `Banner` portion of the fields
- [ ] Go to the `Content` field tab
- [ ] Verify that there are updated instructions for the new Paragraph types being introduced
- [ ] Add one each of `Featured Message`, `Card Group`, `Key Message`, `Stat` and `Service Section`
- [ ] Verify that the form fields for each Paragraph type work correctly
- [ ] Verify that upon saving after adding them to the test page, there are no unexpected styling or display results


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
