### PR TITLE
DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android

### DIFF
--- a/changelogs/DP-46594.yml
+++ b/changelogs/DP-46594.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Updates Mayflower artifacts to fix the global menu drawer edge showing through the translate modal on Android.
+    issue: DP-46594

--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-patternlab/DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c13813cd7c0c9cc9b986fa6589dbc8f",
+    "content-hash": "2a35f45529a831e3c4c8974298489846",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14001,16 +14001,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-patternlab/DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "9d785ff05c69001d49b3e9ee3ea756de7b5c9a35"
+                "reference": "8f3a98778c268e2f567b95a1ca58fc8999e2faf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/9d785ff05c69001d49b3e9ee3ea756de7b5c9a35",
-                "reference": "9d785ff05c69001d49b3e9ee3ea756de7b5c9a35",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/8f3a98778c268e2f567b95a1ca58fc8999e2faf5",
+                "reference": "8f3a98778c268e2f567b95a1ca58fc8999e2faf5",
                 "shasum": ""
             },
             "require": {
@@ -14028,7 +14028,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-05-18T19:02:26+00:00"
+            "time": "2026-05-19T06:34:57+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a35f45529a831e3c4c8974298489846",
+    "content-hash": "3c13813cd7c0c9cc9b986fa6589dbc8f",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14001,16 +14001,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-46594-Fix-global-menu-overlap-on-translate-module-on-Android",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "a6da75216bf62658aedf18a739e98e32081c5de7"
+                "reference": "f9b14299f4b58762d22d13e4cbf4550b64b1a302"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a6da75216bf62658aedf18a739e98e32081c5de7",
-                "reference": "a6da75216bf62658aedf18a739e98e32081c5de7",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f9b14299f4b58762d22d13e4cbf4550b64b1a302",
+                "reference": "f9b14299f4b58762d22d13e4cbf4550b64b1a302",
                 "shasum": ""
             },
             "require": {
@@ -14028,7 +14028,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-05-12T06:28:25+00:00"
+            "time": "2026-05-18T16:30:10+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -14005,12 +14005,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "f9b14299f4b58762d22d13e4cbf4550b64b1a302"
+                "reference": "9d785ff05c69001d49b3e9ee3ea756de7b5c9a35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/f9b14299f4b58762d22d13e4cbf4550b64b1a302",
-                "reference": "f9b14299f4b58762d22d13e4cbf4550b64b1a302",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/9d785ff05c69001d49b3e9ee3ea756de7b5c9a35",
+                "reference": "9d785ff05c69001d49b3e9ee3ea756de7b5c9a35",
                 "shasum": ""
             },
             "require": {
@@ -14028,7 +14028,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-05-18T16:30:10+00:00"
+            "time": "2026-05-18T19:02:26+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Fix translate modal overlap with global menu on Android.

[Mayflower PR](https://github.com/massgov/mayflower/pull/2071)
[Jira Ticket](https://massgov.atlassian.net/browse/DP-46594)