### PR TITLE
DP-40037-Allow-documents-in-Drupal-with-file-extension-rpt

### DIFF
--- a/changelogs/DP-40037.yml
+++ b/changelogs/DP-40037.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Allow Drupal to accept documents with the .rpt extension.
+    issue: DP-40037

--- a/conf/drupal/config/field.field.media.document.field_upload_file.yml
+++ b/conf/drupal/config/field.field.media.document.field_upload_file.yml
@@ -21,7 +21,7 @@ settings:
   handler: 'default:file'
   handler_settings: {  }
   file_directory: 'documents/[date:custom:Y]/[date:custom:m]/[date:custom:d]'
-  file_extensions: 'csv doc docm docx dot dotx dwg geojson gif json jpg kml kmz mp3 mp4 mpp msg odf ods odt pdf png pps ppsx potx ppt pptm pptx ppsm prx pub rdf rfa rte rtf tiff tsv txt xls xlsb xlsm xlsx xml zip'
+  file_extensions: 'csv doc docm docx dot dotx dwg geojson gif json jpg kml kmz mp3 mp4 mpp msg odf ods odt pdf png pps ppsx potx ppt pptm pptx ppsm prx pub rdf rfa rte rtf tiff tsv txt xls xlsb xlsm xlsx xml zip rpt'
   max_filesize: '100 MB'
   description_field: false
 field_type: file


### PR DESCRIPTION
**Description:**
Allow Drupal to accept documents with the .rpt extension.


**Jira:** (Skip unless you are MA staff)
[DP-40037](https://massgov.atlassian.net/browse/DP-40037)

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)


[DP-40037]: https://massgov.atlassian.net/browse/DP-40037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ