### PR TITLE
DP-00000: Update previousnext/phpunit-finder to tagged version to avoid errors with other package updates or lock file maintenance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -276,7 +276,7 @@
         "kint-php/kint": "^5",
         "palantirnet/drupal-rector": "^0.20.3",
         "phpspec/prophecy-phpunit": "^2",
-        "previousnext/phpunit-finder": "dev-main",
+        "previousnext/phpunit-finder": "^2.0.2",
         "vincentlanglet/twig-cs-fixer": "^2.5",
         "weitzman/drupal-test-traits": "^2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "18cd269596ad8e2328a0e15d1085cc2d",
+    "content-hash": "db1831226ea970d3a7fddf95dbe99e75",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -21970,16 +21970,16 @@
         },
         {
             "name": "previousnext/phpunit-finder",
-            "version": "dev-main",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/previousnext/phpunit-finder.git",
-                "reference": "9c68e83570a505b71e2df5a92e6e49d7547f1a54"
+                "reference": "1964f6975a9234f97dd099c6171fed6198784bc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/previousnext/phpunit-finder/zipball/9c68e83570a505b71e2df5a92e6e49d7547f1a54",
-                "reference": "9c68e83570a505b71e2df5a92e6e49d7547f1a54",
+                "url": "https://api.github.com/repos/previousnext/phpunit-finder/zipball/1964f6975a9234f97dd099c6171fed6198784bc2",
+                "reference": "1964f6975a9234f97dd099c6171fed6198784bc2",
                 "shasum": ""
             },
             "require": {
@@ -21992,7 +21992,6 @@
                 "drupal/coder": "~8.3.12",
                 "phpcompatibility/php-compatibility": "^9.3"
             },
-            "default-branch": true,
             "bin": [
                 "phpunit-finder"
             ],
@@ -22017,14 +22016,10 @@
                 }
             ],
             "description": "PHP lib for finding and outputting all tests from a phpunit.xml config file.",
-            "keywords": [
-                "testing"
-            ],
             "support": {
-                "issues": "https://github.com/previousnext/phpunit-finder/issues",
-                "source": "https://github.com/previousnext/phpunit-finder/tree/main"
+                "source": "https://github.com/previousnext/phpunit-finder/tree/2.0.2"
             },
-            "time": "2023-10-17T01:13:39+00:00"
+            "time": "2023-01-13T04:40:56+00:00"
         },
         {
             "name": "react/promise",
@@ -24376,8 +24371,7 @@
         "drupal/openid_connect_windows_aad": 20,
         "drupal/views_taxonomy_term_name_into_id": 15,
         "drupaltest/queue-runner-trait": 20,
-        "massgov/mayflower-artifacts": 20,
-        "previousnext/phpunit-finder": 20
+        "massgov/mayflower-artifacts": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
**Description:**
While working on #2885, I needed a core patch, and after adding it to `composer.json`, and running the typical `ddev composer update --lock` to update the lock file, I was getting the following error. I also get this error simply running `composer update --lock` while on the `develop` branch.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires previousnext/phpunit-finder == dev-main -> satisfiable by previousnext/phpunit-finder[dev-main].
    - previousnext/phpunit-finder dev-main requires phpunit/phpunit ^10.5 -> found phpunit/phpunit[10.5.0, ..., 10.5.x-dev] but these were not loaded, likely because it conflicts with another require.
```

The issue is that `previousnext/phpunit-finder:dev-main`  has recently been updated to support `phpunit/phpunit:^10.5` (see https://github.com/previousnext/phpunit-finder/commits/main/), which conflicts with the sites’ requirements. There is a tagged version available for `previousnext/phpunit-finder`, which we're currently effectively using. The `composer.lock` file uses https://github.com/previousnext/phpunit-finder/commit/9c68e83570a505b71e2df5a92e6e49d7547f1a54. Version 2.0.2 is the commit just behind that one, with no functional difference between the two (see https://github.com/previousnext/phpunit-finder/compare/1964f6975a9234f97dd099c6171fed6198784bc2...9c68e83570a505b71e2df5a92e6e49d7547f1a54).

**To Test:**
- [ ] Pull this branch down locally and run `composer update --lock`. You should no longer get the above error.


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
