### PR TITLE
DP-47987: Skip and log when file being moved is a directory

### DIFF
--- a/changelogs/DP-47987.yml
+++ b/changelogs/DP-47987.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Added check for whether file is a directory before attemping file move.
+    issue: DP-47987

--- a/docroot/modules/custom/mass_bulk_file_replace/src/FilenameMediaMatchTrait.php
+++ b/docroot/modules/custom/mass_bulk_file_replace/src/FilenameMediaMatchTrait.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\mass_bulk_file_replace;
 
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\file\FileInterface;
+
 trait FilenameMediaMatchTrait {
 
   /**
@@ -53,6 +56,24 @@ trait FilenameMediaMatchTrait {
     return $uploaded_base !== ''
       && $existing_base !== ''
       && str_starts_with($uploaded_base, $existing_base);
+  }
+
+  /**
+   * Checks whether a file move should be skipped because the source is a directory.
+   */
+  protected static function skipDirectoryFileMove(FileInterface $file, FileSystemInterface $file_system, string $context): bool {
+    $uri = $file->getFileUri();
+    $realpath = $file_system->realpath($uri);
+    if ($realpath !== FALSE && is_dir($realpath)) {
+      \Drupal::logger('mass_bulk_file_replace')->warning('Skipped @context move for file entity @fid because @uri resolves to a directory.', [
+        '@context' => $context,
+        '@fid' => $file->id(),
+        '@uri' => $uri,
+      ]);
+      return TRUE;
+    }
+
+    return FALSE;
   }
 
 }

--- a/docroot/modules/custom/mass_bulk_file_replace/src/Form/ReplaceMismatchForm.php
+++ b/docroot/modules/custom/mass_bulk_file_replace/src/Form/ReplaceMismatchForm.php
@@ -215,6 +215,9 @@ class ReplaceMismatchForm extends FormBase {
           $fs = \Drupal::service('file_system');
           $directory = $fs->dirname($current_uri);
           $new_uri_same_dir = $directory . '/' . $cleaned_filename;
+          if (static::skipDirectoryFileMove($file, $fs, 'bulk replace filename normalization')) {
+            return;
+          }
           // Rename within the same directory first.
           $moved_same_dir = \Drupal::service('file.repository')->move($file, $new_uri_same_dir, FileExists::Rename);
           if ($moved_same_dir) {
@@ -238,6 +241,9 @@ class ReplaceMismatchForm extends FormBase {
           $file_system = \Drupal::service('file_system');
           if (!$file_system->prepareDirectory($destination, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
             \Drupal::logger('mass_bulk_file_replace')->error('Failed to prepare directory: @dest', ['@dest' => $destination]);
+            return;
+          }
+          if (static::skipDirectoryFileMove($file, $file_system, 'bulk replace destination')) {
             return;
           }
           $moved_file = \Drupal::service('file.repository')->move($file, $destination);

--- a/docroot/modules/custom/mass_media/mass_media.module
+++ b/docroot/modules/custom/mass_media/mass_media.module
@@ -62,12 +62,12 @@ function mass_media_media_update(EntityInterface $entity) {
 
   $file_uri_target = \Drupal::service('stream_wrapper_manager')->getTarget($file_uri);
   $file_destination = 'private://' . $file_uri_target;
+  if (mass_media_skip_directory_file_move($file, $file_system, 'media update')) {
+    return;
+  }
   $dirname = $file_system->dirname($file_destination);
   if (!$file_system->prepareDirectory($dirname, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
     throw new \RuntimeException("Unable to prepare directory for file move '$dirname'");
-  }
-  if (mass_media_skip_directory_file_move($file, $file_system, 'media update')) {
-    return;
   }
   if (!\Drupal::service('file.repository')->move($file, $file_destination)) {
     throw new \RuntimeException("Unable to move file to '$file_destination'");
@@ -286,12 +286,12 @@ function mass_media_media_presave(MediaInterface $entity) {
       }
 
       if (!empty($file_destination)) {
+        if (mass_media_skip_directory_file_move($file, $file_system, 'media presave')) {
+          return;
+        }
         $dirname = $file_system->dirname($file_destination);
         if (!$file_system->prepareDirectory($dirname, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
           throw new \RuntimeException("Unable to prepare directory for file move '$dirname'");
-        }
-        if (mass_media_skip_directory_file_move($file, $file_system, 'media presave')) {
-          return;
         }
         if (!\Drupal::service('file.repository')->move($file, $file_destination)) {
           throw new \RuntimeException("Unable to move file to '$file_destination'");

--- a/docroot/modules/custom/mass_media/mass_media.module
+++ b/docroot/modules/custom/mass_media/mass_media.module
@@ -66,6 +66,9 @@ function mass_media_media_update(EntityInterface $entity) {
   if (!$file_system->prepareDirectory($dirname, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
     throw new \RuntimeException("Unable to prepare directory for file move '$dirname'");
   }
+  if (mass_media_skip_directory_file_move($file, $file_system, 'media update')) {
+    return;
+  }
   if (!\Drupal::service('file.repository')->move($file, $file_destination)) {
     throw new \RuntimeException("Unable to move file to '$file_destination'");
   }
@@ -287,6 +290,9 @@ function mass_media_media_presave(MediaInterface $entity) {
         if (!$file_system->prepareDirectory($dirname, FileSystemInterface::CREATE_DIRECTORY | FileSystemInterface::MODIFY_PERMISSIONS)) {
           throw new \RuntimeException("Unable to prepare directory for file move '$dirname'");
         }
+        if (mass_media_skip_directory_file_move($file, $file_system, 'media presave')) {
+          return;
+        }
         if (!\Drupal::service('file.repository')->move($file, $file_destination)) {
           throw new \RuntimeException("Unable to move file to '$file_destination'");
         }
@@ -341,6 +347,24 @@ function mass_media_paragraph_presave(ParagraphInterface $paragraph) {
 
     $media->save();
   }
+}
+
+/**
+ * Checks whether a file move should be skipped because the source is a directory.
+ */
+function mass_media_skip_directory_file_move(FileInterface $file, FileSystemInterface $file_system, string $context): bool {
+  $uri = $file->getFileUri();
+  $realpath = $file_system->realpath($uri);
+  if ($realpath !== FALSE && is_dir($realpath)) {
+    Drupal::logger('content')->warning('Skipped @context move for file entity @fid because @uri resolves to a directory.', [
+      '@context' => $context,
+      '@fid' => $file->id(),
+      '@uri' => $uri,
+    ]);
+    return TRUE;
+  }
+
+  return FALSE;
 }
 
 /**

--- a/docroot/modules/custom/mass_media/src/Plugin/Action/MediaModerationStateRestricted.php
+++ b/docroot/modules/custom/mass_media/src/Plugin/Action/MediaModerationStateRestricted.php
@@ -35,6 +35,19 @@ class MediaModerationStateRestricted extends ViewsBulkOperationsActionBase {
 
       // Move file to private storage.
       $file = File::load($entity->field_upload_file->target_id);
+      if (!$file) {
+        \Drupal::logger('content')->warning('Skipped restricted bulk action file move because file entity @fid could not be loaded.', [
+          '@fid' => $entity->field_upload_file->target_id,
+        ]);
+        return;
+      }
+
+      /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+      $file_system = \Drupal::service('file_system');
+      if (mass_media_skip_directory_file_move($file, $file_system, 'restricted bulk action')) {
+        return;
+      }
+
       // Path to save files to.
       $directory = "documents/" . date("Y") . "/" . date("m") . "/" . date("d") . "/";
 

--- a/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaPrivateTest.php
+++ b/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaPrivateTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\mass_media\ExistingSite;
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\StreamWrapper\StreamWrapperManager;
 use Drupal\file\Entity\File;
 use Drupal\mass_content_moderation\MassModeration;
@@ -41,6 +42,42 @@ class MediaPrivateTest extends MassExistingSiteBase {
 
     // Make sure the original public file is gone. See mass_caching_file_move().
     $this->assertFileDoesNotExist($file->getFileUri());
+  }
+
+  /**
+   * Directory-backed file entities are skipped instead of moved.
+   */
+  public function testDirectorySourceFileIsNotMovedToPrivate() {
+    /** @var \Drupal\Core\File\FileSystemInterface $file_system */
+    $file_system = \Drupal::service('file_system');
+    $directory_uri = 'public://mass-media-directory-source-test';
+    $this->assertTrue($file_system->prepareDirectory($directory_uri, FileSystemInterface::CREATE_DIRECTORY));
+
+    $file = File::create([
+      'uri' => $directory_uri,
+      'filename' => 'mass-media-directory-source-test',
+    ]);
+    $file->setPermanent();
+    $file->save();
+
+    $media = $this->createMedia([
+      'title' => 'Directory source file',
+      'bundle' => 'document',
+      'field_upload_file' => [$file],
+      'status' => 0,
+      'moderation_state' => MassModeration::DRAFT,
+    ]);
+    $this->markEntityForCleanup($media);
+    $this->cleanupEntities[] = $file;
+
+    $reloaded_file = File::load($file->id());
+    $this->assertEquals('public', StreamWrapperManager::getScheme($reloaded_file->getFileUri()));
+    $realpath = $file_system->realpath($reloaded_file->getFileUri());
+    $this->assertNotFalse($realpath);
+    $this->assertTrue(is_dir($realpath));
+    $this->assertFalse($file_system->realpath('private://mass-media-directory-source-test'));
+
+    $file_system->deleteRecursive($directory_uri);
   }
 
   /**

--- a/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaPrivateTest.php
+++ b/docroot/modules/custom/mass_media/tests/src/ExistingSite/MediaPrivateTest.php
@@ -50,12 +50,14 @@ class MediaPrivateTest extends MassExistingSiteBase {
   public function testDirectorySourceFileIsNotMovedToPrivate() {
     /** @var \Drupal\Core\File\FileSystemInterface $file_system */
     $file_system = \Drupal::service('file_system');
-    $directory_uri = 'public://mass-media-directory-source-test';
+    $directory_name = 'mass-media-directory-source-test-' . uniqid();
+    $directory_uri = 'public://' . $directory_name;
+    $private_directory_uri = 'private://' . $directory_name;
     $this->assertTrue($file_system->prepareDirectory($directory_uri, FileSystemInterface::CREATE_DIRECTORY));
 
     $file = File::create([
       'uri' => $directory_uri,
-      'filename' => 'mass-media-directory-source-test',
+      'filename' => $directory_name,
     ]);
     $file->setPermanent();
     $file->save();
@@ -72,12 +74,15 @@ class MediaPrivateTest extends MassExistingSiteBase {
 
     $reloaded_file = File::load($file->id());
     $this->assertEquals('public', StreamWrapperManager::getScheme($reloaded_file->getFileUri()));
+    $this->assertEquals($directory_uri, $reloaded_file->getFileUri());
     $realpath = $file_system->realpath($reloaded_file->getFileUri());
     $this->assertNotFalse($realpath);
     $this->assertTrue(is_dir($realpath));
-    $this->assertFalse($file_system->realpath('private://mass-media-directory-source-test'));
 
     $file_system->deleteRecursive($directory_uri);
+    if ($file_system->realpath($private_directory_uri) !== FALSE) {
+      $file_system->deleteRecursive($private_directory_uri);
+    }
   }
 
   /**


### PR DESCRIPTION
**Description:**
Adds checks when files are moved that the file is not a directory. Skips move and logs to Watchdog when directory found.


**Jira:** (Skip unless you are MA staff)
DP-47987


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
