### PR TITLE
feature/DP-46633-Threads-social-media-icon-not-rendering-on-MassDOT-org-page

### DIFF
--- a/changelogs/DP-46633.yml
+++ b/changelogs/DP-46633.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Ensure Threads social media icons render for both threads.com and threads.net URLs on organization pages.
+    issue: DP-46633

--- a/docroot/modules/custom/mayflower/mayflower.module
+++ b/docroot/modules/custom/mayflower/mayflower.module
@@ -734,6 +734,7 @@ function mayflower_preprocess_field__node__field_social_links(&$variables) {
     'x.com' => 'x-logo',
     'facebook.com' => 'facebook-logo',
     'threads.net' => 'threads-logo',
+    'threads.com' => 'threads-logo',
     'flickr.com' => 'flickr-logo',
     'blog' => 'blog',
     'linkedin.com' => 'linkedin-logo',

--- a/docroot/modules/custom/mayflower/src/Prepare/Molecules.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Molecules.php
@@ -296,6 +296,7 @@ class Molecules {
       'x.com' => 'x-logo',
       'facebook.com' => 'facebook-logo',
       'threads.net' => 'threads-logo',
+      'threads.com' => 'threads-logo',
       'flickr.com' => 'flickr-logo',
       'linkedin.com' => 'linkedin-logo',
       'instagram.com' => 'instagram-logo',


### PR DESCRIPTION
Ensure Threads social media icons render for both threads.com and threads.net URLs on organization pages