### PR TITLE
DP-39646: Enable content_translation module. 

### DIFF
--- a/changelogs/DP-39093.yml
+++ b/changelogs/DP-39093.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Enable content_translation module.
+    issue: DP-39093

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -256,6 +256,7 @@ module:
   mass_utility: 1
   menu_link_content: 1
   pathauto: 1
+  content_translation: 10
   externalauth: 10
   views: 10
   standard: 1000

--- a/docroot/modules/custom/mass_caching/tests/src/ExistingSite/StaleCachingTest.php
+++ b/docroot/modules/custom/mass_caching/tests/src/ExistingSite/StaleCachingTest.php
@@ -11,6 +11,13 @@ use MassGov\Dtt\MassExistingSiteBase;
  */
 class StaleCachingTest extends MassExistingSiteBase {
 
+  protected static array $uncacheableDynamicPagePatterns = [
+    'admin/.*',
+    '/*edit.*',
+    'user/logout.*',
+    'user/reset/*',
+  ];
+
   /**
    * {@inheritdoc}
    */

--- a/docroot/modules/custom/mass_translations/mass_translations.routing.yml
+++ b/docroot/modules/custom/mass_translations/mass_translations.routing.yml
@@ -1,5 +1,5 @@
 mass_translations.controller_translations:
-  path: '/node/{node}/translations'
+  path: '/node/{node}/mass-translations'
   defaults:
     _controller: '\Drupal\mass_translations\Controller\NodeTranslationsController::content'
     _title: 'Translations'
@@ -8,7 +8,7 @@ mass_translations.controller_translations:
   requirements:
     _custom_access: '\Drupal\mass_translations\Controller\NodeTranslationsController::access'
 mass_translations.controller_media_translations:
-  path: '/media/{media}/translations'
+  path: '/media/{media}/mass-translations'
   defaults:
     _controller: '\Drupal\mass_translations\Controller\MediaTranslationsController::content'
     _title: 'Translations'

--- a/docroot/modules/custom/mass_validation/tests/src/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
+++ b/docroot/modules/custom/mass_validation/tests/src/ExistingSite/UnpublishedEntitiesCanBeReferencedTest.php
@@ -10,6 +10,13 @@ use MassGov\Dtt\MassExistingSiteBase;
  */
 class UnpublishedEntitiesCanBeReferencedTest extends MassExistingSiteBase {
 
+  protected static array $uncacheableDynamicPagePatterns = [
+    'admin/.*',
+    '/*edit.*',
+    'user/logout.*',
+    'user/reset/*',
+  ];
+
   /**
    * The user to log in and test the functionality.
    *


### PR DESCRIPTION
We need this module to be enabled on Prod before we deploy the rest of the code for API Service Card to avoid circular dependency: mass_translations.subscriber service depends on content_translation, which prevents the cache reset if content_translation is disabled. And enabling the content_translation can happens only in hood_update_N or in config sync, which always happens after hood_update_N or in config sync if pipeline is setup correctly.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-39093


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
