### PR TITLE
DP-47688: Spike proof of concept — render media_video through core oEmbed

### DIFF
--- a/docroot/modules/custom/mayflower/src/Prepare/Atoms.php
+++ b/docroot/modules/custom/mayflower/src/Prepare/Atoms.php
@@ -349,6 +349,10 @@ class Atoms {
    * Extract embed URL + dimensions from field render or raw value.
    */
   private static function extractVideoEmbedData($entity, array $video_render_array): array {
+    if ($entity->hasField('field_media_oembed_video')) {
+      return self::extractOembedData((string) ($entity->get('field_media_oembed_video')->value ?? ''));
+    }
+
     if (isset($video_render_array['children']['#url'])) {
       return [
         'src' => $video_render_array['children']['#url'],
@@ -370,6 +374,48 @@ class Atoms {
     }
 
     return [];
+  }
+
+  /**
+   * Resolve the provider embed URL for a core oEmbed video media item.
+   *
+   * The Mayflower video atom builds its own iframe and only needs the provider
+   * embed URL, so the core oEmbed iframe formatter output is not usable here.
+   *
+   * @param string $url
+   *   The oEmbed source URL, e.g. https://youtu.be/abc123.
+   *
+   * @return array
+   *   Array with src/width/height keys, or an empty array when the resource
+   *   cannot be resolved.
+   */
+  public static function extractOembedData(string $url): array {
+    $url = trim($url);
+    if ($url === '') {
+      return [];
+    }
+
+    try {
+      $resource_url = \Drupal::service('media.oembed.url_resolver')->getResourceUrl($url, 854, 480);
+      $resource = \Drupal::service('media.oembed.resource_fetcher')->fetchResource($resource_url);
+    }
+    catch (\Exception $e) {
+      \Drupal::logger('mayflower')->warning('Could not resolve oEmbed resource for @url: @message', [
+        '@url' => $url,
+        '@message' => $e->getMessage(),
+      ]);
+      return [];
+    }
+
+    if (!preg_match('/<iframe[^>]+src="([^"]+)"/i', (string) $resource->getHtml(), $matches)) {
+      return [];
+    }
+
+    return [
+      'src' => html_entity_decode($matches[1]),
+      'width' => $resource->getWidth() ?: '',
+      'height' => $resource->getHeight() ?: '',
+    ];
   }
 
 }

--- a/docroot/themes/custom/mass_theme/mass_theme.theme
+++ b/docroot/themes/custom/mass_theme/mass_theme.theme
@@ -6846,8 +6846,15 @@ function mass_theme_preprocess_media(array &$variables) {
   // Do something special for document bundle.
   $media_bundle = $variables['elements']['#media']->bundle();
 
-  if (isset($variables['elements']['field_media_video_embed_field'][0]['children']['#url'])) {
+  if ($variables['elements']['#media']->hasField('field_media_oembed_video')) {
+    $embed = Atoms::extractOembedData((string) ($variables['elements']['#media']->get('field_media_oembed_video')->value ?? ''));
+    $src = $embed['src'] ?? '';
+  }
+  elseif (isset($variables['elements']['field_media_video_embed_field'][0]['children']['#url'])) {
     $src = $variables['elements']['field_media_video_embed_field'][0]['children']['#url'];
+  }
+
+  if ($src !== '') {
 
     // Set static pageHeader properties to pass to prepare function.
     $pageHeader_options = [

--- a/docroot/themes/custom/mass_theme/templates/content/media--media-video.html.twig
+++ b/docroot/themes/custom/mass_theme/templates/content/media--media-video.html.twig
@@ -25,10 +25,12 @@
         {% if backButton %}
           {{ include('@molecules/back-button.twig') }}
         {% endif %}
-        {# Determine parent heading level: video appears after page header (H1), so parent is H1, video should be H2 #}
-        {% set parent_heading_level = 1 %}
-        {% set video = video|merge({headingLevel: parent_heading_level + 1}) %}
-        {{ include('@atoms/09-media/video.twig') }}
+        {% if video %}
+          {# Determine parent heading level: video appears after page header (H1), so parent is H1, video should be H2 #}
+          {% set parent_heading_level = 1 %}
+          {% set video = video|merge({headingLevel: parent_heading_level + 1}) %}
+          {{ include('@atoms/09-media/video.twig') }}
+        {% endif %}
         {% if backButton %}
           {{ include('@molecules/back-button.twig') }}
         {% endif %}


### PR DESCRIPTION
Prototype only, not for merge. Resolves the provider embed URL through the core oEmbed url resolver and resource fetcher so the Mayflower video atom keeps building its own iframe, and guards the standalone video template against a media item whose video no longer resolves.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
