### PR TITLE
Stop the media view from claiming a local task under /admin/content

### DIFF
--- a/conf/drupal/config/views.view.media.yml
+++ b/conf/drupal/config/views.view.media.yml
@@ -2618,7 +2618,7 @@ display:
           tokenize: false
       path: admin/content/media
       menu:
-        type: tab
+        type: none
         title: Media
         description: ''
         weight: 0


### PR DESCRIPTION
The media_page_list display serves /admin/content/media, a path already owned by core's entity.media.collection route, so Views always discards the local task it would derive from this menu setting. The setting is inert in normal operation, but it is the only thing that can produce the plugin ID views_view:view.media.media_page_list.

When a router rebuild races live traffic, the local_task cache tag is invalidated (MenuRouterRebuildSubscriber, RoutingEvents::FINISHED priority 100) before Views writes views.view_route_names state (priority 0). A request landing in that window derives the phantom plugin from stale state and caches the resulting tab tree for /admin/content permanently. Once state settles the plugin no longer exists, and every subsequent request to /admin/content fatals with PluginNotFoundException until something invalidates the local_task tag again.

Setting the menu type to none removes the only source of that plugin ID. The Media tab keeps coming from core's media.links.task.yml and /admin/content/media still resolves to this display.

**Description:**
Explain the technical implementation of the work done.


**Jira:** (Skip unless you are MA staff)
DP-****


**To Test:**
- [ ] Add steps to test this feature


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
