### PR TITLE
DP-46465: Regression tests for regenerate decision tree and worker resume

### DIFF
--- a/changelogs/DP-46465.yml
+++ b/changelogs/DP-46465.yml
@@ -39,3 +39,5 @@
 Added:
   - description: Add confirmation to entity usage regenerate so that it will confirm before starting a new run.
     issue: DP-46465
+  - description: Add regression tests for the usage-regenerate decision tree and the batch worker resume logic.
+    issue: DP-46465

--- a/docroot/modules/custom/mass_entity_usage/tests/src/ExistingSite/UsageRegenerateWorkerResumeTest.php
+++ b/docroot/modules/custom/mass_entity_usage/tests/src/ExistingSite/UsageRegenerateWorkerResumeTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Drupal\Tests\mass_entity_usage\ExistingSite;
+
+use Drupal\mass_entity_usage\EntityUsageQueueBatchManager;
+use MassGov\Dtt\MassExistingSiteBase;
+
+/**
+ * Tests the batch worker's resume-vs-wipe decision.
+ *
+ * The worker (queueSourcesBatchWorker) is the only code path deleting usage data
+ * (bulkDeleteSources). On resume — saved progress belonging to the current
+ * run — it must restore the sandbox and keep existing records; only a fresh
+ * start (no progress, or progress from a stale run) may wipe. A regression
+ * here silently deletes all usage records while claiming to resume.
+ *
+ * The tests use the `redirect` entity type so the wipe branch only touches
+ * synthetic rows created here (plus a snapshot/restore safety net), never
+ * the site's node/paragraph usage data.
+ *
+ * @group existing-site
+ */
+class UsageRegenerateWorkerResumeTest extends MassExistingSiteBase {
+
+  private const ENTITY_TYPE = 'redirect';
+
+  /**
+   * Saved state values to restore in tearDown, keyed by state key.
+   */
+  private array $originalState = [];
+
+  /**
+   * Snapshot of real usage rows the wipe branch could delete.
+   */
+  private array $usageRowsSnapshot = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    foreach ($this->managedStateKeys() as $key) {
+      $this->originalState[$key] = \Drupal::state()->get($key);
+    }
+    $this->usageRowsSnapshot = \Drupal::database()
+      ->select('entity_usage', 'eu')
+      ->fields('eu')
+      ->condition('source_type', self::ENTITY_TYPE)
+      ->execute()
+      ->fetchAll(\PDO::FETCH_ASSOC);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    $state = \Drupal::state();
+    foreach ($this->originalState as $key => $value) {
+      if ($value === NULL) {
+        $state->delete($key);
+      }
+      else {
+        $state->set($key, $value);
+      }
+    }
+    $database = \Drupal::database();
+    $database->delete('entity_usage')
+      ->condition('source_type', self::ENTITY_TYPE)
+      ->execute();
+    foreach ($this->usageRowsSnapshot as $row) {
+      $database->insert('entity_usage')->fields($row)->execute();
+    }
+    $this->deleteQueueItemsForEntityType(self::ENTITY_TYPE);
+    parent::tearDown();
+  }
+
+  /**
+   * Tests resume restores saved progress and keeps existing usage records.
+   */
+  public function testResumeKeepsUsageRecordsAndRestoresProgress(): void {
+    $runId = 'worker-resume-test.' . time();
+    \Drupal::state()->set(EntityUsageQueueBatchManager::ENQUEUE_RUN_ID_KEY, $runId);
+    // current_item far above any real redirect ID: the worker finds nothing
+    // to enqueue, so the run stays in progress and the queue stays clean.
+    \Drupal::state()->set('mass_entity_usage.queue_progress.' . self::ENTITY_TYPE, [
+      'run_id' => $runId,
+      'progress' => 5,
+      'total' => 10,
+      'current_item' => 999999999,
+      'completed' => FALSE,
+    ]);
+    $this->insertSentinelUsageRow();
+
+    $context = ['sandbox' => [], 'results' => [], 'finished' => 0, 'message' => ''];
+    EntityUsageQueueBatchManager::queueSourcesBatchWorker(self::ENTITY_TYPE, 10, $context);
+
+    $this->assertSame(1, $this->countSentinelUsageRows(), 'Resume must not delete existing usage records.');
+    $this->assertSame(5, $context['sandbox']['progress'], 'Resume must restore saved progress.');
+    $this->assertSame(10, $context['sandbox']['total']);
+    $this->assertSame(999999999, $context['sandbox']['current_item'], 'Resume must continue from the saved position, not from zero.');
+
+    $progress = \Drupal::state()->get('mass_entity_usage.queue_progress.' . self::ENTITY_TYPE);
+    $this->assertFalse($progress['completed']);
+    $this->assertSame($runId, $progress['run_id']);
+  }
+
+  /**
+   * Tests progress from a stale run is discarded and records are wiped.
+   */
+  public function testStaleRunProgressIsDiscardedAndRecordsWiped(): void {
+    \Drupal::state()->set(EntityUsageQueueBatchManager::ENQUEUE_RUN_ID_KEY, 'current-run.' . time());
+    \Drupal::state()->set('mass_entity_usage.queue_progress.' . self::ENTITY_TYPE, [
+      'run_id' => 'stale-run.0',
+      'progress' => 5,
+      'total' => 10,
+      'current_item' => 999999999,
+      'completed' => FALSE,
+    ]);
+    $this->insertSentinelUsageRow();
+
+    $context = ['sandbox' => [], 'results' => [], 'finished' => 0, 'message' => ''];
+    EntityUsageQueueBatchManager::queueSourcesBatchWorker(self::ENTITY_TYPE, 1, $context);
+
+    $this->assertSame(0, $this->countSentinelUsageRows(), 'A fresh start must wipe usage records for the entity type.');
+    $this->assertNotSame(999999999, $context['sandbox']['current_item'], 'Stale progress must not be resumed.');
+
+    $progress = \Drupal::state()->get('mass_entity_usage.queue_progress.' . self::ENTITY_TYPE);
+    $this->assertNotSame('stale-run.0', $progress['run_id'], 'Progress must be re-keyed to the current run.');
+  }
+
+  /**
+   * State keys this test writes and must restore.
+   */
+  private function managedStateKeys(): array {
+    return [
+      EntityUsageQueueBatchManager::ENQUEUE_RUN_ID_KEY,
+      'mass_entity_usage.queue_progress.' . self::ENTITY_TYPE,
+      'mass_entity_usage.enqueue_completed_at',
+    ];
+  }
+
+  /**
+   * Inserts a sentinel usage row that only bulkDeleteSources() would remove.
+   */
+  private function insertSentinelUsageRow(): void {
+    \Drupal::database()->insert('entity_usage')->fields([
+      'target_id' => 999999901,
+      'target_type' => 'node',
+      'source_id' => 999999902,
+      'source_type' => self::ENTITY_TYPE,
+      'source_langcode' => 'en',
+      'source_vid' => 0,
+      'method' => 'test_sentinel',
+      'field_name' => 'test_sentinel',
+      'count' => 1,
+    ])->execute();
+  }
+
+  /**
+   * Counts sentinel usage rows.
+   */
+  private function countSentinelUsageRows(): int {
+    return (int) \Drupal::database()->select('entity_usage', 'eu')
+      ->condition('source_type', self::ENTITY_TYPE)
+      ->condition('method', 'test_sentinel')
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+  }
+
+  /**
+   * Removes queue items the fresh-start branch enqueued for an entity type.
+   */
+  private function deleteQueueItemsForEntityType(string $entityTypeId): void {
+    $database = \Drupal::database();
+    $items = $database->select('queue', 'q')
+      ->fields('q', ['item_id', 'data'])
+      ->condition('name', EntityUsageQueueBatchManager::QUEUE_NAME)
+      ->execute()
+      ->fetchAllKeyed();
+    foreach ($items as $itemId => $data) {
+      $payload = unserialize($data, ['allowed_classes' => FALSE]);
+      if (is_array($payload) && ($payload['entity_type'] ?? '') === $entityTypeId) {
+        $database->delete('queue')->condition('item_id', $itemId)->execute();
+      }
+    }
+  }
+
+}

--- a/docroot/modules/custom/mass_entity_usage/tests/src/Unit/MassEntityUsageCommandsDecisionTest.php
+++ b/docroot/modules/custom/mass_entity_usage/tests/src/Unit/MassEntityUsageCommandsDecisionTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Drupal\Tests\mass_entity_usage\Unit;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\mass_entity_usage\Drush\Commands\MassEntityUsageCommands;
+use Drupal\mass_entity_usage\EntityUsageQueueBatchManager;
+use Drush\Exceptions\UserAbortException;
+use Drush\Log\DrushLoggerManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Tests the usage-regenerate command decision tree.
+ *
+ * An accidental full rebuild wipes all usage data and takes 1.5-2 days to
+ * recover in production (the DP-46437 incident), so every branch of
+ * recreate() is pinned here: which manager calls each input state is allowed
+ * to make, and, just as important, which destructive calls it must never
+ * make.
+ *
+ * @coversDefaultClass \Drupal\mass_entity_usage\Drush\Commands\MassEntityUsageCommands
+ * @group mass_entity_usage
+ */
+class MassEntityUsageCommandsDecisionTest extends TestCase {
+
+  /**
+   * Builds the command with a mocked batch manager and console IO.
+   */
+  private function buildCommand($manager, bool $interactive = FALSE, bool $yes = FALSE): MassEntityUsageCommands {
+    $command = new MassEntityUsageCommands(
+      $manager,
+      $this->createMock(EntityTypeManagerInterface::class),
+      $this->createMock(ConfigFactoryInterface::class),
+      $this->createMock(DateFormatterInterface::class),
+    );
+    $definition = new InputDefinition([
+      new InputOption('yes', 'y', InputOption::VALUE_NONE),
+    ]);
+    $input = new ArrayInput($yes ? ['--yes' => TRUE] : [], $definition);
+    $input->setInteractive($interactive);
+    $command->setInput($input);
+    $command->setOutput(new BufferedOutput());
+    $logger = new DrushLoggerManager();
+    $logger->add('null', new NullLogger());
+    $command->setLogger($logger);
+    return $command;
+  }
+
+  /**
+   * Tests --reset --force starts a fresh run without prompting.
+   */
+  public function testResetWithForceStartsFreshRun(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->expects($this->once())->method('beginFreshEnqueueRun');
+    $manager->expects($this->once())->method('populateQueue')->willReturn(FALSE);
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => TRUE, 'reset' => TRUE]);
+  }
+
+  /**
+   * Tests --reset -y starts a fresh run without prompting.
+   */
+  public function testResetWithYesStartsFreshRun(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->expects($this->once())->method('beginFreshEnqueueRun');
+    $manager->expects($this->once())->method('populateQueue')->willReturn(FALSE);
+
+    $command = $this->buildCommand($manager, FALSE, TRUE);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => TRUE]);
+  }
+
+  /**
+   * Tests --reset aborts in non-interactive mode before touching any state.
+   *
+   * The abort must happen before beginFreshEnqueueRun(): a reorder that
+   * clears the queue first and prompts second would destroy saved progress
+   * even when the operator declines.
+   */
+  public function testResetNonInteractiveAbortsBeforeClearingState(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->expects($this->never())->method('beginFreshEnqueueRun');
+    $manager->expects($this->never())->method('populateQueue');
+
+    $command = $this->buildCommand($manager);
+    $this->expectException(UserAbortException::class);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => TRUE]);
+  }
+
+  /**
+   * Tests an interrupted run resumes without prompting or wiping state.
+   */
+  public function testInterruptedRunResumesWithoutFreshStart(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->method('hasInterruptedProgress')->willReturn(TRUE);
+    $manager->method('getProgressSummary')->willReturn(['node' => 'in progress 5/10']);
+    $manager->expects($this->once())->method('prepareResume');
+    $manager->expects($this->never())->method('beginFreshEnqueueRun');
+    $manager->expects($this->once())->method('populateQueue')->willReturn(FALSE);
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => FALSE]);
+  }
+
+  /**
+   * Tests a run completed within 24 hours exits without enqueueing.
+   */
+  public function testRecentCompletionExitsWithoutEnqueue(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->method('hasInterruptedProgress')->willReturn(FALSE);
+    $manager->method('wasEnqueueCompletedRecently')->willReturn(TRUE);
+    $manager->method('getEnqueueCompletedAt')->willReturn(1000000);
+    $manager->expects($this->never())->method('beginFreshEnqueueRun');
+    $manager->expects($this->never())->method('populateQueue');
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => FALSE]);
+  }
+
+  /**
+   * Tests completed progress without a completion flag stamps and exits.
+   */
+  public function testCompletedProgressWithoutFlagStampsAndExits(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->method('hasInterruptedProgress')->willReturn(FALSE);
+    $manager->method('wasEnqueueCompletedRecently')->willReturn(FALSE);
+    $manager->method('getEnqueueCompletedAt')->willReturn(NULL);
+    $manager->method('isAllEnqueueCompleted')->willReturn(TRUE);
+    $manager->expects($this->once())->method('markEnqueueCompleted');
+    $manager->expects($this->never())->method('beginFreshEnqueueRun');
+    $manager->expects($this->never())->method('populateQueue');
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => FALSE]);
+  }
+
+  /**
+   * Tests an expired completion flag falls through to a fresh run.
+   *
+   * Regression guard: before the fix, this state re-stamped the completion
+   * timestamp on every invocation, so the 24-hour window never expired and a
+   * new run was permanently impossible without --reset.
+   */
+  public function testExpiredCompletionFlagStartsFreshRunWithoutRestamping(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->method('hasInterruptedProgress')->willReturn(FALSE);
+    $manager->method('wasEnqueueCompletedRecently')->willReturn(FALSE);
+    $manager->method('getEnqueueCompletedAt')->willReturn(1000000);
+    $manager->method('isAllEnqueueCompleted')->willReturn(TRUE);
+    $manager->expects($this->never())->method('markEnqueueCompleted');
+    $manager->expects($this->once())->method('beginFreshEnqueueRun');
+    $manager->expects($this->once())->method('populateQueue')->willReturn(FALSE);
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => FALSE]);
+  }
+
+  /**
+   * Tests a bare first run (no saved state at all) starts a fresh run.
+   */
+  public function testFirstRunStartsFresh(): void {
+    $manager = $this->createMock(EntityUsageQueueBatchManager::class);
+    $manager->method('hasInterruptedProgress')->willReturn(FALSE);
+    $manager->method('wasEnqueueCompletedRecently')->willReturn(FALSE);
+    $manager->method('getEnqueueCompletedAt')->willReturn(NULL);
+    $manager->method('isAllEnqueueCompleted')->willReturn(FALSE);
+    $manager->expects($this->once())->method('beginFreshEnqueueRun');
+    $manager->expects($this->once())->method('populateQueue')->willReturn(FALSE);
+
+    $command = $this->buildCommand($manager);
+    $command->recreate(['batch-size' => 10, 'force' => FALSE, 'reset' => FALSE]);
+  }
+
+}


### PR DESCRIPTION
## Objective

Add the missing regression tests for the two places in #3435 where a future change could silently recreate the DP-46437 production incident (an accidental full rebuild wipes all usage data and takes 1.5-2 days to recover). The command decision tree and the batch worker's wipe decision had no coverage; both are pinned now.

**Jira:** [DP-46465](https://massgov.atlassian.net/browse/DP-46465)

## Why these tests are needed

1. **The command decision tree is the ticket.** The confirmation, the `--force`/`-y` bypass, resume-over-fresh, and the recent-completion exit all live in `MassEntityUsageCommands::recreate()`, and none of it was exercised by tests. Any future edit to that if/elseif ladder could silently re-enable the accidental full rebuild. The new unit tests pin every branch, including the order-of-operations guard: a declined/non-interactive `--reset` must abort **before** `beginFreshEnqueueRun()` clears saved progress and the queue.

2. **The 24-hour-timeout bug already shipped once.** Before 34785ec, an expired completion flag was re-stamped on every bare invocation, so a new run was permanently impossible without `--reset`. `testExpiredCompletionFlagStartsFreshRunWithoutRestamping` fails on the pre-fix code (verified) and passes after it — that bug can't come back unnoticed.

3. **The worker's resume-vs-wipe decision is the only code path that deletes usage data.** `queueSourcesBatchWorker()` decides between restoring saved progress and calling `bulkDeleteSources()`. A regression there deletes all usage records while claiming to resume. The new ExistingSite tests prove: resume keeps existing records and continues from the saved position; stale-run progress is discarded and records are wiped. The pair is self-validating — the stale case proves the sentinel row is really deletable, the resume case proves it survives.

The worker tests use the `redirect` entity type and snapshot/restore state and usage rows, so they cannot destroy real node/paragraph usage data even if run against a shared environment.

## Test results

- `MassEntityUsageCommandsDecisionTest`: 8 tests — green (and the timeout-regression test verified to fail on pre-34785ec code).
- `UsageRegenerateWorkerResumeTest`: 2 tests — green.
- Full `mass_entity_usage` suite: 42 tests / 127 assertions — green.
- phpcs clean.


[DP-46465]: https://massgov.atlassian.net/browse/DP-46465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ