### PR TITLE
DP-38748-Disable-ClamAV-service-on-local-and-Tugboat

### DIFF
--- a/changelogs/DP-38748.yml
+++ b/changelogs/DP-38748.yml
@@ -1,0 +1,42 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Disabled ClamAV integration on local and Tugboat environments to resolve file upload issues.
+    issue: DP-38748
+

--- a/docroot/sites/default/settings.vm.php
+++ b/docroot/sites/default/settings.vm.php
@@ -123,3 +123,6 @@ if (file_exists($secrets_file)) {
 if (getenv('TUGBOAT_ROOT')) {
   require __DIR__ . '/settings.tugboat.php';
 }
+
+// Disable ClamAV integration in local environment
+$config['clamav.settings']['enabled'] = FALSE;


### PR DESCRIPTION

**Description:**
Disabled ClamAV integration on local and Tugboat environments to resolve file upload issues on Tugboat and local.


**Jira:** (Skip unless you are MA staff)
DP-38748