### PR TITLE
DP-47348-Remove-horizontal-green-line-from-H3-and-H4-in-rich-text-editor

### DIFF
--- a/changelogs/DP-47348.yml
+++ b/changelogs/DP-47348.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Remove green decorative underline from H3 and H4 in the rich text editor so editor preview matches the published page.
+    issue: DP-47348

--- a/docroot/themes/custom/mass_theme/overrides/css/ckeditor.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/ckeditor.css
@@ -138,16 +138,12 @@
   flex-wrap: wrap;
 }
 
-.ck-content h2,
-.ck-content h3,
-.ck-content h4 {
+.ck-content h2 {
   position: relative;
   padding-bottom: 15px;
 }
 
-.ck-content h2:after,
-.ck-content h3:after,
-.ck-content h4:after {
+.ck-content h2:after {
   content: "";
   height: 3px;
   position: absolute;


### PR DESCRIPTION
 Remove green decorative underline from H3 and H4 in the rich text editor so editor preview matches the published page.