### PR TITLE
DP-45325: Updated Tugboat CLI download URL

### DIFF
--- a/.ddev/web-build/Dockerfile
+++ b/.ddev/web-build/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 # Install Tugboat CLI.
-RUN curl -L https://dashboard.tugboatqa.com/cli/linux/tugboat.tar.gz > tugboat.tar.gz && \
+RUN curl -L https://assets.tugboatqa.com/cli/linux/tugboat.tar.gz > tugboat.tar.gz && \
   tar -zxf tugboat.tar.gz -C /usr/local/bin/ && rm -f tugboat.tar.gz
 
 # Install Jira CLI.

--- a/changelogs/DP-45325.yml
+++ b/changelogs/DP-45325.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes Tugboat CLI download URL used in ddev web image.
+    issue: DP-45325


### PR DESCRIPTION
**Description:**
Updated Tugboat CLI download URL


**Jira:** (Skip unless you are MA staff)
DP-45325


**To Test:**
NOTE: Steps below destroy your local ddev instance.

- [ ] Delete ddev (`ddev delete --omit-snapshot --yes`)
- [ ] Start ddev (`ddev start`)


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
