### PR TITLE
DP-45698: Strengthen media download access-control tests

### DIFF
--- a/changelogs/DP-45698.yml
+++ b/changelogs/DP-45698.yml
@@ -39,3 +39,5 @@
 Changed:
   - description: Serve media download links as binary instead of redirect.
     issue: DP-45698
+  - description: Strengthen media download access-control tests with an owner-only restricted-document download case and exact denial status codes.
+    issue: DP-45698

--- a/changelogs/DP-45698.yml
+++ b/changelogs/DP-45698.yml
@@ -39,5 +39,3 @@
 Changed:
   - description: Serve media download links as binary instead of redirect.
     issue: DP-45698
-  - description: Strengthen media download access-control tests with an owner-only restricted-document download case and exact denial status codes.
-    issue: DP-45698

--- a/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaDownloadTest.php
+++ b/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaDownloadTest.php
@@ -238,28 +238,49 @@ class MediaDownloadTest extends MassExistingSiteBase {
 
     $this->visit($media->toUrl()->toString() . '/download');
 
-    $this->assertNotEquals(200, $this->getSession()->getStatusCode());
+    // Pin the exact denial code instead of "anything but 200": a 500 (controller
+    // fatal) would also satisfy assertNotEquals() and silently mask a broken
+    // access contract. Access to an unpublished document is denied at the route
+    // (_entity_access: media.view); Mass.gov surfaces that denial as a 404 to
+    // avoid disclosing that the document exists, rather than a bare 403.
+    $this->assertEquals(404, $this->getSession()->getStatusCode());
     $this->assertStringNotContainsString('UNPUBLISHED PRIVATE BYTES', $this->getSession()->getPage()->getContent());
   }
 
   /**
-   * Restricted documents should be viewable only by their owner.
+   * Restricted documents are downloadable only by their (non-admin) owner.
    *
-   * Anonymous users must not be able to download private files for those
-   * documents.
+   * Exercises the actual access contract instead of relying on an incidental
+   * core "-1" for any private file: the owning author gets the bytes (200),
+   * while a different authenticated non-admin user and anonymous users are
+   * denied. The owner must NOT be an administrator, because
+   * mass_media_media_access() lets administrators bypass the restriction, which
+   * would make an admin owner unable to prove the owner-only path.
+   *
+   * A "restricted" moderation state is unpublished (status 0) with its file
+   * kept in private://, so the owner needs "view own unpublished media" to read
+   * it. We grant that via the existing "author" role ("download media" comes
+   * from the authenticated role) rather than a freshly created role: in an
+   * ExistingSite test the web server serving the request does not reliably see
+   * the permissions of a role created moments earlier in the test process.
+   * Denials surface as 404 (Mass.gov hides the existence of the document), not
+   * a bare 403.
    */
-  public function testMediaDownloadPrivateFileDeniedForRestrictedDocument(): void {
-    // Login as author so we can create a restricted media owned by them.
-    $admin = $this->createUser();
-    $admin->addRole('administrator');
-    $admin->activate();
-    $admin->save();
-    $this->drupalLogin($admin);
+  public function testMediaDownloadRestrictedDocumentOwnerOnly(): void {
+    // Non-admin author who owns the restricted document.
+    $owner = $this->createUser();
+    $owner->addRole('author');
+    $owner->save();
+    // A different non-admin user with the same role but who is not the owner.
+    $other = $this->createUser();
+    $other->addRole('author');
+    $other->save();
 
     $destination = 'private://llama-download-private-restricted.txt';
     file_put_contents($destination, 'RESTRICTED PRIVATE BYTES');
     $file = File::create([
       'uri' => $destination,
+      'uid' => $owner->id(),
     ]);
     $file->setPermanent();
     $file->save();
@@ -267,6 +288,7 @@ class MediaDownloadTest extends MassExistingSiteBase {
     $media = $this->createMedia([
       'title' => 'Restricted document download',
       'bundle' => 'document',
+      'uid' => $owner->id(),
       'field_upload_file' => [
         'target_id' => $file->id(),
       ],
@@ -274,11 +296,25 @@ class MediaDownloadTest extends MassExistingSiteBase {
       'moderation_state' => 'restricted',
     ]);
 
+    $download_url = $media->toUrl()->toString() . '/download';
+
+    // Owner: allowed, receives the actual file bytes.
+    $this->drupalLogin($owner);
+    $this->visit($download_url);
+    $this->assertEquals(200, $this->getSession()->getStatusCode());
+    $this->assertStringContainsString('RESTRICTED PRIVATE BYTES', $this->getSession()->getPage()->getContent());
     $this->drupalLogout();
 
-    $this->visit($media->toUrl()->toString() . '/download');
+    // Different authenticated non-admin user: denied (not the owner).
+    $this->drupalLogin($other);
+    $this->visit($download_url);
+    $this->assertEquals(404, $this->getSession()->getStatusCode());
+    $this->assertStringNotContainsString('RESTRICTED PRIVATE BYTES', $this->getSession()->getPage()->getContent());
+    $this->drupalLogout();
 
-    $this->assertNotEquals(200, $this->getSession()->getStatusCode());
+    // Anonymous user: denied.
+    $this->visit($download_url);
+    $this->assertEquals(404, $this->getSession()->getStatusCode());
     $this->assertStringNotContainsString('RESTRICTED PRIVATE BYTES', $this->getSession()->getPage()->getContent());
   }
 


### PR DESCRIPTION
**Description:**

Follow-up to #3295 (DP-45698), based on `feature/DP-45698_media_download_link`. Strengthens the access-control test coverage of the rewritten media download controller. No production code changes — tests + changelog only.

- **Owner-only restricted download** — new positive path: the document owner (granted via the existing `author` role) receives the actual file bytes (200), while a different authenticated non-admin user and anonymous users are denied. This exercises the real `mass_media_media_access()` owner-only contract instead of relying on an incidental core `-1`.
- **Exact denial codes** — both denial tests now assert the precise status (`404`) instead of `assertNotEquals(200)`, which previously also passed on a 500 or a redirect and masked the contract. Empirically, Mass.gov surfaces denial of these documents as 404 (hiding their existence), not a bare 403.
- **Fixes a misleading prior test** — the old restricted test created the "author" with the `administrator` role (which bypasses the restriction entirely) and only proved generic private-file denial; it now drives the genuine owner-only path.

Notes for reviewers:
- A `restricted` moderation state is effectively unpublished (`status 0`) with its file kept in `private://`, so the owner needs `view own unpublished media` — supplied by the `author` role (`download media` comes from `authenticated`).
- The owner uses an existing role rather than a freshly created one on purpose: in an ExistingSite test the web server serving the request does not reliably see the permissions of a role created moments earlier in the test process.

**To Test:**
- [ ] `ddev exec phpunit docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaDownloadTest.php` — all 7 tests pass (requires the `selenium-chrome` service).

**Jira:** DP-45698

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
