### PR TITLE
DP-43090-Backport-Hide-email-addresses-and-leaflet-map-tiles-from-editoria11y

### DIFF
--- a/changelogs/DP-43090.yml
+++ b/changelogs/DP-43090.yml
@@ -1,0 +1,3 @@
+Changed:
+  - description: Hide email addresses and leaflet map tiles from editoria11y accessibility checking.
+    issue: DP-43090

--- a/conf/drupal/config/editoria11y.settings.yml
+++ b/conf/drupal/config/editoria11y.settings.yml
@@ -4,7 +4,7 @@ content_root: ''
 assertiveness: smart
 no_load: ''
 ignore_all_if_absent: ''
-ignore_elements: '.ma__location-banner__image *, .ma__suggested-pages__item img, #location-listing-results img, .ma__personal-message__container .ma__image-promo__image img, .ma__key-message__inline-image img, .ma__details__content .ma__image-promos img.ma__image, .ma__card__img.ma__card__img--vertical img, .js-location-listing-link .ma__image-promo__image *, .user-login *, .dt-scroll-footInner table, h3.ma__collapsible-header, .ma__header-alerts__container h3'
+ignore_elements: '.ma__location-banner__image *, .ma__suggested-pages__item img, #location-listing-results img, .ma__personal-message__container .ma__image-promo__image img, .ma__key-message__inline-image img, .ma__details__content .ma__image-promos img.ma__image, .ma__card__img.ma__card__img--vertical img, .js-location-listing-link .ma__image-promo__image *, .user-login *, .dt-scroll-footInner table, h3.ma__collapsible-header, .ma__header-alerts__container h3, a[href^="mailto:"], .leaflet-pane.leaflet-tile-pane img'
 embedded_content_warning: ''
 download_links: 'false'
 link_strings_new_windows: ''


### PR DESCRIPTION
**Description:**
Hide email addresses and leaflet map tiles from editoria11y accessibility checking.

**Jira:** (Skip unless you are MA staff)
[DP-43090](https://massgov.atlassian.net/browse/DP-43090)


[DP-43090]: https://massgov.atlassian.net/browse/DP-43090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ