### PR TITLE
DP-36769: Normalize Mass Forms iframe URL handling.

### DIFF
--- a/changelogs/DP-36769.yml
+++ b/changelogs/DP-36769.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Normalize Mass Forms iframe URL handling
+    issue: DP-36769

--- a/docroot/modules/custom/mass_utility/src/EntityViewBuildAlterGravityFormToken.php
+++ b/docroot/modules/custom/mass_utility/src/EntityViewBuildAlterGravityFormToken.php
@@ -25,17 +25,17 @@ class EntityViewBuildAlterGravityFormToken implements ContainerInjectionInterfac
   private RequestStack $requestStack;
 
   /**
-   * Alters the render array of a specified entity.
+   * Alters the render array of an entity view display.
    *
    * @param array $build
-   *   The render array of the entity to be altered, passed by reference.
+   *   The render array for the entity view.
    * @param EntityInterface $entity
-   *   The entity object being rendered.
+   *   The entity being viewed.
    * @param EntityViewDisplayInterface $display
-   *   The display configuration for the entity's view mode.
+   *   The display plugin used for rendering the entity.
    *
    * @return void
-   *   This method does not return a value, it alters the render array by reference.
+   *   No return value, modifies the $build array by reference.
    */
   public function alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
     if ($entity instanceof NodeInterface
@@ -54,6 +54,9 @@ class EntityViewBuildAlterGravityFormToken implements ContainerInjectionInterfac
       if (!($iframe_url instanceof Url)) {
         return;
       }
+
+      // Normalize iframe URL to always point to slashed url.
+      $iframe_url = Url::fromUri(trim($iframe_url->setAbsolute()->toString(), '/') . '/');
 
       $build["field_form_url"]["iframe_url"]['#markup'] = $iframe_url->toString();
       $gf_token = $this->requestStack->getCurrentRequest()->get('gf_token');


### PR DESCRIPTION
Updated the entity view alteration logic to normalize iframe URLs by ensuring they are always properly slashed. Added a corresponding changelog entry under the "Added" type for better tracking.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-36769


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
