### PR TITLE
Post release 0.439.0 rebuild mayflower artifacts references.

### DIFF
--- a/changelogs/DP-39638.yml
+++ b/changelogs/DP-39638.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Re-add mayflowere artrifacts after 0.439.0 release revert.
+    issue: DP-39638

--- a/composer.lock
+++ b/composer.lock
@@ -12746,12 +12746,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts.git",
-                "reference": "b425a3d61ab087a44151726a7be12b5aace68611"
+                "reference": "ade222004526f5615cac0de15169dd639e55c3bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/b425a3d61ab087a44151726a7be12b5aace68611",
-                "reference": "b425a3d61ab087a44151726a7be12b5aace68611",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/ade222004526f5615cac0de15169dd639e55c3bc",
+                "reference": "ade222004526f5615cac0de15169dd639e55c3bc",
                 "shasum": ""
             },
             "require": {
@@ -12773,7 +12773,7 @@
                 "issues": "https://github.com/massgov/mayflower-artifacts/issues",
                 "source": "https://github.com/massgov/mayflower-artifacts/tree/develop"
             },
-            "time": "2025-05-25T09:21:39+00:00"
+            "time": "2025-05-27T18:17:09+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Since we did the revert of 0.439.0 release, we need to re-reference the mayflower-artifacts, since none of tickets since 0.439.0 didn't add a reference to MF artifacts.

We need this for our 0.440.0 release. 