### PR TITLE
DP-39824-Add-icon-for-email-method-on-how-to

### DIFF
--- a/changelogs/DP-39824.yml
+++ b/changelogs/DP-39824.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Added mail icon to the email how-to method.
+    issue: DP-39824

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -1369,7 +1369,7 @@ class Organisms {
     }
     else {
       $description = [];
-    }
+    };
 
     $table = [];
     if (!empty($items)) {

--- a/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Organisms.php
@@ -1369,7 +1369,7 @@ class Organisms {
     }
     else {
       $description = [];
-    };
+    }
 
     $table = [];
     if (!empty($items)) {
@@ -1594,6 +1594,7 @@ class Organisms {
       'fax' => 'fax-icon',
       'in person' => 'profile',
       'text' => 'message',
+      'by_email' => 'mail',
     ];
 
     // Roll up our action steps.


### PR DESCRIPTION
**Description:**
Added mail icon to the email how-to method.

**Jira:** (Skip unless you are MA staff)
[DP-39824](https://massgov.atlassian.net/browse/DP-39824)


[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)

[DP-39824]: https://massgov.atlassian.net/browse/DP-39824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ