### PR TITLE
DP-38638-Add-a-new-contact-method-for-how-to-pages

### DIFF
--- a/changelogs/DP-38638.yml
+++ b/changelogs/DP-38638.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Add 'Phone' as a contact method option for how-to pages
+    issue: DP-38638

--- a/conf/drupal/config/field.storage.paragraph.field_method_type.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_method_type.yml
@@ -16,7 +16,7 @@ settings:
       label: Online
     -
       value: by_email
-      label: 'By Email'
+      label: 'By email'
     -
       value: phone
       label: 'By phone'

--- a/conf/drupal/config/field.storage.paragraph.field_method_type.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_method_type.yml
@@ -15,6 +15,9 @@ settings:
       value: online
       label: Online
     -
+      value: by_email
+      label: 'By Email'
+    -
       value: phone
       label: 'By phone'
     -


### PR DESCRIPTION
**Description:**
"Add 'Phone' as a contact method option for how-to pages"

**Jira:** (Skip unless you are MA staff)
[DP-38638](https://massgov.atlassian.net/browse/DP-38638)

[DP-38638]: https://massgov.atlassian.net/browse/DP-38638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ