### PR TITLE
DP-44729: help text microsite image size

### DIFF
--- a/changelogs/DP-44729.yml
+++ b/changelogs/DP-44729.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Type:
+  - Changed: Updated help text for microsite banner image size.
+    issue: DP-44729

--- a/changelogs/DP-44729.yml
+++ b/changelogs/DP-44729.yml
@@ -36,6 +36,6 @@
 #  - description: Third change item that needs a description along with an issue.
 #    issue: DP-19843
 #
-Type:
-  - Changed: Updated help text for microsite banner image size.
+Changed:
+  - description: Updated help text for microsite banner image size.
     issue: DP-44729

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -974,7 +974,7 @@ function mass_fields_field_widget_single_element_image_image_form_alter(&$elemen
  */
 function _mass_fields_microsite_key_message_image_process($element, &$form_state, $form) {
   // Modify the help text
-  $element['#description'] = t("Recommended image size is 2560x600, with a files size that doesn't exceed 5MB. Allowed types: png, gif, jpg, jpeg. Choose a high quality, decorative image that does not need text explanation. No ALT text is provided for visitors using a screenreader. If there is any text in the image, it should be repeated within the Key Message row.");
+  $element['#description'] = t("Recommended image size is 2560x1280, with a files size that doesn't exceed 5MB. Allowed types: png, gif, jpg, jpeg. Choose a high quality, decorative image that does not need text explanation. No ALT text is provided for visitors using a screenreader. If there is any text in the image, it should be repeated within the Key Message row.");
   return $element;
 }
 


### PR DESCRIPTION
**Description:**
Help text change for microsite banner image size


**Jira:** (Skip unless you are MA staff)
DP-44729


**To Test:**
- [ ] Edit any microsite. Verify that the recommended image size is 2560x1280


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
