### PR TITLE
DP-45281-Buttons-look-too-narrow-and-tall

### DIFF
--- a/changelogs/DP-45281.yml
+++ b/changelogs/DP-45281.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Pin mayflower-artifacts for DP-45281 so info-details callout link buttons use 5-of-12 width in the narrow content column instead of the action-finder three-up grid.
+    issue: DP-45281

--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-45281-Buttons-look-narrow-and-tall",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50da811ad7b731dbf64872317f703abd",
+    "content-hash": "f1186efccb03b54943bed4b76a72d196",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14008,16 +14008,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-45281-Buttons-look-narrow-and-tall",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "85f63ece10978e8cdb49bc3e12c00c1f48ed02cf"
+                "reference": "79443c44781637e32c7406bb6f84523ece12c411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/85f63ece10978e8cdb49bc3e12c00c1f48ed02cf",
-                "reference": "85f63ece10978e8cdb49bc3e12c00c1f48ed02cf",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/79443c44781637e32c7406bb6f84523ece12c411",
+                "reference": "79443c44781637e32c7406bb6f84523ece12c411",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-15T21:36:27+00:00"
+            "time": "2026-06-17T19:47:11+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
adjust width for a single callout link in rich-text action-finder so the button is not sized for a three-up grid.

[JIRA](https://massgov.atlassian.net/browse/DP-45281)
[Mayflower](https://github.com/massgov/mayflower/pull/2078)