### PR TITLE
DP-46332: Updated BacktraceRemoveProcessor to be compatible with Monolog 3

### DIFF
--- a/changelogs/DP-46332.yml
+++ b/changelogs/DP-46332.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Updated log processing class to address issues with missing and broken logs.
+    issue: DP-46332

--- a/docroot/modules/custom/mass_utility/src/Logger/Processor/BacktraceRemovalProcessor.php
+++ b/docroot/modules/custom/mass_utility/src/Logger/Processor/BacktraceRemovalProcessor.php
@@ -1,31 +1,34 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Drupal\mass_utility\Logger\Processor;
 
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+
 /**
- * Removes backtrace property, which causes infinite loop.
+ * Removes backtrace data that can bloat or recurse in log payloads.
  */
-class BacktraceRemovalProcessor {
+class BacktraceRemovalProcessor implements ProcessorInterface {
 
   /**
    * Process an individual record.
    */
-  public function __invoke($record) {
-    // Remove the backtrace from context so it doesn't cause infinite recursion.
-    if (isset($record['context']) && isset($record['context']['backtrace'])) {
-      unset($record['context']['backtrace']);
-    }
+  public function __invoke(LogRecord $record): LogRecord {
+    $context = $record->context;
 
-    if (getenv('AH_SITE_ENVIRONMENT')) {
+    // Remove the raw backtrace so it doesn't cause infinite recursion.
+    unset($context['backtrace']);
+
+    if (getenv('AH_SITE_ENVIRONMENT') && isset($context['@backtrace_string'])) {
       // Limit the backtrace in the message to N lines in Acquia environments.
       // This prevents truncation of log lines that exceed the max length.
-      if (isset($record['context']) && isset($record['context']['@backtrace_string'])) {
-        $parts = explode("\n", $record['context']['@backtrace_string']);
-        $record['context']['@backtrace_string'] = implode("\n", array_slice($parts, 0, 5));
-      }
+      $parts = explode("\n", (string) $context['@backtrace_string']);
+      $context['@backtrace_string'] = implode("\n", array_slice($parts, 0, 5));
     }
 
-    return $record;
+    return $record->with(context: $context);
   }
 
 }

--- a/docroot/modules/custom/mass_utility/tests/src/Unit/Logger/Processor/BacktraceRemovalProcessorTest.php
+++ b/docroot/modules/custom/mass_utility/tests/src/Unit/Logger/Processor/BacktraceRemovalProcessorTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mass_utility\Unit\Logger\Processor;
+
+use Drupal\mass_utility\Logger\Processor\BacktraceRemovalProcessor;
+use Drupal\Tests\UnitTestCase;
+use Monolog\Level;
+use Monolog\LogRecord;
+
+/**
+ * @coversDefaultClass \Drupal\mass_utility\Logger\Processor\BacktraceRemovalProcessor
+ * @group mass_utility
+ */
+class BacktraceRemovalProcessorTest extends UnitTestCase {
+
+  /**
+   * Tests that the raw backtrace is removed from the log context.
+   */
+  public function testBacktraceIsRemoved(): void {
+    $processor = new BacktraceRemovalProcessor();
+    $record = $this->createRecord([
+      'backtrace' => ['frame1', 'frame2'],
+      '@backtrace_string' => "one\ntwo\nthree",
+      'foo' => 'bar',
+    ]);
+
+    $processed = $processor($record);
+
+    $this->assertArrayNotHasKey('backtrace', $processed->context);
+    $this->assertSame("one\ntwo\nthree", $processed->context['@backtrace_string']);
+    $this->assertSame('bar', $processed->context['foo']);
+  }
+
+  /**
+   * Tests that the backtrace string is truncated on Acquia.
+   */
+  public function testBacktraceStringIsTrimmedOnAcquia(): void {
+    putenv('AH_SITE_ENVIRONMENT=test');
+
+    try {
+      $processor = new BacktraceRemovalProcessor();
+      $record = $this->createRecord([
+        '@backtrace_string' => "one\ntwo\nthree\nfour\nfive\nsix\nseven",
+      ]);
+
+      $processed = $processor($record);
+
+      $this->assertSame("one\ntwo\nthree\nfour\nfive", $processed->context['@backtrace_string']);
+    }
+    finally {
+      putenv('AH_SITE_ENVIRONMENT');
+    }
+  }
+
+  /**
+   * Tests that the backtrace string is unchanged off Acquia.
+   */
+  public function testBacktraceStringIsUnchangedOutsideAcquia(): void {
+    putenv('AH_SITE_ENVIRONMENT');
+
+    $processor = new BacktraceRemovalProcessor();
+    $record = $this->createRecord([
+      '@backtrace_string' => "one\ntwo\nthree\nfour\nfive\nsix\nseven",
+    ]);
+
+    $processed = $processor($record);
+
+    $this->assertSame(
+      "one\ntwo\nthree\nfour\nfive\nsix\nseven",
+      $processed->context['@backtrace_string'],
+    );
+  }
+
+  /**
+   * Creates a log record for testing.
+   */
+  private function createRecord(array $context): LogRecord {
+    return new LogRecord(
+      datetime: new \DateTimeImmutable(),
+      channel: 'test',
+      level: Level::Info,
+      message: 'Test message',
+      context: $context,
+      extra: [],
+    );
+  }
+
+}


### PR DESCRIPTION
**Description:**
Updated BacktraceRemoveProcessor to be compatible with Monolog 3. Details in ticket.


**Jira:** (Skip unless you are MA staff)
DP-46332


**To Test:**
- [ ] Automated tests pass


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
