### PR TITLE
DP-41032-Highlight-and-callout-are-too-close-together-vertically

### DIFF
--- a/changelogs/DP-41032.yml
+++ b/changelogs/DP-41032.yml
@@ -1,0 +1,3 @@
+Fixed:
+  - description: Pin mayflower artifact to add spacing between Highlight and callout components in rich text.
+    issue: DP-41032

--- a/changelogs/DP-41032.yml
+++ b/changelogs/DP-41032.yml
@@ -1,3 +1,3 @@
 Fixed:
-  - description: Pin mayflower artifact to add spacing between Highlight and callout components in rich text.
+  - description: Pin mayflower artifact to add vertical spacing for Highlight and callout components in rich text.
     issue: DP-41032

--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-assets/DP-41032-Highlight-and-callout-are-too-close-together-vertically",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.json
+++ b/composer.json
@@ -296,7 +296,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-assets/DP-41032-Highlight-and-callout-are-too-close-together-vertically",
+        "massgov/mayflower-artifacts": "dev-develop",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.lock
+++ b/composer.lock
@@ -14012,12 +14012,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0"
+                "reference": "882fcd5844f47a5727e776ca9907b72539491c7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
-                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/882fcd5844f47a5727e776ca9907b72539491c7f",
+                "reference": "882fcd5844f47a5727e776ca9907b72539491c7f",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-22T20:09:17+00:00"
+            "time": "2026-06-23T18:07:36+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -14012,12 +14012,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "15539673a301ebf85bad77f524af49438995c9d8"
+                "reference": "594d9969bea35be7abab1055212a513fc4ff9a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/15539673a301ebf85bad77f524af49438995c9d8",
-                "reference": "15539673a301ebf85bad77f524af49438995c9d8",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/594d9969bea35be7abab1055212a513fc4ff9a5c",
+                "reference": "594d9969bea35be7abab1055212a513fc4ff9a5c",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-22T20:09:09+00:00"
+            "time": "2026-06-24T06:22:47+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eae1d9d549c903e7269be28599130686",
+    "content-hash": "7124dee40cc1fec8ccaaa7a8c4bda360",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14008,16 +14008,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-assets/DP-41032-Highlight-and-callout-are-too-close-together-vertically",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0"
+                "reference": "15539673a301ebf85bad77f524af49438995c9d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
-                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/15539673a301ebf85bad77f524af49438995c9d8",
+                "reference": "15539673a301ebf85bad77f524af49438995c9d8",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-22T20:09:17+00:00"
+            "time": "2026-06-22T20:09:09+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7124dee40cc1fec8ccaaa7a8c4bda360",
+    "content-hash": "eae1d9d549c903e7269be28599130686",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14008,16 +14008,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-assets/DP-41032-Highlight-and-callout-are-too-close-together-vertically",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "a761547d6e9bc930aa917a25a86e19664a1c6cdf"
+                "reference": "23a76d9f3825d5b37aaf4cceca04304c19c63fd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/a761547d6e9bc930aa917a25a86e19664a1c6cdf",
-                "reference": "a761547d6e9bc930aa917a25a86e19664a1c6cdf",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/23a76d9f3825d5b37aaf4cceca04304c19c63fd7",
+                "reference": "23a76d9f3825d5b37aaf4cceca04304c19c63fd7",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-17T13:36:13+00:00"
+            "time": "2026-06-22T19:51:18+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -25831,5 +25831,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -14012,12 +14012,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "23a76d9f3825d5b37aaf4cceca04304c19c63fd7"
+                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/23a76d9f3825d5b37aaf4cceca04304c19c63fd7",
-                "reference": "23a76d9f3825d5b37aaf4cceca04304c19c63fd7",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
+                "reference": "edefbfbbc75e2da1c27a1ea121dbb288fd2995e0",
                 "shasum": ""
             },
             "require": {
@@ -14035,7 +14035,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-06-22T19:51:18+00:00"
+            "time": "2026-06-22T20:09:17+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/docroot/themes/custom/mass_theme/overrides/css/info-details-richtext.css
+++ b/docroot/themes/custom/mass_theme/overrides/css/info-details-richtext.css
@@ -22,17 +22,8 @@
 /* .ma__action-finder__items */
 
 .ma__rich-text .ma__action-finder__items {
-  margin-top: 21.75px;
-  margin-bottom: 1.75px;
-  margin-top: 1.5rem;
-  margin-bottom: calc(1.5rem - 20px);
-}
-
-@media (min-width: 621px) {
-  .ma__rich-text .ma__action-finder__items {
-    margin-top: 1.75rem;
-    margin-bottom: calc(1.75rem - 20px);
-  }
+  margin-top: 0;
+  margin-bottom: 0;
 }
 
 .ma__rich-text .ma__action-finder__items:not(.ma__action-finder__items--all) {


### PR DESCRIPTION
Pin mayflower artifact to add spacing between Highlight and callout components in rich text.

[Jira](https://massgov.atlassian.net/browse/DP-41032)
[Mayflower](https://github.com/massgov/mayflower/pull/2080)