### PR TITLE
DP-48741-Update-Document-Links-So-Screen-Readers-Announce-the-Document-Title-Before-File-Information

### DIFF
--- a/changelogs/DP-48741.yml
+++ b/changelogs/DP-48741.yml
@@ -1,0 +1,41 @@
+#
+# Write your changelog entry here. Every pull request must have a changelog yml file.
+#
+# Change types:
+# #############################################################################
+# You can use one of the following types:
+#  - Added: For new features.
+#  - Changed: For changes to existing functionality.
+#  - Deprecated: For soon-to-be removed features.
+#  - Removed: For removed features.
+#  - Fixed: For any bug fixes.
+#  - Security: In case of vulnerabilities.
+#
+# Format
+# #############################################################################
+# The format is crucial. Please follow the examples below. For reference, the requirements are:
+#  - All 3 parts are required and you must include "Type", "description" and "issue".
+#  - "Type" must be left aligned and followed by a colon.
+#  - "description" must be indented with 2 spaces followed by a colon
+#  - "issue" must be indented with 4 spaces followed by a colon.
+#  - "issue" is for the Jira ticket number only e.g. DP-1234
+#  - No extra spaces, indents, or blank lines are allowed.
+#
+# Example:
+# #############################################################################
+# Fixed:
+#  - description: Fixes scrolling on edit pages in Safari.
+#    issue: DP-13314
+#
+# You may add more than 1 description & issue for each type using the following format:
+# Changed:
+#  - description: Automating the release branch.
+#    issue: DP-10166
+#  - description: Second change item that needs a description.
+#    issue: DP-19875
+#  - description: Third change item that needs a description along with an issue.
+#    issue: DP-19843
+#
+Changed:
+  - description: Announce the document title before file type and size so screen readers hear the link name first.
+    issue: DP-48741

--- a/composer.json
+++ b/composer.json
@@ -297,7 +297,7 @@
         "jashkenas/backbone": "^1.6",
         "jashkenas/underscore": "^1.13",
         "league/commonmark": "^2.7",
-        "massgov/mayflower-artifacts": "dev-develop",
+        "massgov/mayflower-artifacts": "dev-patternlab/DP-48741-document-link-screenreader-order",
         "monolog/monolog": "^3",
         "npm-asset/ace-builds": "~1.0",
         "npm-asset/select2": "^4.1.0-rc.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2289c6e8ca5b9a64de280424dbdf1b2f",
+    "content-hash": "f1f96d2671d038222fadca7e5e92c96f",
     "packages": [
         {
             "name": "akamai-open/edgegrid-auth",
@@ -14152,16 +14152,16 @@
         },
         {
             "name": "massgov/mayflower-artifacts",
-            "version": "dev-develop",
+            "version": "dev-patternlab/DP-48741-document-link-screenreader-order",
             "source": {
                 "type": "git",
                 "url": "https://github.com/massgov/mayflower-artifacts",
-                "reference": "8e27666951a64f145607a9143f108a6f6725b2a4"
+                "reference": "7d4db8e9d7bd4da10881e59f8dfac4b1c1dee8df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/8e27666951a64f145607a9143f108a6f6725b2a4",
-                "reference": "8e27666951a64f145607a9143f108a6f6725b2a4",
+                "url": "https://api.github.com/repos/massgov/mayflower-artifacts/zipball/7d4db8e9d7bd4da10881e59f8dfac4b1c1dee8df",
+                "reference": "7d4db8e9d7bd4da10881e59f8dfac4b1c1dee8df",
                 "shasum": ""
             },
             "require": {
@@ -14179,7 +14179,7 @@
                 }
             ],
             "description": "This repository is the product of the built artifact from massgov/mayflower",
-            "time": "2026-07-08T12:35:06+00:00"
+            "time": "2026-09-09T19:09:27+00:00"
         },
         {
             "name": "masterminds/html5",


### PR DESCRIPTION
Announce the document title before file type and size so screen readers hear the link name first

- [JIRA issue](https://massgov.atlassian.net/browse/DP-48741)
- [Mayflower PR](https://github.com/massgov/mayflower/pull/2086)