### PR TITLE
DP-48501: Fix 500 errors on /admin/content

### DIFF
--- a/changelogs/DP-48501.yml
+++ b/changelogs/DP-48501.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Fixed:
+  - description: Fixes intermittent 500 errors on the All Content page by stopping the media view from claiming a local task that core already provides.
+    issue: DP-48501

--- a/conf/drupal/config/views.view.media.yml
+++ b/conf/drupal/config/views.view.media.yml
@@ -2618,7 +2618,7 @@ display:
           tokenize: false
       path: admin/content/media
       menu:
-        type: tab
+        type: none
         title: Media
         description: ''
         weight: 0


### PR DESCRIPTION
**Description:**

`/admin/content` intermittently fatals for authenticated users with:

```
Drupal\Component\Plugin\Exception\PluginNotFoundException
The "views_view:view.media.media_page_list" plugin does not exist.
Valid plugin IDs for Drupal\Core\Menu\LocalTaskManager are: …
```

### That plugin ID should never exist

`views.view.media`, display `media_page_list`, has `menu.type: tab` and path `admin/content/media`. That path is already owned by core: the Media entity type declares `'collection' => '/admin/content/media'`, and `core/modules/media/media.links.task.yml` registers the **Media** tab with `base_route: system.admin_content`.

Because the view overrides an existing route, Views deliberately refuses to derive a local task of its own — `ViewsLocalTask::getDerivativeDefinitions()`:

```php
$route_name = $view_route_names[$view_id . '.' . $display_id];
// Don't add a local task for views which override existing routes.
if ($route_name != $plugin_id) {
  continue;
}
```

On a healthy site `views.view_route_names['media.media_page_list']` is `entity.media.collection`, the derivative is absent, and the tab comes from core. So `menu.type: tab` here is inert config — it never renders anything. But it is the only thing that can ever produce that plugin ID.

### The race

Two subscribers listen on `RoutingEvents::FINISHED`, and they run in the wrong order:

| Priority | Subscriber | What it does |
|---|---|---|
| 100 | `MenuRouterRebuildSubscriber::onRouterRebuild()` | `Cache::invalidateTags(['local_task'])` |
| 0 | views `RouteSubscriber::routeRebuildFinished()` | `$state->set('views.view_route_names', …)` |

The local task caches are dropped *before* Views records which routes its displays override. A request landing in that window rebuilds the definitions from stale state, derives the phantom plugin, and `LocalTaskManager::getLocalTasksForRoute()` caches the resulting tab tree for `/admin/content` with `Cache::PERMANENT` (`LocalTaskManager.php:256`).

Once state settles the plugin is gone from the definitions while the cached tree still names it, so `createInstance()` fatals on every subsequent request. A state change invalidates no cache tag, so nothing heals this on its own — it clears only when something invalidates `local_task` again (any router rebuild). That is why some episodes cleared by themselves after a few hours and the most recent one did not.

Two things have to line up: a tab tree cached with the phantom, **and** the definitions rebuilt without it while the tree survives — the definitions and the tab tree are two separate keys in `cache.discovery`, so memcache can drop one and keep the other. That matches the Acquia support case linked on the ticket.

### The fix

`menu.type: none` removes the only source of the plugin ID, so the race has nothing to poison the tree with. The Media tab keeps coming from core's `media.links.task.yml`, and `/admin/content/media` still resolves to this display.

**Jira:**
DP-48501

**To Test:**

Nothing should change in normal operation:

- [ ] `/admin/content` loads and still shows the **Media** tab
- [ ] The Media tab opens `/admin/content/media` and renders this view — filters, columns and bulk operations intact
- [ ] `/admin/content/media/migrated` still works

Reproduce the bug and confirm the fix (local DDEV). The script performs the steps above deterministically instead of waiting for the race:

```bash
# 1. put the config back into the unfixed state
ddev drush config:set views.view.media display.media_page_list.display_options.menu.type tab -y
ddev drush cr

# 2. poison the cached tab tree
cat > repro.php <<'PHP'
<?php
$state = \Drupal::state();
$manager = \Drupal::service('plugin.manager.menu.local_task');
$cache = \Drupal::cache('discovery');
$cid = 'local_task_plugins:' . \Drupal::languageManager()->getCurrentLanguage()->getId();
$good = $state->get('views.view_route_names');
// Stale state: Views has not yet recorded that the view overrides the core route.
$state->set('views.view_route_names', ['media.media_page_list' => 'view.media.media_page_list'] + $good);
// A request lands in that window and caches a tab tree naming the phantom.
$manager->clearCachedDefinitions();
$manager->getLocalTasksForRoute('system.admin_content');
// Views finishes the rebuild and state settles back to the truth.
$state->set('views.view_route_names', $good);
// The definition cache is dropped on its own while the tab tree survives.
// Deleting the key rather than calling clearCachedDefinitions() matters: the
// latter invalidates the local_task tag, which takes the tab tree with it and
// heals the site - that is exactly what makes this bug self-clearing.
$cache->delete($cid);
$tree = $cache->get($cid . ':system.admin_content');
print 'phantom still in cached tab tree: '
  . (($tree && str_contains(serialize($tree->data), 'views_view:view.media.media_page_list')) ? "YES\n" : "no\n");
PHP
ddev drush php:script repro.php

# 3. log in and load the page
ddev drush uli --uri=https://mass.local
```

- [ ] With `menu.type: tab` — the script prints `YES` and `/admin/content` returns **500**
- [ ] With `menu.type: none` (this PR) — the script prints `no` and `/admin/content` returns **200**

Same script, same steps, only that one config value differs. Clean up with `ddev drush cr` and `rm repro.php`.

The exception can also be triggered without logging in:

```bash
ddev drush php:eval 'try { \Drupal::service("plugin.manager.menu.local_task")
  ->getLocalTasksForRoute("system.admin_content"); print "no error\n"; }
  catch (\Throwable $e) { print get_class($e) . ": " . $e->getMessage() . "\n"; }'
```

---

Replaces #3478, which had no ticket number or changelog.

[Peer Review Checklist](https://github.com/massgov/openmass/blob/develop/docs/peer_review_checklist.md)
