### PR TITLE
DP-47095-Non-admins-should-not-see-or-edit-approval-fields-in-user-profile-develop

### DIFF
--- a/changelogs/DP-47095.yml
+++ b/changelogs/DP-47095.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Restrict user approval fields to users with administer users permission and normalize editor profile form spacing after the fields are hidden.
+    issue: DP-47095

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -740,6 +740,16 @@ function mass_fields_paragraph_view(array &$build, EntityInterface $entity, Enti
  * Implements hook_entity_field_access().
  */
 function mass_fields_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL) {
+  // User approval fields are for access managers only.
+  if ($field_definition->getTargetEntityTypeId() === 'user') {
+    switch ($field_definition->getName()) {
+      case 'field_approved':
+      case 'field_approval_notes':
+        return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
+          ->cachePerPermissions();
+    }
+  }
+
   // This is being used to hide the custom HTML field from all roles without permission.
   // At this point only Admin have access.
   if ($operation === 'edit') {

--- a/docroot/modules/custom/mass_fields/mass_fields.module
+++ b/docroot/modules/custom/mass_fields/mass_fields.module
@@ -740,16 +740,6 @@ function mass_fields_paragraph_view(array &$build, EntityInterface $entity, Enti
  * Implements hook_entity_field_access().
  */
 function mass_fields_entity_field_access($operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL) {
-  // User approval fields are for access managers only.
-  if ($field_definition->getTargetEntityTypeId() === 'user') {
-    switch ($field_definition->getName()) {
-      case 'field_approved':
-      case 'field_approval_notes':
-        return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
-          ->cachePerPermissions();
-    }
-  }
-
   // This is being used to hide the custom HTML field from all roles without permission.
   // At this point only Admin have access.
   if ($operation === 'edit') {

--- a/docroot/modules/custom/mass_fields/mass_fields.services.yml
+++ b/docroot/modules/custom/mass_fields/mass_fields.services.yml
@@ -1,4 +1,9 @@
 services:
+  mass_fields.hooks:
+    class: Drupal\mass_fields\Hook\MassFieldsHooks
+    tags:
+      - { name: drupal.hook }
+
   mass_fields.route_subscriber:
     class: Drupal\mass_fields\Routing\AutocompleteRouteSubscriber
     tags:

--- a/docroot/modules/custom/mass_fields/src/Hook/MassFieldsHooks.php
+++ b/docroot/modules/custom/mass_fields/src/Hook/MassFieldsHooks.php
@@ -19,7 +19,7 @@ class MassFieldsHooks {
    *
    * This hook class intentionally handles only the DP-47095 fields:
    * - field_approved
-   * - field_approval_notes
+   * - field_approval_notes.
    */
   #[Hook('entity_field_access')]
   public function entityFieldAccess(string $operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL): AccessResultInterface {

--- a/docroot/modules/custom/mass_fields/src/Hook/MassFieldsHooks.php
+++ b/docroot/modules/custom/mass_fields/src/Hook/MassFieldsHooks.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\mass_fields\Hook;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * OOP hook implementations for DP-47095 user approval field access.
+ */
+class MassFieldsHooks {
+
+  /**
+   * Restricts user approval fields to access managers.
+   *
+   * This hook class intentionally handles only the DP-47095 fields:
+   * - field_approved
+   * - field_approval_notes
+   */
+  #[Hook('entity_field_access')]
+  public function entityFieldAccess(string $operation, FieldDefinitionInterface $field_definition, AccountInterface $account, ?FieldItemListInterface $items = NULL): AccessResultInterface {
+    if ($operation !== 'edit' && $operation !== 'view') {
+      return AccessResult::neutral();
+    }
+
+    // User approval fields are for access managers only.
+    if ($field_definition->getTargetEntityTypeId() === 'user') {
+      switch ($field_definition->getName()) {
+        case 'field_approved':
+        case 'field_approval_notes':
+          return AccessResult::forbiddenIf(!$account->hasPermission('administer users'))
+            ->cachePerPermissions();
+      }
+    }
+
+    return AccessResult::neutral();
+  }
+
+}

--- a/docroot/modules/custom/mass_fields/tests/src/ExistingSite/UserApprovalFieldAccessTest.php
+++ b/docroot/modules/custom/mass_fields/tests/src/ExistingSite/UserApprovalFieldAccessTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mass_fields\ExistingSite;
+
+use MassGov\Dtt\MassExistingSiteBase;
+
+/**
+ * Verifies user approval fields are restricted to access managers.
+ *
+ * @group mass_fields
+ */
+class UserApprovalFieldAccessTest extends MassExistingSiteBase {
+
+  /**
+   * Editors must not see or edit user approval fields on their profile.
+   */
+  public function testEditorCannotAccessApprovalFields(): void {
+    $editor = $this->createUser();
+    $editor->addRole('editor');
+    $editor->set('field_approved', TRUE);
+    $editor->set('field_approval_notes', 'Approved by access manager.');
+    $editor->activate();
+    $editor->save();
+
+    foreach (['view', 'edit'] as $operation) {
+      $this->assertFalse(
+        $editor->get('field_approved')->access($operation, $editor),
+        "An editor must not {$operation} field_approved."
+      );
+      $this->assertFalse(
+        $editor->get('field_approval_notes')->access($operation, $editor),
+        "An editor must not {$operation} field_approval_notes."
+      );
+    }
+  }
+
+  /**
+   * Users with administer users can manage user approval fields.
+   */
+  public function testAdminCanAccessApprovalFields(): void {
+    $user_manager = $this->createUser(['administer users']);
+    $editor = $this->createUser();
+    $editor->addRole('editor');
+    $editor->set('field_approved', TRUE);
+    $editor->set('field_approval_notes', 'Approved by access manager.');
+    $editor->activate();
+    $editor->save();
+
+    foreach (['view', 'edit'] as $operation) {
+      $this->assertTrue(
+        $editor->get('field_approved')->access($operation, $user_manager),
+        "A user with administer users must be able to {$operation} field_approved."
+      );
+      $this->assertTrue(
+        $editor->get('field_approval_notes')->access($operation, $user_manager),
+        "A user with administer users must be able to {$operation} field_approval_notes."
+      );
+    }
+  }
+
+}

--- a/docroot/themes/custom/mass_admin_theme/css/components/user-form.css
+++ b/docroot/themes/custom/mass_admin_theme/css/components/user-form.css
@@ -1,3 +1,15 @@
 .user-form fieldset:not(.fieldgroup) {
   background-color: #f2f2f2;
 }
+
+/*
+ * Editors do not see approval fields, so picture settings can sit directly above
+ * language settings. Normalize spacing to match other sections.
+ */
+.user-form #edit-user-picture-wrapper:has(+ #edit-language) {
+  padding-bottom: 0;
+}
+
+.user-form #edit-user-picture-wrapper:has(+ #edit-language) .claro-details {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Restrict user approval fields to users with administer users permission and normalize editor profile form spacing after the fields are hidden.