### PR TITLE
DP-47935: Increased max cache tag limit for edge cache tag header logging

### DIFF
--- a/changelogs/DP-47935.yml
+++ b/changelogs/DP-47935.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Increased max for detecting and logging when edge cache tag limit is exceeded.
+    issue: DP-47935

--- a/docroot/modules/custom/mass_caching/src/EventSubscriber/AkamaiHeaderCreationSubscriber.php
+++ b/docroot/modules/custom/mass_caching/src/EventSubscriber/AkamaiHeaderCreationSubscriber.php
@@ -17,7 +17,7 @@ class AkamaiHeaderCreationSubscriber implements EventSubscriberInterface {
   /**
    * Akamai Edge-Cache-Tag response header tag count limit.
    */
-  private const MAX_HEADER_TAGS = 128;
+  private const MAX_HEADER_TAGS = 1024;
 
   /**
    * Akamai cache tag formatter.

--- a/docroot/modules/custom/mass_caching/tests/src/Unit/EventSubscriber/AkamaiHeaderCreationSubscriberTest.php
+++ b/docroot/modules/custom/mass_caching/tests/src/Unit/EventSubscriber/AkamaiHeaderCreationSubscriberTest.php
@@ -92,7 +92,7 @@ class AkamaiHeaderCreationSubscriberTest extends UnitTestCase {
    * Tests oversized header tag sets are logged.
    */
   public function testOversizedHeaderTagSetLogged(): void {
-    $tags = range(1, 129);
+    $tags = range(1, 1025);
     $tags = array_map(static fn ($tag): string => "node:$tag", $tags);
     $event = new AkamaiHeaderEvents($tags);
     $logger = $this->createMock(LoggerInterface::class);
@@ -101,8 +101,8 @@ class AkamaiHeaderCreationSubscriberTest extends UnitTestCase {
       ->with(
         'Akamai Edge-Cache-Tag header contains {count} tags, exceeding Akamai\'s {limit}-tag header limit. Akamai may reject or truncate the header.',
         [
-          'count' => 129,
-          'limit' => 128,
+          'count' => 1025,
+          'limit' => 1024,
         ]
       );
     $subscriber = $this->createSubscriber($logger);
@@ -114,7 +114,7 @@ class AkamaiHeaderCreationSubscriberTest extends UnitTestCase {
    * Tests oversized tag sets are not logged while hashing purge events.
    */
   public function testOversizedPurgeTagSetNotLoggedWhileHashing(): void {
-    $tags = range(1, 129);
+    $tags = range(1, 1025);
     $tags = array_map(static fn ($tag): string => "node:$tag", $tags);
     $event = new AkamaiPurgeEvents($tags);
     $logger = $this->createMock(LoggerInterface::class);


### PR DESCRIPTION
**Description:**
Set max cache tag limit to reflect edge cache tag limit.


**Jira:** (Skip unless you are MA staff)
DP-47935


---

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
