### PR TITLE
DP-39691-Fix-semantic-markup-on-feedback-page

### DIFF
--- a/changelogs/DP-39691.yml
+++ b/changelogs/DP-39691.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Created a block plugin (`FeedbackHeaderBlock`) in the `mass_feedback_loop` module to render contextual links on feedback pages.
+    issue: DP-39691

--- a/conf/drupal/config/block.block.alerts.yml
+++ b/conf/drupal/config/block.block.alerts.yml
@@ -10,7 +10,7 @@ dependencies:
 id: alerts
 theme: mass_admin_theme
 region: header
-weight: -9
+weight: -8
 provider: null
 plugin: alerts_block
 settings:

--- a/conf/drupal/config/block.block.help.yml
+++ b/conf/drupal/config/block.block.help.yml
@@ -9,7 +9,7 @@ dependencies:
 id: help
 theme: mass_admin_theme
 region: header
-weight: -7
+weight: -5
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.mass_admin_theme_feedbackdescriptionblock.yml
+++ b/conf/drupal/config/block.block.mass_admin_theme_feedbackdescriptionblock.yml
@@ -1,0 +1,25 @@
+uuid: 22790669-3adc-4c2c-9818-200ba657ac50
+langcode: en
+status: true
+dependencies:
+  module:
+    - mass_feedback_loop
+    - system
+  theme:
+    - mass_admin_theme
+id: mass_admin_theme_feedbackdescriptionblock
+theme: mass_admin_theme
+region: header
+weight: -6
+provider: null
+plugin: feedback_description_block
+settings:
+  id: feedback_description_block
+  label: 'Feedback Description Block'
+  label_display: '0'
+  provider: mass_feedback_loop
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: "/*/feedback\r\n\r\n"

--- a/conf/drupal/config/block.block.mass_admin_theme_pagetitle.yml
+++ b/conf/drupal/config/block.block.mass_admin_theme_pagetitle.yml
@@ -7,7 +7,7 @@ dependencies:
 id: mass_admin_theme_pagetitle
 theme: mass_admin_theme
 region: header
-weight: -8
+weight: -7
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.mass_admin_theme_primary_tabs.yml
+++ b/conf/drupal/config/block.block.mass_admin_theme_primary_tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: mass_admin_theme_primary_tabs
 theme: mass_admin_theme
 region: header
-weight: -6
+weight: -4
 provider: null
 plugin: local_tasks_block
 settings:

--- a/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopPerNodeForm.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Form/MassFeedbackLoopPerNodeForm.php
@@ -54,17 +54,7 @@ class MassFeedbackLoopPerNodeForm extends FormBase {
    * {@inheritdoc}
    */
   public function getTitle() {
-    $negative_feedback_url = Url::fromRoute('view.pages_with_high_negative_feedback.page_2')->toString();
-    $feedback_manager_url = Url::fromRoute('mass_feedback_loop.mass_feedback_loop_author_interface_form')->toString();
-    $message = 'Feedback submitted by constituents for this content<p>Also see: <a href="@negative_feedback_url">Pages with high negative feedback</a> and <a href="@feedback_manager_url">Feedback Manager</a> where you can view, filter and sort feedback submissions.</p>';
-    $markup = Markup::create($this->t($message, [
-      '@negative_feedback_url' => $negative_feedback_url,
-      '@feedback_manager_url' => $feedback_manager_url,
-    ]));
-
-    return [
-      '#markup' => $markup,
-    ];
+    return $this->t('Feedback submitted by constituents for this content');
   }
 
   /**

--- a/docroot/modules/custom/mass_feedback_loop/src/Plugin/Block/FeedbackDescriptionBlock.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Plugin/Block/FeedbackDescriptionBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\mass_feedback_loop\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -27,11 +28,16 @@ class FeedbackDescriptionBlock extends BlockBase {
       return [];
     }
 
-    $neg_url = Url::fromRoute('view.pages_with_high_negative_feedback.page_2')->toString();
-    $mgr_url = Url::fromRoute('mass_feedback_loop.mass_feedback_loop_author_interface_form')->toString();
+    $negative_feedback_url = Url::fromRoute('view.pages_with_high_negative_feedback.page_2')->toString();
+    $feedback_manager_url = Url::fromRoute('mass_feedback_loop.mass_feedback_loop_author_interface_form')->toString();
+    $message = '<p class="ma__page-header__description">Also see: <a href="@negative_feedback_url">Pages with high negative feedback</a> and <a href="@feedback_manager_url">Feedback Manager</a> where you can view, filter and sort feedback submissions.</p>';
+    $markup = Markup::create($this->t($message, [
+      '@negative_feedback_url' => $negative_feedback_url,
+      '@feedback_manager_url' => $feedback_manager_url,
+    ]));
 
     return [
-      '#markup' => '<p class="ma__page-header__description">Also see: <a href="' . $neg_url . '">Pages with high negative feedback</a> and <a href="' . $mgr_url . '">Feedback Manager</a> where you can view, filter and sort feedback submissions.</p>',
+      '#markup' => $markup
     ];
   }
 

--- a/docroot/modules/custom/mass_feedback_loop/src/Plugin/Block/FeedbackDescriptionBlock.php
+++ b/docroot/modules/custom/mass_feedback_loop/src/Plugin/Block/FeedbackDescriptionBlock.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\mass_feedback_loop\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Url;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a block with a feedback description.
+ *
+ * @Block(
+ *   id = "feedback_description_block",
+ *   admin_label = @Translation("Feedback Description Block")
+ * )
+ */
+class FeedbackDescriptionBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $route_name = \Drupal::routeMatch()->getRouteName();
+
+    if ($route_name !== 'mass_feedback_loop.per_node_feedback_form') {
+      return [];
+    }
+
+    $neg_url = Url::fromRoute('view.pages_with_high_negative_feedback.page_2')->toString();
+    $mgr_url = Url::fromRoute('mass_feedback_loop.mass_feedback_loop_author_interface_form')->toString();
+
+    return [
+      '#markup' => '<p class="ma__page-header__description">Also see: <a href="' . $neg_url . '">Pages with high negative feedback</a> and <a href="' . $mgr_url . '">Feedback Manager</a> where you can view, filter and sort feedback submissions.</p>',
+    ];
+  }
+
+}


### PR DESCRIPTION
**Description:**
Added a custom block plugin `(FeedbackHeaderBlock)` in the `mass_feedback_loop` module to render the contextual description on feedback pages. Placed the block in the header region via the Block UI and restricted visibility to `*/feedback`paths.

**Jira:** (Skip unless you are MA staff)
[DP-39691](https://massgov.atlassian.net/browse/DP-39691)


[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)


[DP-39691]: https://massgov.atlassian.net/browse/DP-39691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ