### PR TITLE
DP-43985: Help text changes

### DIFF
--- a/changelogs/DP-43985.yml
+++ b/changelogs/DP-43985.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Added:
+  - description: Help text for exclude from search and sitewide alert config page.
+    issue: DP-43985

--- a/docroot/modules/custom/mass_alerts/src/Form/AlertsExclusionsForm.php
+++ b/docroot/modules/custom/mass_alerts/src/Form/AlertsExclusionsForm.php
@@ -22,6 +22,13 @@ class AlertsExclusionsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config(self::CONFIG_NAME);
 
+    $instructions = [
+      $this->t('Use this configuration to disable the display on sitewide alerts on pages related to certain organizations. This affects all sitewide alerts. This does not affect organization or page based alerts.'),
+      $this->t('These orgs are stored in the database and a code change is not needed to add or remove organizations.'),
+    ];
+    $form['#prefix'] = '<div class="description">' . implode('<br>', $instructions) . '</div>';
+
+
     if ($form_state->get('initialized') !== TRUE) {
       $stored = array_values(array_unique(array_map('intval', (array) ($config->get('excluded_org_ids') ?? []))));
       $form_state->set('excluded_org_nids', $stored);

--- a/docroot/modules/custom/mass_alerts/src/Form/AlertsExclusionsForm.php
+++ b/docroot/modules/custom/mass_alerts/src/Form/AlertsExclusionsForm.php
@@ -28,7 +28,6 @@ class AlertsExclusionsForm extends ConfigFormBase {
     ];
     $form['#prefix'] = '<div class="description">' . implode('<br>', $instructions) . '</div>';
 
-
     if ($form_state->get('initialized') !== TRUE) {
       $stored = array_values(array_unique(array_map('intval', (array) ($config->get('excluded_org_ids') ?? []))));
       $form_state->set('excluded_org_nids', $stored);

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -279,7 +279,7 @@ function mass_fields_entity_base_field_info(EntityTypeInterface $entity_type) {
     ->setTranslatable(FALSE)
     ->setDisplayConfigurable('form', TRUE)
     ->setDisplayOptions('form', $options)
-    ->setDescription('If you need to publish this content but hide it from search engines, check this box. If you change the value of this checkbox, it may take multiple days for your page to be added or removed from search.');
+    ->setDescription('Content can only be hidden from search if this option is selected <strong>before</strong> the content is first published and if no links point to it. If you later uncheck this option, it may take several days for the page to appear in search results. Selecting this option after the content has already been published will not work.');
   $nosnippet = BaseFieldDefinition::create('boolean')
     ->setLabel(t('Omit snippet in search results'))
     ->setDefaultValue(FALSE)


### PR DESCRIPTION
**Description:**
Help text changes for "Exclude from search" field and Hide sitewide alerts config page.


**Jira:** (Skip unless you are MA staff)
DP-43985


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
