### PR TITLE
DP-38325: Fix component style issue on promo page introduced by layout card component

### DIFF
--- a/changelogs/DP-38325.yml
+++ b/changelogs/DP-38325.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes the max width for first card used in Campaign Feature.
+    issue: DP-38325

--- a/changelogs/DP-38325.yml
+++ b/changelogs/DP-38325.yml
@@ -39,3 +39,5 @@
 Fixed:
   - description: Fixes the max width for first card used in Campaign Feature.
     issue: DP-38325
+  - description: Add layout paragraphs styling to the "clone" page for Info Details content type
+    issue: NA (Teams conversation)

--- a/composer.json
+++ b/composer.json
@@ -258,7 +258,7 @@
         "enyo/dropzone": "5.7.2",
         "geocoder-php/open-cage-provider": "^4.6",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.json
+++ b/composer.json
@@ -258,7 +258,7 @@
         "enyo/dropzone": "5.7.2",
         "geocoder-php/open-cage-provider": "^4.6",
         "google/cloud-bigquery": "^1.25",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "phlak/semver": "^2.0",
         "previousnext/drupal-test-utils": "^0.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3529152cdd946b7757caec248802676",
+    "content-hash": "b05ef403f7ad7eae9de3c91db487cede",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12342,16 +12342,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "d4d09adb7b4ed6a2de7024c1e15915a0272a76d7"
+                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d4d09adb7b4ed6a2de7024c1e15915a0272a76d7",
-                "reference": "d4d09adb7b4ed6a2de7024c1e15915a0272a76d7",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
+                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
                 "shasum": ""
             },
             "require": {
@@ -12371,9 +12371,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2025-03-28T14:57:56+00:00"
+            "time": "2025-03-27T17:55:37+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b05ef403f7ad7eae9de3c91db487cede",
+    "content-hash": "d3529152cdd946b7757caec248802676",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -12342,16 +12342,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148"
+                "reference": "d4d09adb7b4ed6a2de7024c1e15915a0272a76d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
-                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/d4d09adb7b4ed6a2de7024c1e15915a0272a76d7",
+                "reference": "d4d09adb7b4ed6a2de7024c1e15915a0272a76d7",
                 "shasum": ""
             },
             "require": {
@@ -12371,9 +12371,9 @@
             "description": "This repository is the product of the built artifact from massgov/mayflower",
             "support": {
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
-                "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
+                "source": "https://github.com/massgov/mayflower-artifacts/tree/patternlab/DP-38325_fix_component_style_issue_promo_page_introduced_layout_card_component"
             },
-            "time": "2025-03-27T17:55:37+00:00"
+            "time": "2025-03-28T14:57:56+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -12346,12 +12346,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148"
+                "reference": "e25623daefed97baf5d275431261f79a8d41697f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
-                "reference": "3bb706d63208c1c2a4fc9f8e0109a101faaf9148",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/e25623daefed97baf5d275431261f79a8d41697f",
+                "reference": "e25623daefed97baf5d275431261f79a8d41697f",
                 "shasum": ""
             },
             "require": {
@@ -12373,7 +12373,7 @@
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
                 "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2025-03-27T17:55:37+00:00"
+            "time": "2025-03-31T07:21:51+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
+++ b/docroot/themes/custom/mass_admin_theme/mass_admin_theme.theme
@@ -286,7 +286,7 @@ function mass_admin_theme_form_layout_paragraphs_component_form_alter(array &$fo
  */
 function mass_admin_theme_form_alter(&$form, &$form_state, $form_id) {
 
-  if ($form_id == 'node_info_details_form' || $form_id == 'node_info_details_edit_form') {
+  if ($form_id == 'node_info_details_form' || $form_id == 'node_info_details_edit_form' || $form_id == 'node_info_details_quick_node_clone_form') {
     $form['#attached']['library'][] = 'mass_theme/global-styling-lp';
   }
 

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -7235,7 +7235,7 @@ function mass_theme_featured_content_cards(&$variables) {
         $return_array['thumbnail'] = $style->buildUrl($paragraph->field_image->entity->getFileUri());
       }
       else {
-        // fallback to raw file URL
+        // Fallback to raw file URL
         $return_array['thumbnail'] = $paragraph->field_image->entity->createFileUrl();
       }
 


### PR DESCRIPTION
**Description:**
This fixes a regression within Cards used in the Campaign Feature where the first card is not stretched full width.


**Jira:** (Skip unless you are MA staff)
DP-38325


**To Test:**
- [ ] Visit the deployed site
- [ ] Go to `/massvets-veteran-state-financial-benefits`
- [ ] Verify that the first card stretches the full width of the container
- [ ] Verify that the first card in the 2nd set on the page stretches the full width of the container
- [ ] Go to `/try-fishing`
- [ ] Verfiy that the first card stretches the full width of the container



---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
