### PR TITLE
DP-0000 Expose weight sub-field of the field_primary_parent field when value is a microsite

### DIFF
--- a/conf/drupal/config/core.entity_form_display.node.advisory.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.advisory.default.yml
@@ -297,7 +297,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.binder.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.binder.default.yml
@@ -551,7 +551,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.campaign_landing.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.campaign_landing.default.yml
@@ -185,7 +185,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.curated_list.default.yml
@@ -497,7 +497,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_related_links:
     type: link_default

--- a/conf/drupal/config/core.entity_form_display.node.decision.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.decision.default.yml
@@ -303,7 +303,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.decision_tree.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.decision_tree.default.yml
@@ -108,7 +108,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.event.default.yml
@@ -637,7 +637,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.executive_order.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.executive_order.default.yml
@@ -285,7 +285,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.form_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.form_page.default.yml
@@ -296,7 +296,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.guide_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.guide_page.default.yml
@@ -351,7 +351,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.how_to_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.how_to_page.default.yml
@@ -534,7 +534,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.info_details.default.yml
@@ -539,7 +539,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.location.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.location.default.yml
@@ -384,7 +384,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_ref_contact_info:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.location_details.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.location_details.default.yml
@@ -154,7 +154,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.news.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.news.default.yml
@@ -425,7 +425,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.org_page.default.yml
@@ -517,7 +517,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_public_records_link:
     type: link_default

--- a/conf/drupal/config/core.entity_form_display.node.person.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.person.default.yml
@@ -303,7 +303,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_publish_bio_page:
     type: boolean_checkbox

--- a/conf/drupal/config/core.entity_form_display.node.regulation.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.regulation.default.yml
@@ -168,7 +168,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_regluation_official_ver:
     type: link_default

--- a/conf/drupal/config/core.entity_form_display.node.rules.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.rules.default.yml
@@ -202,7 +202,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.service_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.service_page.default.yml
@@ -410,7 +410,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_ref_contact_info:
     type: entity_reference_autocomplete

--- a/conf/drupal/config/core.entity_form_display.node.topic_page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic_page.default.yml
@@ -203,7 +203,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_restrict_link_management:
     type: boolean_checkbox

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.collections.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.collections.default.yml
@@ -199,7 +199,7 @@ content:
       match_limit: 10
       size: 60
       placeholder: ''
-      hide_weight: true
+      hide_weight: false
     third_party_settings: {  }
   field_reusable_label:
     type: entity_reference_autocomplete

--- a/docroot/modules/custom/mass_hierarchy/mass_hierarchy.api.php
+++ b/docroot/modules/custom/mass_hierarchy/mass_hierarchy.api.php
@@ -1,0 +1,19 @@
+<?php
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Allows modules to alter the AJAX response for parent page entity reference.
+ *
+ * @param \Drupal\Core\Ajax\AjaxResponse $response
+ *   The AjaxResponse object that will be returned to the client.
+ * @param array $form
+ *   The form API render array.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ */
+function hook_mass_hierarchy_breadcrumb_ajax_alter(AjaxResponse $response, array &$form, FormStateInterface $form_state) {
+  $response->addCommand(new ReplaceCommand('#mass-microsites-field-primary-parent-wrapper', $form['field_primary_parent']['widget'][0]));
+}

--- a/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
+++ b/docroot/modules/custom/mass_hierarchy/mass_hierarchy.module
@@ -229,6 +229,12 @@ function _mass_hierarchy_breadcrumb_ajax(array &$form, FormStateInterface $form_
     // Replace the existing breadcrumb preview element with the new one.
     $response->addCommand(new ReplaceCommand('#breadcrumb-preview-wrapper', $rendered_block));
   }
+
+  // Allow others to adjust the response.
+  /** @var \Drupal\Core\Extension\ModuleHandlerInterface $module_handler */
+  $module_handler = \Drupal::service('module_handler');
+  $module_handler->alter('mass_hierarchy_breadcrumb_ajax', $response, $form, $form_state);
+
   return $response;
 }
 

--- a/docroot/modules/custom/mass_microsites/mass_microsites.module
+++ b/docroot/modules/custom/mass_microsites/mass_microsites.module
@@ -5,6 +5,11 @@
  * Primary module hooks for Mass Microsites module.
  */
 
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Entity\Element\EntityAutocomplete;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\entity_hierarchy_microsite\Entity\MicrositeInterface;
 use Drupal\node\NodeInterface;
 use Drupal\entity_hierarchy_microsite\ChildOfMicrositeLookup;
@@ -145,4 +150,69 @@ function mass_microsites_entity_hierarchy_microsite_links_alter(array &$links) {
       $links[$key]['title'] = $short_title;
     }
   }
+}
+
+/**
+ * Implements hook_field_widget_single_element_WIDGET_TYPE_form_alter().
+ *
+ * Alters the entity_reference_hierarchy_autocomplete widget for the
+ * field_primary_parent field in order to add some logic that will show the
+ * weight field only when a value is set that is part of a microsite.
+ */
+function mass_microsites_field_widget_single_element_entity_reference_hierarchy_autocomplete_form_alter(array &$element, FormStateInterface $form_state, array $context) {
+  $items = $context['items'];
+  if (!$items instanceof FieldItemListInterface) {
+    return;
+  }
+  $field_name = $items->getFieldDefinition()->getName();
+  if ($field_name !== 'field_primary_parent') {
+    return;
+  }
+  $element['#after_build'][] = '_mass_microsites_field_widget_single_element_entity_reference_hierarchy_autocomplete_form_alter_after_build';
+  $element['#attributes']['id'] = 'mass-microsites-field-primary-parent-wrapper';
+}
+
+/**
+ * #after_build callback for entity_reference_hierarchy_autocomplete widget for
+ * the field_primary_parent field. Adds logic that will show the weight field
+ * only when a value is set that is part of a microsite.
+ *
+ * @param array $element
+ *   The form API render array for the widget.
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ *   Form state.
+ *
+ * @return array|void
+ *   Render array of the altered form element.
+ *
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function _mass_microsites_field_widget_single_element_entity_reference_hierarchy_autocomplete_form_alter_after_build(array $element, FormStateInterface $form_state) {
+  $entity = $form_state->getFormObject()->getEntity();
+  // Ignore non-node entities.
+  if (!$entity instanceof NodeInterface) {
+    return;
+  }
+  /** @var \Drupal\mass_microsites\ChildOfMicrositeLookup $microsite_lookup */
+  $microsite_lookup = \Drupal::service('mass_microsites.microsite_lookup');
+  if ($parent_id = $form_state->getValue(['field_primary_parent', '0', 'target_id'])) {
+    $parent_id = trim(reset($parent_id));
+    if (!is_numeric($parent_id)) {
+      $parent_id = trim(EntityAutocomplete::extractEntityIdFromAutocompleteInput($parent_id));
+    }
+    $parent_id = (int) $parent_id;
+  }
+  else {
+    $parent_id = $entity->get('field_primary_parent')->target_id;
+  }
+  $element['weight']['#access'] = $parent_id && $microsite_lookup->hasMicrositeForChildNodeParentNid($entity, $parent_id, 'field_primary_parent');
+  return $element;
+}
+
+/**
+ * Implements hook_microsites_mass_hierarchy_breadcrumb_ajax_alter().
+ */
+function mass_microsites_mass_hierarchy_breadcrumb_ajax_alter(AjaxResponse $response, array &$form, FormStateInterface $form_state) {
+  $response->addCommand(new ReplaceCommand('#mass-microsites-field-primary-parent-wrapper', $form['field_primary_parent']['widget'][0]));
 }

--- a/docroot/modules/custom/mass_microsites/mass_microsites.services.yml
+++ b/docroot/modules/custom/mass_microsites/mass_microsites.services.yml
@@ -1,0 +1,7 @@
+services:
+  mass_microsites.microsite_lookup:
+    class: Drupal\mass_microsites\ChildOfMicrositeLookup
+    arguments:
+      - '@entity_type.manager'
+      - '@entity_hierarchy.nested_set_storage_factory'
+      - '@entity_hierarchy.nested_set_node_factory'

--- a/docroot/modules/custom/mass_microsites/src/ChildOfMicrositeLookup.php
+++ b/docroot/modules/custom/mass_microsites/src/ChildOfMicrositeLookup.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\mass_microsites;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\entity_hierarchy\Storage\NestedSetNodeKeyFactory;
+use Drupal\entity_hierarchy\Storage\NestedSetStorageFactory;
+use Drupal\node\NodeInterface;
+use PNX\NestedSet\Node;
+
+/**
+ * Defines a class for looking up a microsite given a child node and parent nid.
+ */
+class ChildOfMicrositeLookup {
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Nested set storage.
+   *
+   * @var \Drupal\entity_hierarchy\Storage\NestedSetStorageFactory
+   */
+  protected $nestedSetStorageFactory;
+
+  /**
+   * Nested set node key factory.
+   *
+   * @var \Drupal\entity_hierarchy\Storage\NestedSetNodeKeyFactory
+   */
+  protected $nodeKeyFactory;
+
+  /**
+   * Constructs a new ChildOfMicrositeLookup.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
+   * @param \Drupal\entity_hierarchy\Storage\NestedSetStorageFactory $nestedSetStorageFactory
+   *   Storage factory.
+   * @param \Drupal\entity_hierarchy\Storage\NestedSetNodeKeyFactory $nodeKeyFactory
+   *   Key factory.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, NestedSetStorageFactory $nestedSetStorageFactory, NestedSetNodeKeyFactory $nodeKeyFactory) {
+    $this->entityTypeManager = $entityTypeManager;
+    $this->nestedSetStorageFactory = $nestedSetStorageFactory;
+    $this->nodeKeyFactory = $nodeKeyFactory;
+  }
+
+  /**
+   * Determine if the given child node, parent pair has a microsite.
+   *
+   * @param \Drupal\node\NodeInterface $child_node
+   *   The child or leaf node.
+   * @param int $parent_id
+   *   The entity_id of the parent node.
+   * @param string $field_name
+   *   The field name that defines the entity hierarchy.
+   *
+   * @return bool
+   *   If the given child node, parent pair has a microsite in the entity
+   *   hierarchy defined by the given field.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function hasMicrositeForChildNodeParentNid(NodeInterface $child_node, int $parent_id, string $field_name): bool {
+    $node_storage = $this->entityTypeManager->getStorage('node');
+    $parent_node = $node_storage->load($parent_id);
+
+    if (!$parent_node instanceof ContentEntityInterface) {
+      return FALSE;
+    }
+
+    $key = $this->nodeKeyFactory->fromEntity($parent_node);
+    /** @var \PNX\NestedSet\NestedSetInterface $nested_set_storage */
+    $nested_set_storage = $this->nestedSetStorageFactory->get($field_name, 'node');
+    $ids = array_map(function (Node $treeNode) {
+      return $treeNode->getId();
+    }, $nested_set_storage->findAncestors($key));
+
+    $ids[] = $parent_node->id();
+    $ids[] = $child_node->id();
+
+    $eh_microsite_storage = $this->entityTypeManager->getStorage('entity_hierarchy_microsite');
+    $microsite_ids = $eh_microsite_storage
+      ->getQuery()
+      ->accessCheck(FALSE)
+      ->sort('id')
+      ->condition('home', array_unique($ids), 'IN')
+      ->execute();
+    return !empty($microsite_ids);
+  }
+
+}


### PR DESCRIPTION
**Description:**
To allow editors to influence the ordering of microsite pages, this change will always expose the weight sub-field of the Parent (`field_primary_parent`) field in config. We then add some logic to only show the weight sub-field of the Parent field if the value places the page into a hierarchy of an existing microsite.

**To Test:**
- [ ] If one does not yet exist, create a Microsite
- [ ] Edit any content that has a Parent (`field_primary_parent`) field
- [ ] The parent field should only display a "Weight" sub-field when the value would place the content into the hierarchy of a microsite. Adjust its value and verify. Weight should show/hide as appropriate afer loading the form, and as you change the value via AJAX.
- [ ] Also perform same testing steps with Creating content.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
