### PR TITLE
DP-42439-Quotes-in-service-page-titles-are-rendered-as-quot-when-they-appear-

### DIFF
--- a/changelogs/DP-42439.yml
+++ b/changelogs/DP-42439.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Fixes quotes in service page titles being rendered as HTML entities in table of contents
+    issue: DP-42439

--- a/docroot/themes/custom/mass_theme/templates/content/node--binder--table-of-contents.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--binder--table-of-contents.html.twig
@@ -9,7 +9,7 @@
     "id": "overlay-toc-" ~ node.id,
     "typeContext": node.field_binder_binder_type ? node.field_binder_binder_type.entity.name.value|lower,
     "title": {
-      "text": label|render|striptags,
+      "text": label,
       "href": url,
       "info": ""
     }


### PR DESCRIPTION
Fixes quotes in service page titles being rendered as HTML in table of contents