### PR TITLE
DP-47095-Non-admins-should-not-see-or-edit-approval-fields-in-user-profile

### DIFF
--- a/changelogs/DP-47095.yml
+++ b/changelogs/DP-47095.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Restrict user approval fields to users with administer users permission.
+    issue: DP-47095

--- a/docroot/modules/custom/mass_org_access/README.md
+++ b/docroot/modules/custom/mass_org_access/README.md
@@ -88,7 +88,7 @@ OOP hooks (Drupal 11.3+ `#[Hook(...)]`) in `src/Hook/MassOrgAccessHooks.php`.
 | Hook | Behavior |
 |------|----------|
 | `node_access` / `media_access` | The access decision above. |
-| `entity_field_access` | Locks `field_user_org` to `administer users` (prevents self-promotion). Permission Groups itself is not field-restricted. |
+| `entity_field_access` | Locks `field_user_org` edit to `administer users` (prevents self-promotion). Locks `field_approved` and `field_approval_notes` view/edit to `administer users`. Permission Groups itself is not field-restricted. |
 | `entity_prepare_form` | On new entities only: pre-fills `field_content_organization` from the creator's `field_user_org` + ancestors. Existing entities are populated exclusively by `drush moab`. |
 | `form_node_form_alter` | Adds `validateOrgAccess` callback (static method — closures break paragraphs AJAX). Defense-in-depth: surfaces an error if a save reaches form validation despite `node_access` already denying it. |
 | `field_widget_complete_form_alter` | Renders Permission Groups as a read-only list (see widget section). Attaches both JS libraries. |
@@ -157,7 +157,9 @@ Authors and editors maintain optional profile fields:
 | `field_default_labels` | label terms pre-filled on **new** pages/documents |
 
 `field_user_org` (Permission Groups on the user) remains **admin-only**
-via `entity_field_access`. Authors edit defaults on their own profile.
+via `entity_field_access`. `field_approved` and `field_approval_notes` are
+also restricted to users with `administer users` (view and edit). Authors
+edit defaults on their own profile.
 
 **New content only** (`entity_prepare_form` when `$entity->isNew()`):
 

--- a/docroot/modules/custom/mass_org_access/src/Hook/MassOrgAccessHooks.php
+++ b/docroot/modules/custom/mass_org_access/src/Hook/MassOrgAccessHooks.php
@@ -53,24 +53,32 @@ class MassOrgAccessHooks {
   }
 
   /**
-   * Locks field_user_org to users with `administer users`.
+   * Restricts sensitive user profile fields to `administer users`.
    *
-   * Prevents an editor from self-assigning organizations on
-   * `/user/UID/edit`. View access stays neutral so editors can still
-   * see the org listed on user pages. field_content_organization is
-   * not restricted here — anyone who can edit the host entity may edit
-   * the widget.
+   * - field_user_org: edit only (editors may still view their org).
+   * - field_approved / field_approval_notes: view and edit (access managers only).
    */
   #[Hook('entity_field_access')]
   public function entityFieldAccess(string $operation, FieldDefinitionInterface $field, AccountInterface $account, ?FieldItemListInterface $items = NULL): AccessResultInterface {
-    if ($field->getName() !== 'field_user_org') {
+    if ($field->getTargetEntityTypeId() !== 'user') {
       return AccessResult::neutral();
     }
-    if ($operation === 'view') {
-      return AccessResult::neutral();
+
+    $field_name = $field->getName();
+    if ($field_name === 'field_user_org') {
+      if ($operation === 'view') {
+        return AccessResult::neutral();
+      }
+      return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
+        ->cachePerPermissions();
     }
-    return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
-      ->cachePerPermissions();
+
+    if (in_array($field_name, ['field_approved', 'field_approval_notes'], TRUE)) {
+      return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
+        ->cachePerPermissions();
+    }
+
+    return AccessResult::neutral();
   }
 
   /**

--- a/docroot/modules/custom/mass_org_access/tests/src/ExistingSite/UserApprovalFieldAccessTest.php
+++ b/docroot/modules/custom/mass_org_access/tests/src/ExistingSite/UserApprovalFieldAccessTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mass_org_access\ExistingSite;
+
+use MassGov\Dtt\MassExistingSiteBase;
+
+/**
+ * Verifies user approval fields are restricted to access managers.
+ *
+ * @group mass_org_access
+ */
+class UserApprovalFieldAccessTest extends MassExistingSiteBase {
+
+  /**
+   * Editors must not see or edit user approval fields on their profile.
+   */
+  public function testEditorCannotAccessApprovalFields(): void {
+    $editor = $this->createUser();
+    $editor->addRole('editor');
+    $editor->set('field_approved', TRUE);
+    $editor->set('field_approval_notes', 'Approved by access manager.');
+    $editor->activate();
+    $editor->save();
+
+    foreach (['view', 'edit'] as $operation) {
+      $this->assertFalse(
+        $editor->get('field_approved')->access($operation, $editor),
+        "An editor must not {$operation} field_approved."
+      );
+      $this->assertFalse(
+        $editor->get('field_approval_notes')->access($operation, $editor),
+        "An editor must not {$operation} field_approval_notes."
+      );
+    }
+  }
+
+  /**
+   * Users with administer users can manage user approval fields.
+   */
+  public function testAdminCanAccessApprovalFields(): void {
+    $user_manager = $this->createUser(['administer users']);
+    $editor = $this->createUser();
+    $editor->addRole('editor');
+    $editor->set('field_approved', TRUE);
+    $editor->set('field_approval_notes', 'Approved by access manager.');
+    $editor->activate();
+    $editor->save();
+
+    foreach (['view', 'edit'] as $operation) {
+      $this->assertTrue(
+        $editor->get('field_approved')->access($operation, $user_manager),
+        "A user with administer users must be able to {$operation} field_approved."
+      );
+      $this->assertTrue(
+        $editor->get('field_approval_notes')->access($operation, $user_manager),
+        "A user with administer users must be able to {$operation} field_approval_notes."
+      );
+    }
+  }
+
+}

--- a/docroot/themes/custom/mass_admin_theme/css/components/user-form.css
+++ b/docroot/themes/custom/mass_admin_theme/css/components/user-form.css
@@ -1,3 +1,15 @@
 .user-form fieldset:not(.fieldgroup) {
   background-color: #f2f2f2;
 }
+
+/*
+ * Editors do not see approval fields; picture is followed by language settings.
+ * Match language → locale spacing (adjacent claro-details), not field--type padding.
+ */
+.user-form #edit-user-picture-wrapper:has(+ #edit-language) {
+  padding-bottom: 0;
+}
+
+.user-form #edit-user-picture-wrapper:has(+ #edit-language) .claro-details {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Restrict user profile approval fields so only administrators can view or edit them.