### PR TITLE
DP-37258-Prevent-authors-from-using-non-organizations-in-the-Organizations-field

### DIFF
--- a/changelogs/DP-37258.yml
+++ b/changelogs/DP-37258.yml
@@ -1,0 +1,4 @@
+Fixed:
+  - description: Prevent non-organization pages from being pasted and saved in Organization(s) fields by adding form-level validation. Entity-level validation is handled by Drupal core's ValidReferenceConstraint based on field configuration.
+    issue: DP-37258
+

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -240,6 +240,7 @@ function mass_validation_form_node_form_alter(&$form, FormStateInterface $form_s
 
 /**
  * Validates to ensure at least one value is filled out for field_organizations.
+ *
  * Also validates that only org_page nodes are referenced.
  */
 function _mass_validation_field_organizations_validate(array &$form, FormStateInterface $form_state) {

--- a/docroot/modules/custom/mass_validation/mass_validation.module
+++ b/docroot/modules/custom/mass_validation/mass_validation.module
@@ -240,6 +240,7 @@ function mass_validation_form_node_form_alter(&$form, FormStateInterface $form_s
 
 /**
  * Validates to ensure at least one value is filled out for field_organizations.
+ * Also validates that only org_page nodes are referenced.
  */
 function _mass_validation_field_organizations_validate(array &$form, FormStateInterface $form_state) {
   if ($form_state->hasValue('field_organizations')) {
@@ -290,6 +291,23 @@ function _mass_validation_field_organizations_validate(array &$form, FormStateIn
       // the error on field_organizations.
       if ((count($multiple_ogranizations) == 1 && isset($multiple_ogranizations['add_more'])) || $multiple_ogranizations[0]['target_id'] == NULL) {
         $form_state->setErrorByName($error_key, t('At least one organization value must be filled out.'));
+      }
+    }
+
+    // Validate that only org_page nodes are referenced.
+    $organizations = $form_state->getValue('field_organizations');
+    foreach ($organizations as $delta => $org) {
+      if (is_array($org) && !empty($org['target_id'])) {
+        $node = Node::load($org['target_id']);
+        if ($node && $node->bundle() !== 'org_page') {
+          $form_state->setErrorByName(
+            'field_organizations][' . $delta . '][target_id',
+            t('Only organization pages can be referenced in this field. The item "@title" is a @type page and is not allowed.', [
+              '@title' => $node->getTitle(),
+              '@type' => $node->bundle(),
+            ])
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
**Description:**
validates that only org_page nodes are referenced in the organization field


**Jira:** (Skip unless you are MA staff)
[DP-37258](https://massgov.atlassian.net/browse/DP-37258)

[DP-37258]: https://massgov.atlassian.net/browse/DP-37258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ