### PR TITLE
DP-39936: Hide sections on news content type for blog posts

### DIFF
--- a/changelogs/DP-39936.yml
+++ b/changelogs/DP-39936.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Hide sections on news content type for blog posts.
+    issue: DP-39936

--- a/conf/drupal/config/core.entity_form_display.node.news.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.news.default.yml
@@ -375,20 +375,18 @@ content:
           dependee: field_news_type
           settings:
             state: '!visible'
+            reset: false
             condition: value
             grouping: AND
             values_set: 3
             value: ''
-            values: "speech\r\npress_release"
+            values: "speech\r\npress_release\r\nblog_post"
             value_form:
               -
                 value: press_release
             effect: show
             effect_options: {  }
             selector: ''
-            field_news_type:
-              -
-                value: press_release
   field_news_signees:
     type: paragraphs
     weight: 36


### PR DESCRIPTION
**Description:**
Hide sections on news content type for blog posts.


**Jira:** (Skip unless you are MA staff)
DP-39936


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
