### PR TITLE
DP-44689-Update-decision-tree-disclaimer-icon

### DIFF
--- a/changelogs/DP-44689.yml
+++ b/changelogs/DP-44689.yml
@@ -1,0 +1,3 @@
+Changed:
+  - description: Use the info icon and standard callout spacing for the decision tree disclaimer.
+    issue: DP-44689

--- a/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
+++ b/docroot/modules/custom/mass_decision_tree/css/mass_decision_tree.css
@@ -122,7 +122,7 @@
 @media (min-width: 621px) {
   .ma__decision-tree-post .ma__callout-alert__content {
     padding: 20px;
-    padding-left: 94px;
+    padding-left: 72px;
   }
 }
 

--- a/docroot/themes/custom/mass_theme/templates/content/node--decision-tree.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/node--decision-tree.html.twig
@@ -225,7 +225,7 @@
             <section class="ma__callout-alert">
               <div class="ma__callout-alert__content">
                 <div class="ma__callout-alert__icon">
-                  {{ icon('chat', '36px', '36px', null, false) }}
+                  {{ icon('info') }}
                 </div>
                 <div class="ma__callout-alert__link">
                   {{ disclaimer }}


### PR DESCRIPTION
 Use the info icon and standard callout spacing for the decision tree disclaimer.