### PR TITLE
Release 0.466.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 
 
+## [0.466.0] - February 10, 2026
+
+### Changed
+  - DP-44710: Fix campaign video heading level skip accessibility issue on promo page section videos without titles by using H2 instead of H3 to maintain proper heading hierarchy
+  
+
+
 ## [0.465.0] - February 3, 2026
 
 ### Security

--- a/changelogs/DP-44710.yml
+++ b/changelogs/DP-44710.yml
@@ -1,0 +1,4 @@
+Changed:
+  - description: Fix campaign video heading level skip accessibility issue on promo page section videos without titles by using H2 instead of H3 to maintain proper heading hierarchy
+    issue: DP-44710
+

--- a/changelogs/DP-44710.yml
+++ b/changelogs/DP-44710.yml
@@ -1,4 +1,0 @@
-Changed:
-  - description: Fix campaign video heading level skip accessibility issue on promo page section videos without titles by using H2 instead of H3 to maintain proper heading hierarchy
-    issue: DP-44710
-

--- a/composer.lock
+++ b/composer.lock
@@ -13619,12 +13619,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "8b5fb79aeb71f01b65967b6f6e96f00077949918"
+                "reference": "3302b41542cac02832d179a9405be9b5ea7e0c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/8b5fb79aeb71f01b65967b6f6e96f00077949918",
-                "reference": "8b5fb79aeb71f01b65967b6f6e96f00077949918",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/3302b41542cac02832d179a9405be9b5ea7e0c79",
+                "reference": "3302b41542cac02832d179a9405be9b5ea7e0c79",
                 "shasum": ""
             },
             "require": {
@@ -13642,7 +13642,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-01-29T15:51:14+00:00"
+            "time": "2026-02-06T18:09:39+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/scripts/changelog-body.txt
+++ b/scripts/changelog-body.txt
@@ -1,14 +1,7 @@
 
 
-## [0.465.0] - February 3, 2026
+## [0.466.0] - February 10, 2026
 
-### Security
-  - DP-44147: Address issues flagged by nightly_pending_security workflow.
-  
-### Fixed
-  - DP-44415: Remove redundant directions link context to prevent duplicate title attributes on address contact items.
-  - DP-44561: Filter out login links that reference deleted or unpublished nodes. The LogInLinksBuilder now validates that target nodes exist and are published before including them in the login links list.
-  
 ### Changed
-  - DP-44729: Updated help text for microsite banner image size.
+  - DP-44710: Fix campaign video heading level skip accessibility issue on promo page section videos without titles by using H2 instead of H3 to maintain proper heading hierarchy
   


### PR DESCRIPTION


## [0.466.0] - February 10, 2026

### Changed
  - DP-44710: Fix campaign video heading level skip accessibility issue on promo page section videos without titles by using H2 instead of H3 to maintain proper heading hierarchy
  
