### PR TITLE
DP-47970-Editoria11y-Incorrectly-Flags-Related-Organization-Logos-as-Missing-Alt-Text

### DIFF
--- a/changelogs/DP-47970.yml
+++ b/changelogs/DP-47970.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Editoria11y no longer flags Related Organizations logos as missing alt text.
+    issue: DP-47970

--- a/conf/drupal/config/editoria11y.settings.yml
+++ b/conf/drupal/config/editoria11y.settings.yml
@@ -4,7 +4,7 @@ content_root: ''
 assertiveness: assertive
 no_load: ''
 ignore_all_if_absent: ''
-ignore_elements: '.ma__location-banner__image *, .ma__suggested-pages__item img, #location-listing-results img, .ma__personal-message__container .ma__image-promo__image img, .ma__key-message__inline-image img, .ma__details__content .ma__image-promos img.ma__image, .ma__card__img.ma__card__img--vertical img, .js-location-listing-link .ma__image-promo__image *, .user-login *, .dt-scroll-footInner table, h3.ma__collapsible-header, .ma__header-alerts__container h3, a[href^="mailto:"], .leaflet-pane.leaflet-tile-pane img, .ma__inline-links ul *, .ma__decision-tree-node a.start, .ma__press-listing__more a.ma__content-link--chevron, .popover__title'
+ignore_elements: '.ma__location-banner__image *, .ma__suggested-pages__item img, #location-listing-results img, .ma__personal-message__container .ma__image-promo__image img, .ma__key-message__inline-image img, .ma__details__content .ma__image-promos img.ma__image, .ma__card__img.ma__card__img--vertical img, .js-location-listing-link .ma__image-promo__image *, .user-login *, .dt-scroll-footInner table, h3.ma__collapsible-header, .ma__header-alerts__container h3, a[href^="mailto:"], .leaflet-pane.leaflet-tile-pane img, .ma__inline-links ul *, .ma__decision-tree-node a.start, .ma__press-listing__more a.ma__content-link--chevron, .popover__title, .ma__our-organizations img'
 panel_no_cover: ''
 embedded_content_warning: ''
 download_links: 'false'


### PR DESCRIPTION
Editoria11y no longer flags Related Organizations logos as missing alt text.